### PR TITLE
fix: distinguish reachable and available hosts

### DIFF
--- a/src/backend/hosts/metrics/host-status.test.ts
+++ b/src/backend/hosts/metrics/host-status.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import {
+  statusAfterAuthentication,
+  statusAfterReachabilityCheck,
+} from "./host-status.js";
+
+describe("host availability status", () => {
+  it("does not call a TCP-reachable host online before authentication", () => {
+    expect(statusAfterReachabilityCheck(true)).toBe("reachable");
+  });
+
+  it("keeps a verified host online across later reachability checks", () => {
+    expect(statusAfterReachabilityCheck(true, "online")).toBe("online");
+  });
+
+  it("marks successful authentication online", () => {
+    expect(statusAfterAuthentication(true, "reachable")).toBe("online");
+  });
+
+  it("downgrades failed authentication without hiding reachability", () => {
+    expect(statusAfterAuthentication(false, "online")).toBe("reachable");
+    expect(statusAfterAuthentication(false, "offline")).toBe("offline");
+  });
+});

--- a/src/backend/hosts/metrics/host-status.ts
+++ b/src/backend/hosts/metrics/host-status.ts
@@ -1,0 +1,17 @@
+export type HostStatus = "online" | "reachable" | "offline";
+
+export function statusAfterReachabilityCheck(
+  reachable: boolean,
+  current?: HostStatus,
+): HostStatus {
+  if (!reachable) return "offline";
+  return current === "online" ? "online" : "reachable";
+}
+
+export function statusAfterAuthentication(
+  authenticated: boolean,
+  current?: HostStatus,
+): HostStatus {
+  if (authenticated) return "online";
+  return current === "offline" ? "offline" : "reachable";
+}

--- a/src/backend/hosts/metrics/index.ts
+++ b/src/backend/hosts/metrics/index.ts
@@ -63,6 +63,11 @@ import {
   supportsMetrics,
   tcpPingThroughJumpHost,
 } from "./helpers.js";
