### PR TITLE
fix: throttle session activity persistence

### DIFF
--- a/src/backend/database/repositories/session-repository.ts
+++ b/src/backend/database/repositories/session-repository.ts
@@ -7,6 +7,8 @@ import { insertReturning } from "./returning.js";
 export type SessionRecord = typeof sessions.$inferSelect;
 export type NewSessionRecord = typeof sessions.$inferInsert;
 
+const SESSION_ACTIVITY_PERSIST_INTERVAL_MS = 60_000;
+
 export class SessionRepository {
   constructor(
     private readonly context: DatabaseContext,
@@ -50,12 +52,19 @@ export class SessionRepository {
   async touch(
     id: string,
     lastActiveAt = new Date().toISOString(),
-  ): Promise<void> {
-    await this.context.drizzle
+    minIntervalMs = SESSION_ACTIVITY_PERSIST_INTERVAL_MS,
+  ): Promise<boolean> {
+    const cutoff = new Date(
+      new Date(lastActiveAt).getTime() - minIntervalMs,
+    ).toISOString();
+    const result = await this.context.drizzle
       .update(sessions)
       .set({ lastActiveAt })
-      .where(eq(sessions.id, id));
+      .where(and(eq(sessions.id, id), lte(sessions.lastActiveAt, cutoff)));
+
+    if (rowsAffected(result) === 0) return false;
     await this.afterWrite();
+    return true;
   }
 
   async updateToken(

--- a/src/backend/tests/database/repositories/user-session-repositories.test.ts
+++ b/src/backend/tests/database/repositories/user-session-repositories.test.ts
@@ -193,6 +193,44 @@ describe("UserRepository and SessionRepository", () => {
     expect(await repo.sessions.findById("session-1")).toBeNull();
   });
 
+  it("persists session activity at most once per minute", async () => {
+    let writeCount = 0;
+    const repo = await createRepositories({
+      onSessionWrite: () => {
+        writeCount += 1;
+      },
+    });
+    await repo.users.create({
+      id: "user-1",
+      username: "user",
+      passwordHash: "hash",
+      isAdmin: false,
+      isOidc: false,
+    });
+    await repo.sessions.create({
+      id: "session-1",
+      userId: "user-1",
+      jwtToken: "token",
+      deviceType: "desktop",
+      deviceInfo: "Firefox",
+      createdAt: "2026-06-26T00:00:00.000Z",
+      expiresAt: "2026-06-27T00:00:00.000Z",
+      lastActiveAt: "2026-06-26T00:00:00.000Z",
+    });
+
+    expect(
+      await repo.sessions.touch("session-1", "2026-06-26T00:00:30.000Z"),
+    ).toBe(false);
+    expect(
+      await repo.sessions.touch("session-1", "2026-06-26T00:01:00.000Z"),
+    ).toBe(true);
+
+    expect(writeCount).toBe(2);
+    expect((await repo.sessions.findById("session-1"))?.lastActiveAt).toBe(
+      "2026-06-26T00:01:00.000Z",
+    );
+  });
+
   it("revokes all user sessions except an optional current session", async () => {
     const repo = await createRepositories();
     await repo.users.create({


### PR DESCRIPTION
## Summary
- throttle session `lastActiveAt` writes to once per minute
- skip the SQLite persistence hook when an activity update is suppressed
- add regression coverage for repeated session touches

Authenticated frontend polling previously touched the session on every request. For encrypted in-memory SQLite deployments, each touch immediately serialized and encrypted the entire database, causing excessive disk writes while a browser tab was open. Critical session mutations such as create, revoke, and token updates remain immediately persisted.

## Testing
- `npx vitest run src/backend/tests/database/repositories/user-session-repositories.test.ts`
- `npm run type-check`
- `npm run lint` (passes with existing warnings)

Fixes Termix-SSH/Support#1119