### PR TITLE
fix: bind trusted MFA devices to client installs

### DIFF
--- a/src/backend/database/routes/user-totp-routes.ts
+++ b/src/backend/database/routes/user-totp-routes.ts
@@ -11,6 +11,7 @@ import { authLogger } from "../../utils/logger.js";
 import { loginRateLimiter } from "../../utils/login-rate-limiter.js";
 import {
   generateDeviceFingerprint,
+  getDeviceId,
   parseUserAgent,
 } from "../../utils/user-agent-parser.js";
 import {
@@ -627,18 +628,23 @@ export function registerUserTotpRoutes(
       const deviceInfo = parseUserAgent(req);
 
       if (rememberMe) {
-        const deviceFingerprint = generateDeviceFingerprint(deviceInfo);
-        await authManager.addTrustedDevice(
-          userRecord.id,
-          deviceFingerprint,
-          deviceInfo.type,
-          deviceInfo.deviceInfo,
+        const deviceFingerprint = generateDeviceFingerprint(
+          deviceInfo,
+          getDeviceId(req),
         );
-        authLogger.info("Device automatically trusted via Remember Me", {
-          operation: "totp_auto_trust",
-          userId: userRecord.id,
-          deviceType: deviceInfo.type,
-        });
+        if (deviceFingerprint) {
+          await authManager.addTrustedDevice(
+            userRecord.id,
+            deviceFingerprint,
+            deviceInfo.type,
+            deviceInfo.deviceInfo,
+          );
+          authLogger.info("Device automatically trusted via Remember Me", {
+            operation: "totp_auto_trust",
+            userId: userRecord.id,
+            deviceType: deviceInfo.type,
+          });
+        }
       }
 
       const token = await authManager.generateJWTToken(userRecord.id, {

--- a/src/backend/database/routes/user-webauthn-routes.ts
+++ b/src/backend/database/routes/user-webauthn-routes.ts
@@ -18,6 +18,7 @@ import { AuthManager } from "../../utils/auth-manager.js";
 import { authLogger } from "../../utils/logger.js";
 import {
   generateDeviceFingerprint,
+  getDeviceId,
   parseUserAgent,
 } from "../../utils/user-agent-parser.js";
 import {
@@ -487,11 +488,13 @@ export function registerUserWebAuthnRoutes(
       );
 
       if (userRecord.totpEnabled) {
-        const deviceFingerprint = generateDeviceFingerprint(deviceInfo);
-        const isTrusted = await authManager.isTrustedDevice(
-          userRecord.id,
-          deviceFingerprint,
+        const deviceFingerprint = generateDeviceFingerprint(
+          deviceInfo,
+          getDeviceId(req),
         );
+        const isTrusted = deviceFingerprint
+          ? await authManager.isTrustedDevice(userRecord.id, deviceFingerprint)
+          : false;
 
         if (!isTrusted) {
           const tempToken = await authManager.generateJWTToken(userRecord.id, {

--- a/src/backend/database/routes/users.ts
+++ b/src/backend/database/routes/users.ts
@@ -8,6 +8,7 @@ import { AuthManager } from "../../utils/auth-manager.js";
 import { DatabaseSaveTrigger } from "../../utils/database-save-trigger.js";
 import { DataCrypto } from "../../utils/data-crypto.js";
 import {
+  getDeviceId,
   parseUserAgent,
   generateDeviceFingerprint,
 } from "../../utils/user-agent-parser.js";
@@ -1643,12 +1644,14 @@ router.post("/login", async (req, res) => {
     );
 
     if (userRecord.totpEnabled) {
-      const deviceFingerprint = generateDeviceFingerprint(deviceInfo);
-
-      const isTrusted = await authManager.isTrustedDevice(
-        userRecord.id,
-        deviceFingerprint,
+      const deviceFingerprint = generateDeviceFingerprint(
+        deviceInfo,
+        getDeviceId(req),
       );
+
+      const isTrusted = deviceFingerprint
+        ? await authManager.isTrustedDevice(userRecord.id, deviceFingerprint)
+        : false;
 
       if (isTrusted) {
         authLogger.info("TOTP bypassed for trusted device", {

--- a/src/backend/tests/utils/user-agent-parser.test.ts
+++ b/src/backend/tests/utils/user-agent-parser.test.ts
@@ -4,6 +4,7 @@ import {
   detectPlatform,
   parseUserAgent,
   generateDeviceFingerprint,
+  getDeviceId,
 } from "../../utils/user-agent-parser.js";
 
 function reqWith(headers: Record<string, string>): Request {
@@ -98,50 +99,81 @@ describe("parseUserAgent", () => {
 });
 
 describe("generateDeviceFingerprint", () => {
-  it("is stable across minor browser version bumps on web", () => {
-    const a = generateDeviceFingerprint({
-      type: "web",
-      browser: "Chrome",
-      version: "120.5",
-      os: "Windows 10/11",
-      deviceInfo: "Chrome 120.5 on Windows 10/11",
-    });
-    const b = generateDeviceFingerprint({
-      type: "web",
-      browser: "Chrome",
-      version: "120.9",
-      os: "Windows 10/11",
-      deviceInfo: "Chrome 120.9 on Windows 10/11",
-    });
+  it("is stable for the same client device id", () => {
+    const a = generateDeviceFingerprint(
+      {
+        type: "web",
+        browser: "Chrome",
+        version: "120.5",
+        os: "Windows 10/11",
+        deviceInfo: "Chrome 120.5 on Windows 10/11",
+      },
+      "a".repeat(64),
+    );
+    const b = generateDeviceFingerprint(
+      {
+        type: "web",
+        browser: "Chrome",
+        version: "121.9",
+        os: "Windows 10/11",
+        deviceInfo: "Chrome 121.9 on Windows 10/11",
+      },
+      "a".repeat(64),
+    );
     expect(a).toBe(b);
   });
 
-  it("differs across major browser versions on web", () => {
-    const a = generateDeviceFingerprint({
-      type: "web",
-      browser: "Chrome",
-      version: "120.0",
-      os: "Windows 10/11",
-      deviceInfo: "",
-    });
-    const b = generateDeviceFingerprint({
-      type: "web",
-      browser: "Chrome",
-      version: "121.0",
-      os: "Windows 10/11",
-      deviceInfo: "",
-    });
+  it("differs for two clients on the same platform", () => {
+    const a = generateDeviceFingerprint(
+      {
+        type: "desktop",
+        browser: "Termix Desktop",
+        version: "2.7.0",
+        os: "Linux",
+        deviceInfo: "",
+      },
+      "a".repeat(64),
+    );
+    const b = generateDeviceFingerprint(
+      {
+        type: "desktop",
+        browser: "Termix Desktop",
+        version: "2.7.0",
+        os: "Linux",
+        deviceInfo: "",
+      },
+      "b".repeat(64),
+    );
     expect(a).not.toBe(b);
   });
 
-  it("produces a 64-char hex sha256 digest", () => {
-    const fp = generateDeviceFingerprint({
-      type: "desktop",
-      browser: "Termix Desktop",
-      version: "2.3.1",
-      os: "macOS",
-      deviceInfo: "",
-    });
-    expect(fp).toMatch(/^[0-9a-f]{64}$/);
+  it("does not trust clients without a device id", () => {
+    const fp = generateDeviceFingerprint(
+      {
+        type: "desktop",
+        browser: "Termix Desktop",
+        version: "2.3.1",
+        os: "macOS",
+        deviceInfo: "",
+      },
+      null,
+    );
+    expect(fp).toBeNull();
+  });
+});
+
+describe("getDeviceId", () => {
+  it("accepts a 256-bit hex device id", () => {
+    const deviceId = "a".repeat(64);
+    expect(getDeviceId(reqWith({ "x-termix-device-id": deviceId }))).toBe(
+      deviceId,
+    );
+  });
+
+  it("rejects missing or malformed device ids", () => {
+    expect(getDeviceId(reqWith({}))).toBeNull();
+    expect(
+      getDeviceId(reqWith({ "x-termix-device-id": "shared-linux" })),
+    ).toBeNull();
   });
 });

--- a/src/backend/utils/cors-config.ts
+++ b/src/backend/utils/cors-config.ts
@@ -35,6 +35,7 @@ export function createCorsMiddleware(
     "Authorization",
     "User-Agent",
     "X-Electron-App",
+    "X-Termix-Device-ID",
     "Cache-Control",
     "x-admin-target-user",
     ...extraHeaders,

--- a/src/backend/utils/user-agent-parser.ts
+++ b/src/backend/utils/user-agent-parser.ts
@@ -250,17 +250,21 @@ function parseMacVersion(userAgent: string): string {
   return "macOS";
 }
 
-/**
- * Generate a stable device fingerprint based on device type, browser, and OS.
- * Ignores minor version numbers to handle browser auto-updates.
- */
-export function generateDeviceFingerprint(deviceInfo: DeviceInfo): string {
-  const fingerprintString =
-    deviceInfo.type === "desktop" || deviceInfo.type === "mobile"
-      ? `${deviceInfo.type}|${deviceInfo.browser}|${deviceInfo.os}`
-      : `${deviceInfo.type}|${deviceInfo.browser} ${
-          deviceInfo.version.split(".")[0]
-        }|${deviceInfo.os}`;
+/** Return the installation-scoped identifier used for trusted-device checks. */
+export function getDeviceId(req: Request): string | null {
+  const value = req.headers["x-termix-device-id"];
+  if (typeof value !== "string" || !/^[a-f0-9]{64}$/.test(value)) return null;
+  return value;
+}
 
-  return crypto.createHash("sha256").update(fingerprintString).digest("hex");
+/** Bind a trusted-device record to one client installation and platform. */
+export function generateDeviceFingerprint(
+  deviceInfo: DeviceInfo,
+  deviceId: string | null,
+): string | null {
+  if (!deviceId) return null;
+  return crypto
+    .createHash("sha256")
+    .update(`${deviceInfo.type}|${deviceId}`)
+    .digest("hex");
 }

--- a/src/ui/lib/device-id.ts
+++ b/src/ui/lib/device-id.ts
@@ -1,0 +1,23 @@
+const DEVICE_ID_STORAGE_KEY = "termixDeviceId";
+const DEVICE_ID_PATTERN = /^[a-f0-9]{64}$/;
+
+function createDeviceId(): string {
+  const bytes = new Uint8Array(32);
+  crypto.getRandomValues(bytes);
+  return Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join(
+    "",
+  );
+}
+
+export function getDeviceId(): string | null {
+  try {
+    const stored = localStorage.getItem(DEVICE_ID_STORAGE_KEY);
+    if (stored && DEVICE_ID_PATTERN.test(stored)) return stored;
+
+    const deviceId = createDeviceId();
+    localStorage.setItem(DEVICE_ID_STORAGE_KEY, deviceId);
+    return deviceId;
+  } catch {
+    return null;
+  }
+}

--- a/src/ui/main-axios.ts
+++ b/src/ui/main-axios.ts
@@ -61,6 +61,7 @@ import {
 } from "@/lib/frontend-logger";
 import { dbHealthMonitor } from "@/lib/db-health-monitor";
 import { asHttpError } from "@/lib/http-error";
+import { getDeviceId } from "@/lib/device-id";
 
 export type ServerStatus = {
   status: "online" | "offline";
@@ -445,6 +446,15 @@ function createApiInstance(
 
     if (isDevMode) {
       logger.requestStart(method, fullUrl, context);
+    }
+
+    const deviceId = getDeviceId();
+    if (deviceId) {
+      if (config.headers.set) {
+        config.headers.set("X-Termix-Device-ID", deviceId);
+      } else {
+        config.headers["X-Termix-Device-ID"] = deviceId;
+      }
     }
 
     if (isElectron()) {


### PR DESCRIPTION
## Summary

- replace shared platform/OS trusted-device fingerprints with a random 256-bit ID scoped to each client installation
- require a valid client device ID before bypassing TOTP for password or passkey login
- keep older clients compatible while forcing them through MFA instead of trusting a broad legacy fingerprint
- allow the device ID header through CORS and cover same-platform client isolation with regression tests

Fixes Termix-SSH/Support#1129.

## Security impact

Previously, every Termix desktop client on the same OS produced the same trusted-device fingerprint for a user. Trusting one Linux desktop could therefore suppress MFA on another Linux desktop after password authentication. Legacy fingerprints no longer match after this change.

## Validation

- `npm test` — 259 files passed, 1948 tests passed, 1 skipped
- `npm run type-check`
- `npm run lint` — 0 errors (existing warnings only)
- `npm run build`
- `git diff --check`