### PR TITLE
fix: merge OIDC group claims across sources

### DIFF
--- a/src/backend/database/routes/user-oidc-utils.ts
+++ b/src/backend/database/routes/user-oidc-utils.ts
@@ -205,6 +205,22 @@ export function extractOidcGroups(
   return [];
 }
 
+/**
+ * OIDC providers may return group claims in the ID token, userinfo response,
+ * or both. Keep every verified source authoritative instead of letting a
+ * sparse userinfo payload overwrite claims from the ID token.
+ */
+export function extractOidcGroupsFromSources(
+  sources: Record<string, unknown>[],
+  groupClaim?: string,
+): string[] {
+  return [
+    ...new Set(
+      sources.flatMap((source) => extractOidcGroups(source, groupClaim)),
+    ),
+  ];
+}
+
 export function isOIDCUserAllowed(
   allowedUsers: string,
   identifier: string,

--- a/src/backend/database/routes/users.ts
+++ b/src/backend/database/routes/users.ts
@@ -30,7 +30,7 @@ import {
   isOIDCUserAllowed,
   OIDCTokenFormatError,
   verifyOIDCToken,
-  extractOidcGroups,
+  extractOidcGroupsFromSources,
   parseOidcRoleMap,
   resolveOidcMappedRoles,
   loadProviderConfig,
@@ -1014,6 +1014,7 @@ router.get("/oidc/callback", async (req, res) => {
     await deleteOIDCStateSettings(state);
 
     let userInfo: Record<string, unknown> = null;
+    const oidcClaimSources: Record<string, unknown>[] = [];
     const userInfoUrls: string[] = [];
 
     const normalizedIssuerUrl = config.issuer_url.endsWith("/")
@@ -1069,6 +1070,7 @@ router.get("/oidc/callback", async (req, res) => {
           });
           return res.status(401).json({ error: "Invalid OIDC token nonce" });
         }
+        oidcClaimSources.push(userInfo);
       } catch (error) {
         // A token we cannot parse as a JWS carries no claims we could trust, so
         // fall through to the userinfo endpoint instead of failing the login.
@@ -1102,6 +1104,7 @@ router.get("/oidc/callback", async (req, res) => {
               string,
               unknown
             >;
+            oidcClaimSources.push(fetchedUserInfo);
             userInfo = { ...userInfo, ...fetchedUserInfo };
             break;
           } else {
@@ -1306,8 +1309,8 @@ router.get("/oidc/callback", async (req, res) => {
 
     // Sync admin status based on OIDC group membership
     if (config.admin_group) {
-      const groups = extractOidcGroups(
-        userInfo as Record<string, unknown>,
+      const groups = extractOidcGroupsFromSources(
+        oidcClaimSources,
         config.group_claim,
       );
 
@@ -1369,8 +1372,8 @@ router.get("/oidc/callback", async (req, res) => {
       );
 
       if (roleMap.size > 0) {
-        const groups = extractOidcGroups(
-          userInfo as Record<string, unknown>,
+        const groups = extractOidcGroupsFromSources(
+          oidcClaimSources,
           config.group_claim,
         );
         const { desired, managed } = resolveOidcMappedRoles(groups, roleMap);

--- a/src/backend/tests/database/routes/user-oidc-utils.test.ts
+++ b/src/backend/tests/database/routes/user-oidc-utils.test.ts
@@ -15,6 +15,7 @@ const {
   isOIDCUserAllowed,
   getOIDCConfigFromEnv,
   extractOidcGroups,
+  extractOidcGroupsFromSources,
   validateLogoutTokenClaims,
   parseOidcRoleMap,
   resolveOidcMappedRoles,
@@ -342,6 +343,35 @@ describe("extractOidcGroups", () => {
 
   it("returns an empty array when no groups are present", () => {
     expect(extractOidcGroups({})).toEqual([]);
+  });
+});
+
+describe("extractOidcGroupsFromSources", () => {
+  it("preserves ID token groups when userinfo omits them", () => {
+    expect(
+      extractOidcGroupsFromSources([
+        { groups: ["admins", "users"] },
+        { sub: "user-1", name: "Example User" },
+      ]),
+    ).toEqual(["admins", "users"]);
+  });
+
+  it("combines and deduplicates groups from both verified sources", () => {
+    expect(
+      extractOidcGroupsFromSources([
+        { roles: ["users", "operators"] },
+        { roles: ["operators", "admins"] },
+      ]),
+    ).toEqual(["users", "operators", "admins"]);
+  });
+
+  it("supports a configured group claim across sources", () => {
+    expect(
+      extractOidcGroupsFromSources(
+        [{ custom_groups: ["admins"] }, { custom_groups: ["users"] }],
+        "custom_groups",
+      ),
+    ).toEqual(["admins", "users"]);
   });
 });
 


### PR DESCRIPTION
## Summary

- keep verified ID token and userinfo claims as separate OIDC group sources
- merge and deduplicate groups before admin-group and RBAC role synchronization
- preserve valid ID-token groups when a sparse userinfo response omits them
- cover standard, deduplicated, and custom group claims with regression tests

Fixes Termix-SSH/Support#1128.

## Why

The callback previously shallow-merged userinfo over ID-token claims and then evaluated groups from only that final object. A sparse or empty group claim in userinfo could therefore erase a valid group from the verified ID token and revoke admin access for a dual-auth account. Both responses are authenticated outputs from the same login, so group synchronization now evaluates their union.

## Validation

- `npm test` — 259 files passed, 1949 tests passed, 1 skipped
- `npm run type-check`
- `npm run lint` — 0 errors (existing warnings only)
- `npm run build`
- `git diff --check`