### PR TITLE
fix: preserve saved RDP connection settings

### DIFF
--- a/src/backend/hosts/guacamole/rdp-settings.ts
+++ b/src/backend/hosts/guacamole/rdp-settings.ts
@@ -1,0 +1,26 @@
+interface RdpSettingsInput {
+  port: number;
+  domain?: string;
+  security?: string;
+  ignoreCert: boolean;
+  guacConfig: Record<string, unknown>;
+  guacdOverrides: Record<string, unknown>;
+}
+
+export function buildRdpSettings({
+  port,
+  domain,
+  security,
+  ignoreCert,
+  guacConfig,
+  guacdOverrides,
+}: RdpSettingsInput): Record<string, unknown> {
+  return {
+    ...guacConfig,
+    port,
+    domain,
+    ...(security === undefined ? {} : { security }),
+    "ignore-cert": ignoreCert,
+    ...guacdOverrides,
+  };
+}

--- a/src/backend/hosts/guacamole/routes.ts
+++ b/src/backend/hosts/guacamole/routes.ts
@@ -21,6 +21,7 @@ import {
   getRequestMeta,
 } from "../../utils/audit-logger.js";
 import { resolveJumpTunnelEndpoint } from "./jump-tunnel-endpoint.js";
+import { buildRdpSettings } from "./rdp-settings.js";
 
 const router = express.Router();
 const tokenService = GuacamoleTokenService.getInstance();
@@ -618,22 +619,22 @@ router.post(
             hostname,
             username,
             password,
-            {
+            buildRdpSettings({
               port,
               domain,
               security:
                 (host.rdpSecurity as string) ||
                 (host.security as string) ||
                 undefined,
-              "ignore-cert":
+              ignoreCert:
                 host.rdpIgnoreCert !== undefined
                   ? !!host.rdpIgnoreCert
                   : host.ignoreCert !== undefined
                     ? !!host.ignoreCert
                     : true,
-              ...guacConfig,
-              ...guacdOverrides,
-            },
+              guacConfig,
+              guacdOverrides,
+            }),
             recordingMetadata,
             termixMeta,
           );

--- a/src/backend/tests/hosts/guacamole/rdp-settings.test.ts
+++ b/src/backend/tests/hosts/guacamole/rdp-settings.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { buildRdpSettings } from "../../../hosts/guacamole/rdp-settings.js";
+
+describe("buildRdpSettings", () => {
+  it("keeps saved RDP settings authoritative over stale advanced config", () => {
+    expect(
+      buildRdpSettings({
+        port: 3390,
+        domain: "EXAMPLE",
+        security: "nla",
+        ignoreCert: true,
+        guacConfig: {
+          port: 3389,
+          domain: "OLD",
+          security: "rdp",
+          "ignore-cert": false,
+          "color-depth": 24,
+        },
+        guacdOverrides: { guacdHost: "guacd.internal" },
+      }),
+    ).toEqual({
+      port: 3390,
+      domain: "EXAMPLE",
+      security: "nla",
+      "ignore-cert": true,
+      "color-depth": 24,
+      guacdHost: "guacd.internal",
+    });
+  });
+
+  it("preserves an advanced security value when no saved value exists", () => {
+    expect(
+      buildRdpSettings({
+        port: 3389,
+        ignoreCert: false,
+        guacConfig: { security: "tls" },
+        guacdOverrides: {},
+      }).security,
+    ).toBe("tls");
+  });
+});


### PR DESCRIPTION
## Summary
- make saved RDP host settings override stale values in advanced Guacamole config
- preserve unrelated advanced options and per-connection guacd routing
- add regression coverage for `ignore-cert`, security, domain, and port precedence

The host connection route previously applied `guacamoleConfig` after the structured RDP fields. A stale `ignore-cert` or `security` value in that JSON silently replaced the value shown and saved by the host editor before the token reached guacd.

## Testing
- `npx vitest run src/backend/tests/hosts/guacamole/rdp-settings.test.ts src/backend/tests/hosts/guacamole/token-service.test.ts`
- `npm run type-check`
- `npx eslint src/backend/hosts/guacamole/routes.ts src/backend/hosts/guacamole/rdp-settings.ts src/backend/tests/hosts/guacamole/rdp-settings.test.ts`

Fixes Termix-SSH/Support#1116