+import {
+  type HostStatus,
+  statusAfterAuthentication,
+  statusAfterReachabilityCheck,
+} from "./host-status.js";
 import { createConnectionLog } from "../connection-log.js";
 import {
   cleanupMetricsSession,
@@ -85,8 +90,6 @@ import {
 
 const authManager = AuthManager.getInstance();
 const permissionManager = PermissionManager.getInstance();
-
-type HostStatus = "online" | "offline";
 
 interface SSHHostWithCredentials {
   id: number;
@@ -520,7 +523,10 @@ class PollingManager {
         isOnline = await tcpPing(refreshedHost.ip, pingPort, 5000);
       }
       const statusEntry: StatusEntry = {
-        status: isOnline ? "online" : "offline",
+        status: statusAfterReachabilityCheck(
+          isOnline,
+          this.statusStore.get(refreshedHost.id)?.status,
+        ),
         lastChecked: new Date().toISOString(),
       };
       this.statusStore.set(refreshedHost.id, statusEntry);
@@ -571,8 +577,19 @@ class PollingManager {
       return;
     }
 
+    let authenticated = false;
     try {
-      const metrics = await collectMetrics(refreshedHost);
+      const metrics = await collectMetrics(refreshedHost, () => {
+        authenticated = true;
+        this.statusStore.set(refreshedHost.id, {
+          status: statusAfterAuthentication(true),
+          lastChecked: new Date().toISOString(),
+        });
+      });
+      this.statusStore.set(refreshedHost.id, {
+        status: statusAfterAuthentication(true),
+        lastChecked: new Date().toISOString(),
+      });
       this.metricsStore.set(refreshedHost.id, {
         data: metrics,
         timestamp: Date.now(),
@@ -584,6 +601,15 @@ class PollingManager {
       pollingBackoff.reset(refreshedHost.id);
       authFailureTracker.reset(refreshedHost.id);
     } catch (error) {
+      if (!authenticated) {
+        this.statusStore.set(refreshedHost.id, {
+          status: statusAfterAuthentication(
+            false,
+            this.statusStore.get(refreshedHost.id)?.status,
+          ),
+          lastChecked: new Date().toISOString(),
+        });
+      }
       const isAuthError =
         error instanceof Error &&
         (error.message.includes("authentication") ||
@@ -752,7 +778,11 @@ class PollingManager {
     for (const [hostId, config] of this.pollingConfigs.entries()) {
       const status = this.statusStore.get(hostId);
 
-      if (!status || status.status === "online") {
+      if (
+        !status ||
+        status.status === "online" ||
+        status.status === "reachable"
+      ) {
         hostsToRefresh.push({
           host: config.host,
           viewerUserId: config.viewerUserId,
@@ -1496,7 +1526,10 @@ const proxmoxPollingManager = new ProxmoxPollingManager<SSHHostWithCredentials>(
   },
 );
 
-async function collectMetrics(host: SSHHostWithCredentials): Promise<{
+async function collectMetrics(
+  host: SSHHostWithCredentials,
+  onAuthenticated?: () => void,
+): Promise<{
   cpu: {
     percent: number | null;
     cores: number | null;
@@ -1556,6 +1589,7 @@ async function collectMetrics(host: SSHHostWithCredentials): Promise<{
 
   const cached = metricsCache.get(host.id);
   if (cached) {
+    onAuthenticated?.();
     return cached as ReturnType<typeof collectMetrics> extends Promise<infer T>
       ? T
       : never;
@@ -1571,6 +1605,7 @@ async function collectMetrics(host: SSHHostWithCredentials): Promise<{
       ).excludedMounts;
 
       const collectFn = async (client: Client) => {
+        onAuthenticated?.();
         const cpu = await collectCpuMetrics(client);
         const memory = await collectMemoryMetrics(client);
         const disk = await collectDiskMetrics(client, excludedMounts);

--- a/src/types/ui-types.ts
+++ b/src/types/ui-types.ts
@@ -26,6 +26,7 @@ export type Host = {
    */
   childHosts?: Host[];
   online: boolean;
+  status?: "online" | "reachable" | "offline" | "unknown";
   cpu: number | null;
   ram: number | null;
   lastAccess: string;

--- a/src/ui/dashboard/DashboardTab.tsx
+++ b/src/ui/dashboard/DashboardTab.tsx
@@ -144,7 +144,7 @@ function StatsBarCard({
   dbHealth: "healthy" | "error";
 }) {
   const { t } = useTranslation();
-  const online = hosts.filter((h) => h.online).length;
+  const online = hosts.filter((h) => h.status === "online").length;
   return (
     <Card className="grid grid-cols-4 divide-x divide-border overflow-hidden w-full h-full py-0 gap-0">
       <div className="flex flex-col justify-center px-4 py-2 gap-1">
@@ -182,7 +182,9 @@ function StatsBarCard({
       </div>
       <div className="flex flex-col justify-center px-4 py-2 gap-1">
         <span className="text-[10px] text-muted-foreground uppercase tracking-widest font-semibold">
-          {t("dashboardTab.hostsOnline")}
+          {t("dashboardTab.hostsAvailable", {
+            defaultValue: "Hosts Available",
+          })}
         </span>
         <div className="flex items-baseline gap-1">
           <span className="text-xl font-bold leading-none">{online}</span>
@@ -435,7 +437,7 @@ function HostStatusCard({
 }) {
   const { t } = useTranslation();
   const statusScheme = useStatusColorScheme();
-  const online = hosts.filter((h) => h.online).length;
+  const online = hosts.filter((h) => h.status === "online").length;
   return (
     <Card className="flex flex-col overflow-hidden w-full h-full py-0 gap-0">
       <div className="flex items-center justify-between px-4 py-3 border-b border-border shrink-0">
@@ -446,7 +448,8 @@ function HostStatusCard({
           </span>
         </div>
         <span className="text-xs text-muted-foreground">
-          {online}/{hosts.length} {t("dashboardTab.onlineLower")}
+          {online}/{hosts.length}{" "}
+          {t("dashboardTab.availableLower", { defaultValue: "Available" })}
         </span>
       </div>
       <div className="flex flex-col overflow-auto flex-1">
@@ -456,6 +459,12 @@ function HostStatusCard({
           </div>
         )}
         {hosts.map((host, i) => {
+          const availability =
+            host.status && host.status !== "unknown"
+              ? host.status
+              : host.online
+                ? "online"
+                : "offline";
           const metrics = hostMetrics.get(host.id);
           const cpu = metrics?.cpu ?? null;
           const ram = metrics?.ram ?? null;
@@ -469,7 +478,7 @@ function HostStatusCard({
             >
               <div className="flex items-center gap-2.5">
                 <span
-                  className={`size-1.5 rounded-full shrink-0 ${getStatusClasses(host.online, statusScheme, "dot", statusLoading)}`}
+                  className={`size-1.5 rounded-full shrink-0 ${getStatusClasses(availability, statusScheme, "dot", statusLoading)}`}
                 />
                 <div className="flex flex-col">
                   <div className="flex items-center gap-1">
@@ -482,7 +491,7 @@ function HostStatusCard({
                 </div>
               </div>
               <div className="flex items-center gap-3">
-                {host.online && hasMetrics ? (
+                {availability === "online" && hasMetrics ? (
                   <div className="flex items-center gap-3">
                     {cpu !== null && (
                       <MetricBar label={t("dashboard.cpu")} value={cpu} />
@@ -508,13 +517,19 @@ function HostStatusCard({
                   </div>
                 )}
                 <span
-                  className={`text-[10px] px-2 py-0.5 font-semibold border ${getStatusClasses(host.online, statusScheme, "badge", statusLoading)}`}
+                  className={`text-[10px] px-2 py-0.5 font-semibold border ${getStatusClasses(availability, statusScheme, "badge", statusLoading)}`}
                 >
                   {statusLoading
                     ? t("dashboardTab.checking")
-                    : host.online
-                      ? t("dashboardTab.online")
-                      : t("dashboardTab.offline")}
+                    : availability === "online"
+                      ? t("dashboardTab.available", {
+                          defaultValue: "AVAILABLE",
+                        })
+                      : availability === "reachable"
+                        ? t("dashboardTab.reachable", {
+                            defaultValue: "REACHABLE",
+                          })
+                        : t("dashboardTab.offline")}
                 </span>
               </div>
             </div>

--- a/src/ui/dashboard/cards/NetworkGraphCard.tsx
+++ b/src/ui/dashboard/cards/NetworkGraphCard.tsx
@@ -136,6 +136,8 @@ function buildNodeSvg(
     statusColor = useRealColors
       ? "rgb(16,185,129)"
       : resolveCssVar("--accent-brand", "rgb(16,185,129)");
+  } else if (status === "reachable") {
+    statusColor = "rgb(251,191,36)";
   } else if (isOffline) {
     statusColor = useRealColors ? "rgb(239,68,68)" : "rgba(16,185,129,0.2)";
   } else {

--- a/src/ui/features/homepage/widgets/HostGridWidget.tsx
+++ b/src/ui/features/homepage/widgets/HostGridWidget.tsx
@@ -24,9 +24,11 @@ function StatusDot({ status }: { status: string }) {
   const color =
     status === "online"
       ? getAccentColor()
-      : status === "offline"
-        ? "#ef4444"
-        : "#6b7280";
+      : status === "reachable"
+        ? "#fbbf24"
+        : status === "offline"
+          ? "#ef4444"
+          : "#6b7280";
   return (
     <span
       className="w-1.5 h-1.5 rounded-full shrink-0 inline-block"

--- a/src/ui/features/homepage/widgets/HostStatusWidget.tsx
+++ b/src/ui/features/homepage/widgets/HostStatusWidget.tsx
@@ -93,6 +93,7 @@ function HostStatusWidget({
   const { hostId } = config;
   const [hostName, setHostName] = useState<string | null>(null);
   const [online, setOnline] = useState<boolean | null>(null);
+  const [reachable, setReachable] = useState(false);
   const [metrics, setMetrics] = useState<ServerMetrics | null>(null);
 
   const needsMetrics = shownMetrics.length > 0;
@@ -114,9 +115,15 @@ function HostStatusWidget({
     const poll = async () => {
       try {
         const s = await getServerStatusById(hostId);
-        if (!cancelled) setOnline(s.status === "online");
+        if (!cancelled) {
+          setOnline(s.status === "online");
+          setReachable(s.status === "reachable");
+        }
       } catch {
-        if (!cancelled) setOnline(false);
+        if (!cancelled) {
+          setOnline(false);
+          setReachable(false);
+        }
       }
 
       if (needsMetrics) {
@@ -173,13 +180,21 @@ function HostStatusWidget({
   }
 
   const onlineColor =
-    online === null ? "#6b7280" : online ? getAccentColor() : "#ef4444";
+    online === null
+      ? "#6b7280"
+      : online
+        ? getAccentColor()
+        : reachable
+          ? "#fbbf24"
+          : "#ef4444";
   const onlineLabel =
     online === null
       ? t("common.unknown")
       : online
         ? t("common.online")
-        : t("common.offline");
+        : reachable
+          ? t("common.reachable", { defaultValue: "Reachable" })
+          : t("common.offline");
 
   const networkIfaces = metrics?.network?.interfaces ?? [];
   const totalRx = networkIfaces.reduce((sum, iface) => {

--- a/src/ui/hooks/use-status-color-scheme.ts
+++ b/src/ui/hooks/use-status-color-scheme.ts
@@ -27,11 +27,13 @@ export function useStatusColorScheme(): StatusColorScheme {
 
 /** Returns Tailwind class names for a status dot/stripe. */
 export function getStatusClasses(
-  online: boolean,
+  status: boolean | "online" | "reachable" | "offline" | "degraded",
   scheme: StatusColorScheme,
   variant: "dot" | "stripe" | "badge",
   loading = false,
 ): string {
+  const online = status === true || status === "online";
+  const reachable = status === "reachable";
   if (loading) {
     if (scheme === "status") {
       if (variant === "dot") return "bg-yellow-400 animate-pulse";
@@ -41,6 +43,11 @@ export function getStatusClasses(
     if (variant === "dot") return "bg-muted-foreground/40 animate-pulse";
     if (variant === "stripe") return "bg-muted-foreground/20 animate-pulse";
     return "border-border/50 text-muted-foreground/50 bg-muted/20 animate-pulse";
+  }
+  if (reachable) {
+    if (variant === "dot") return "bg-amber-400";
+    if (variant === "stripe") return "bg-amber-400/50";
+    return "border-amber-400/40 text-amber-400 bg-amber-400/10";
   }
   if (scheme === "status") {
     if (variant === "dot") return online ? "bg-emerald-500" : "bg-red-500";

--- a/src/ui/lib/ServerStatusContext.tsx
+++ b/src/ui/lib/ServerStatusContext.tsx
@@ -125,7 +125,10 @@ export function ServerStatusProvider({
             const id = parseInt(idStr, 10);
             if (!isNaN(id)) {
               const status =
-                statusData?.status === "online" ? "online" : "offline";
+                statusData?.status === "online" ||
+                statusData?.status === "reachable"
+                  ? statusData.status
+                  : "offline";
               newStatuses.set(id, {
                 status,
                 lastChecked: statusData?.lastChecked || now,

--- a/src/ui/lib/server-status-store.ts
+++ b/src/ui/lib/server-status-store.ts
@@ -1,4 +1,4 @@
-export type StatusValue = "online" | "offline" | "degraded";
+export type StatusValue = "online" | "reachable" | "offline" | "degraded";
 
 export interface ServerStatusEntry {
   status: StatusValue;

--- a/src/ui/main-axios.ts
+++ b/src/ui/main-axios.ts
@@ -63,12 +63,12 @@ import { dbHealthMonitor } from "@/lib/db-health-monitor";
 import { asHttpError } from "@/lib/http-error";
 
 export type ServerStatus = {
-  status: "online" | "offline";
+  status: "online" | "reachable" | "offline";
   lastChecked: string;
 };
 
 export type SSHHostWithStatus = SSHHost & {
-  status: "online" | "offline" | "unknown";
+  status: "online" | "reachable" | "offline" | "unknown";
 };
 
 interface CpuMetrics {

--- a/src/ui/sidebar/HostManagerData.ts
+++ b/src/ui/sidebar/HostManagerData.ts
@@ -55,6 +55,7 @@ export function sshHostToHost(h: SSHHostWithStatus): Host {
         ? String((h as { parentHostId?: number | string }).parentHostId)
         : null,
     online: h.status === "online",
+    status: h.status,
     cpu: null,
     ram: null,
     lastAccess: "",

--- a/src/ui/sidebar/HostsPanel.tsx
+++ b/src/ui/sidebar/HostsPanel.tsx
@@ -125,7 +125,9 @@ function hostPassesFilters(host: Host, filters: FilterState): boolean {
   if (filters.status.length > 0) {
     const ok =
       (filters.status.includes("online") && host.online) ||
-      (filters.status.includes("offline") && !host.online) ||
+      (filters.status.includes("offline") &&
+        host.status !== "reachable" &&
+        !host.online) ||
       (filters.status.includes("pinned") && !!host.pin);
     if (!ok) return false;
   }

--- a/src/ui/sidebar/tree/HostItem/HostItem.tsx
+++ b/src/ui/sidebar/tree/HostItem/HostItem.tsx
@@ -72,8 +72,16 @@ export function statusCheckEnabled(host: Host): boolean {
   return host.statsConfig?.statusCheckEnabled !== false;
 }
 
-export function buildStatusTooltip(host: Host, online: boolean): string {
-  const statusLabel = online ? "Online" : "Offline";
+export function buildStatusTooltip(
+  host: Host,
+  status: "online" | "reachable" | "offline",
+): string {
+  const statusLabel =
+    status === "online"
+      ? "Available"
+      : status === "reachable"
+        ? "Reachable, not authenticated"
+        : "Offline";
   if (!statusCheckEnabled(host)) return "Monitoring disabled";
   const protocols: string[] = [];
   if (host.enableSsh) protocols.push("SSH");
@@ -282,7 +290,17 @@ export function HostItem({
   const statusLoading = !initialLoadComplete && statusCheckOn;
   // Per-host subscription — status polls only re-render rows that flipped.
   const liveStatus = useHostStatus(Number(host.id), statusCheckOn);
-  const isOnline = liveStatus != null ? liveStatus === "online" : host.online;
+  const availability =
+    liveStatus === "online" ||
+    liveStatus === "reachable" ||
+    liveStatus === "offline"
+      ? liveStatus
+      : host.status === "reachable"
+        ? "reachable"
+        : host.online
+          ? "online"
+          : "offline";
+  const isOnline = availability === "online";
   const isTouchOnly =
     typeof window !== "undefined" && window.matchMedia("(hover: none)").matches;
   const alwaysShowTray = trayTrigger === "always";
@@ -808,7 +826,7 @@ export function HostItem({
       {/* Status stripe */}
       {showStatusStripes && (
         <div
-          className={`w-[3px] shrink-0 transition-colors ${getStatusClasses(isOnline, statusScheme, "stripe", statusLoading)}`}
+          className={`w-[3px] shrink-0 transition-colors ${getStatusClasses(availability, statusScheme, "stripe", statusLoading)}`}
         />
       )}
 
@@ -853,7 +871,7 @@ export function HostItem({
                 </span>
               </TooltipTrigger>
               <TooltipContent side="right">
-                {buildStatusTooltip(host, isOnline)}
+                {buildStatusTooltip(host, availability)}
               </TooltipContent>
             </Tooltip>
           </TooltipProvider>

--- a/src/ui/tests/lib/server-status-store.test.ts
+++ b/src/ui/tests/lib/server-status-store.test.ts
@@ -65,6 +65,15 @@ describe("ServerStatusStore", () => {
     expect(store.getStatus(5)).toBe("online");
   });
 
+  it("preserves reachable as distinct from authenticated online", () => {
+    const store = new ServerStatusStore();
+    store.setEnabledHostIds(new Set([7]));
+    store.applyStatuses(
+      new Map([[7, { status: "reachable", lastChecked: "t" }]]),
+    );
+    expect(store.getStatus(7)).toBe("reachable");
+  });
+
   it("emits meta listeners when initial load completes", () => {
     const store = new ServerStatusStore();
     const onMeta = vi.fn();


### PR DESCRIPTION
# Overview

- [x] Fixed: stop reporting a host as available based only on an open TCP port
- [x] Updated: expose distinct available, reachable, and offline host states

# Changes Made

- Report `reachable` after a successful TCP probe until SSH authentication succeeds
- Promote a host to `online`/available when the metrics SSH session authenticates
- Downgrade failed authentication to reachable while preserving an actual offline result
- Keep authenticated state stable across later TCP probes
- Display reachable hosts in amber across the dashboard, sidebar, homepage widgets, and network graph
- Exclude reachable hosts from the Offline filter and available-host totals
- Add regression coverage for backend state transitions and frontend status storage

# Related Issues

- Closes Termix-SSH/Support#1120

# Screenshots / Demos

Not included; state transitions and rendering contracts are covered by tests.

# Checklist

- [x] Code follows project style guidelines
- [x] Supports mobile and desktop UI/app (if applicable)
- [x] I have read [Contributing.md](https://github.com/Termix-SSH/Termix/blob/main/CONTRIBUTING.md)
- [x] This is not a translation request. See [docs](https://docs.termix.site/translations)

# Verification

- `npm test -- --reporter=dot` (1951 passed, 1 skipped)
- `npm run type-check`
- `npm run lint` (0 errors; existing warnings only)
- `npm run build`