### PR TITLE
fix: keep dashboard metrics aligned for long host names

### DIFF
--- a/src/ui/dashboard/DashboardTab.tsx
+++ b/src/ui/dashboard/DashboardTab.tsx
@@ -421,7 +421,7 @@ function MetricBar({ label, value }: { label: string; value: number }) {
   );
 }
 
-function HostStatusCard({
+export function HostStatusCard({
   hosts,
   hostMetrics,
   onOpenTab,
@@ -474,23 +474,31 @@ function HostStatusCard({
             <div
               key={i}
               onClick={() => onOpenTab(host, "host-metrics")}
-              className="flex items-center justify-between px-4 py-2.5 border-b border-border last:border-0 hover:bg-muted/50 cursor-pointer group/row"
+              className="flex min-w-0 items-center justify-between px-4 py-2.5 border-b border-border last:border-0 hover:bg-muted/50 cursor-pointer group/row"
             >
-              <div className="flex items-center gap-2.5">
+              <div className="flex min-w-0 flex-1 items-center gap-2.5">
                 <span
                   className={`size-1.5 rounded-full shrink-0 ${getStatusClasses(availability, statusScheme, "dot", statusLoading)}`}
                 />
-                <div className="flex flex-col">
-                  <div className="flex items-center gap-1">
-                    <span className="text-xs font-semibold">{host.name}</span>
+                <div className="flex min-w-0 flex-col">
+                  <div className="flex min-w-0 items-center gap-1">
+                    <span
+                      className="truncate text-xs font-semibold"
+                      title={host.name}
+                    >
+                      {host.name}
+                    </span>
                     <ExternalLink className="size-2.5 text-muted-foreground/0 group-hover/row:text-muted-foreground/60 transition-colors shrink-0" />
                   </div>
-                  <span className="text-[10px] text-muted-foreground font-mono">
+                  <span
+                    className="truncate text-[10px] text-muted-foreground font-mono"
+                    title={host.ip}
+                  >
                     {host.ip}
                   </span>
                 </div>
               </div>
-              <div className="flex items-center gap-3">
+              <div className="flex shrink-0 items-center gap-3">
                 {availability === "online" && hasMetrics ? (
                   <div className="flex items-center gap-3">
                     {cpu !== null && (

--- a/src/ui/tests/dashboard/HostStatusCard.test.tsx
+++ b/src/ui/tests/dashboard/HostStatusCard.test.tsx
@@ -1,0 +1,43 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+import { HostStatusCard } from "@/dashboard/DashboardTab";
+import type { Host } from "@/types/ui-types";
+
+afterEach(cleanup);
+
+describe("HostStatusCard", () => {
+  it("truncates long host identity without shrinking the metrics", () => {
+    const host = {
+      id: "host-1",
+      name: "a-very-long-host-name-that-must-not-shift-the-status-columns",
+      ip: "a-very-long-hostname.example.internal",
+      online: false,
+    } as Host;
+
+    render(
+      <HostStatusCard
+        hosts={[host]}
+        hostMetrics={new Map()}
+        onOpenTab={() => {}}
+      />,
+    );
+
+    const name = screen.getByText(host.name);
+    const ip = screen.getByText(host.ip);
+    const identity = name.parentElement?.parentElement;
+    const row = identity?.parentElement?.parentElement;
+    const metrics = row?.lastElementChild;
+
+    expect(name.className).toContain("truncate");
+    expect(name.getAttribute("title")).toBe(host.name);
+    expect(ip.className).toContain("truncate");
+    expect(ip.getAttribute("title")).toBe(host.ip);
+    expect(identity?.className).toContain("min-w-0");
+    expect(metrics?.className).toContain("shrink-0");
+  });
+});


### PR DESCRIPTION
# Overview

- [x] Fixed: prevent long host names and addresses from shifting Host Status metric columns
- [x] Updated: retain the full host identity in native hover text when the visible value is truncated

# Changes Made

- Allow the host identity flex item to shrink within the status row
- Truncate long host names and addresses to one line
- Keep CPU, RAM, disk, and availability columns from shrinking
- Add regression coverage for a long host identity

# Related Issues

- Closes Termix-SSH/Support#1121

# Screenshots / Demos

Not included; the regression test covers the flex sizing and truncation contract.

# Checklist

- [x] Code follows project style guidelines
- [x] Supports mobile and desktop UI/app (if applicable)
- [x] I have read [Contributing.md](https://github.com/Termix-SSH/Termix/blob/main/CONTRIBUTING.md)
- [x] This is not a translation request. See [docs](https://docs.termix.site/translations)

# Verification

- `npm test -- --reporter=dot` (1947 passed, 1 skipped)
- `npm run type-check`
- `npm run lint` (0 errors; existing warnings only)
- `npm run build`