### PR TITLE
fix: allow disabling SSH keepalives

### DIFF
--- a/src/backend/hosts/file-manager/index.ts
+++ b/src/backend/hosts/file-manager/index.ts
@@ -50,6 +50,7 @@ import {
 import { registerFileListingRoutes } from "./list-routes.js";
 import { registerFileOperationRoutes } from "./operation-routes.js";
 import { resolveSshConnectConfigHost } from "../ssh-dns.js";
+import { resolveSshKeepalive } from "../ssh-keepalive.js";
 import {
   hostAddressMismatch,
   HostAddressMismatchError,
@@ -957,19 +958,18 @@ app.post("/ssh/file_manager/ssh/connect", async (req, res) => {
   }
 
   const preloadedHostData = await SSHHostKeyVerifier.preloadHostData(hostId);
+  const keepalive = resolveSshKeepalive(
+    hostKeepaliveInterval,
+    hostKeepaliveCountMax,
+    60000,
+    5,
+  );
   const config: Record<string, unknown> = {
     host: resolvedIp?.replace(/^\[|\]$/g, "") || resolvedIp,
     port: resolvedPort,
     username: resolvedUsername,
     tryKeyboard: true,
-    keepaliveInterval:
-      typeof hostKeepaliveInterval === "number"
-        ? Math.max(5000, hostKeepaliveInterval * 1000)
-        : 60000,
-    keepaliveCountMax:
-      typeof hostKeepaliveCountMax === "number"
-        ? Math.max(1, hostKeepaliveCountMax)
-        : 5,
+    ...keepalive,
     readyTimeout: 60000,
     tcpKeepAlive: true,
     tcpKeepAliveInitialDelay: 30000,

--- a/src/backend/hosts/ssh-keepalive.test.ts
+++ b/src/backend/hosts/ssh-keepalive.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { resolveSshKeepalive } from "./ssh-keepalive.js";
+
+describe("resolveSshKeepalive", () => {
+  it("preserves zero to disable SSH keepalives", () => {
+    expect(resolveSshKeepalive(0, 0, 30000, 5)).toEqual({
+      keepaliveInterval: 0,
+      keepaliveCountMax: 0,
+    });
+  });
+
+  it("uses defaults when keepalive settings are absent", () => {
+    expect(resolveSshKeepalive(undefined, undefined, 60000, 5)).toEqual({
+      keepaliveInterval: 60000,
+      keepaliveCountMax: 5,
+    });
+  });
+
+  it("enforces the existing minimums for positive settings", () => {
+    expect(resolveSshKeepalive(1, 0.5, 30000, 5)).toEqual({
+      keepaliveInterval: 5000,
+      keepaliveCountMax: 1,
+    });
+  });
+});

--- a/src/backend/hosts/ssh-keepalive.ts
+++ b/src/backend/hosts/ssh-keepalive.ts
@@ -1,0 +1,23 @@
+const MIN_KEEPALIVE_INTERVAL_MS = 5000;
+
+export function resolveSshKeepalive(
+  intervalSeconds: number | undefined,
+  countMax: number | undefined,
+  defaultIntervalMs: number,
+  defaultCountMax: number,
+) {
+  return {
+    keepaliveInterval:
+      typeof intervalSeconds !== "number"
+        ? defaultIntervalMs
+        : intervalSeconds === 0
+          ? 0
+          : Math.max(MIN_KEEPALIVE_INTERVAL_MS, intervalSeconds * 1000),
+    keepaliveCountMax:
+      typeof countMax !== "number"
+        ? defaultCountMax
+        : countMax === 0
+          ? 0
+          : Math.max(1, countMax),
+  };
+}

--- a/src/backend/hosts/terminal/index.ts
+++ b/src/backend/hosts/terminal/index.ts
@@ -47,6 +47,7 @@ import { preparePrivateKeyForSSH2 } from "../../utils/ssh-key-utils.js";
 import { triggerLoginAlert } from "../../utils/alert-trigger.js";
 import { getClientIp } from "../../utils/request-origin.js";
 import { isRetriableDnsError, resolveHostForSshConnect } from "../ssh-dns.js";
+import { resolveSshKeepalive } from "../ssh-keepalive.js";
 import {
   hostAddressMismatch,
   HOST_ADDRESS_MISMATCH_MESSAGE,
@@ -2761,6 +2762,12 @@ wss.on("connection", async (ws: WebSocket, req) => {
 
     const hostKeepaliveInterval = hostConfig.terminalConfig?.keepaliveInterval;
     const hostKeepaliveCountMax = hostConfig.terminalConfig?.keepaliveCountMax;
+    const keepalive = resolveSshKeepalive(
+      hostKeepaliveInterval,
+      hostKeepaliveCountMax,
+      30000,
+      5,
+    );
 
     // Pre-fetch the stored host key before connect so the verifier callback
     // runs synchronously during SSH key exchange, avoiding LoginGraceTime
@@ -2772,14 +2779,7 @@ wss.on("connection", async (ws: WebSocket, req) => {
       port,
       username,
       tryKeyboard: resolvedCredentials.authType !== "tailscale",
-      keepaliveInterval:
-        typeof hostKeepaliveInterval === "number"
-          ? Math.max(5000, hostKeepaliveInterval * 1000)
-          : 30000,
-      keepaliveCountMax:
-        typeof hostKeepaliveCountMax === "number"
-          ? Math.max(1, hostKeepaliveCountMax)
-          : 5,
+      ...keepalive,
       readyTimeout:
         resolvedCredentials.authType === "tailscale"
           ? TAILSCALE_CHECK_TIMEOUT_MS


### PR DESCRIPTION
# Overview

- [x] Fixed: preserve an explicit zero keepalive interval so SSH keepalives can be disabled
- [x] Updated: apply the same keepalive normalization to terminal and file manager connections

# Changes Made

- Keep the existing defaults when host keepalive settings are absent
- Keep the existing minimums for positive keepalive settings
- Pass zero through to `ssh2`, where `keepaliveInterval: 0` disables the keepalive timer
- Add regression coverage for disabled, default, and positive settings

# Related Issues

- Closes Termix-SSH/Support#1122

# Screenshots / Demos

Not applicable; backend SSH connection behavior only.

# Checklist

- [x] Code follows project style guidelines
- [x] Supports mobile and desktop UI/app (if applicable)
- [x] I have read [Contributing.md](https://github.com/Termix-SSH/Termix/blob/main/CONTRIBUTING.md)
- [x] This is not a translation request. See [docs](https://docs.termix.site/translations)

# Verification

- `npm test -- --reporter=dot` (1949 passed, 1 skipped)
- `npm run type-check`
- `npm run lint` (0 errors; existing warnings only)
- `npm run build`