### PR TITLE
fix: authenticate tunnel status stream

### DIFF
--- a/src/ui/api/sse-stream.ts
+++ b/src/ui/api/sse-stream.ts
@@ -1,0 +1,46 @@
+export interface ServerSentEvent {
+  event: string;
+  data: string;
+}
+
+export async function streamServerSentEvents(
+  url: string,
+  init: RequestInit,
+  onEvent: (event: ServerSentEvent) => void,
+): Promise<void> {
+  const response = await fetch(url, init);
+  if (!response.ok) {
+    throw new Error(`SSE request failed with status ${response.status}`);
+  }
+  if (!response.body) throw new Error("SSE response has no body");
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+  let eventName = "message";
+  let data: string[] = [];
+
+  const dispatch = () => {
+    if (data.length > 0) onEvent({ event: eventName, data: data.join("\n") });
+    eventName = "message";
+    data = [];
+  };
+
+  while (true) {
+    const { done, value } = await reader.read();
+    buffer += decoder.decode(value, { stream: !done });
+    const lines = buffer.split(/\r?\n/);
+    buffer = done ? "" : (lines.pop() ?? "");
+
+    for (const line of lines) {
+      if (line === "") dispatch();
+      else if (line.startsWith("event:")) eventName = line.slice(6).trimStart();
+      else if (line.startsWith("data:")) data.push(line.slice(5).trimStart());
+    }
+
+    if (done) {
+      dispatch();
+      return;
+    }
+  }
+}

--- a/src/ui/api/tunnel-api.ts
+++ b/src/ui/api/tunnel-api.ts
@@ -12,6 +12,7 @@ import type {
   TunnelConnection,
   TunnelStatus,
 } from "@/types/index";
+import { streamServerSentEvents } from "./sse-stream";
 
 // TUNNEL MANAGEMENT
 // ============================================================================
@@ -65,9 +66,7 @@ export function subscribeTunnelStatuses(
   onError?: () => void,
 ): () => void {
   const baseURL = (tunnelApi.defaults.baseURL || "").replace(/\/$/, "");
-  const source = new EventSource(`${baseURL}/tunnel/status/stream`, {
-    withCredentials: true,
-  });
+  const controller = new AbortController();
 
   let latestLocal: Record<string, TunnelStatus> = {};
   let latestRemote: Record<string, TunnelStatus> = {};
@@ -77,18 +76,54 @@ export function subscribeTunnelStatuses(
     onStatuses({ ...latestLocal, ...latestRemote });
   };
 
-  source.addEventListener("statuses", (event) => {
-    try {
-      latestLocal = JSON.parse(event.data) as Record<string, TunnelStatus>;
-      emitMerged();
-    } catch {
-      onError?.();
-    }
-  });
+  const waitToReconnect = () =>
+    new Promise<void>((resolve) => {
+      const onAbort = () => {
+        clearTimeout(timeout);
+        resolve();
+      };
+      const timeout = setTimeout(() => {
+        controller.signal.removeEventListener("abort", onAbort);
+        resolve();
+      }, 1000);
+      controller.signal.addEventListener("abort", onAbort, { once: true });
+    });
 
-  source.onerror = () => {
-    onError?.();
-  };
+  void (async () => {
+    while (!controller.signal.aborted) {
+      const headers = new Headers({ Accept: "text/event-stream" });
+      if (isElectron()) {
+        headers.set("X-Electron-App", "true");
+        const jwt = localStorage.getItem("jwt");
+        if (jwt) headers.set("Authorization", `Bearer ${jwt}`);
+      }
+      try {
+        await streamServerSentEvents(
+          `${baseURL}/tunnel/status/stream`,
+          { credentials: "include", headers, signal: controller.signal },
+          (event) => {
+            if (event.event !== "statuses") return;
+            try {
+              latestLocal = JSON.parse(event.data) as Record<
+                string,
+                TunnelStatus
+              >;
+              emitMerged();
+            } catch {
+              onError?.();
+            }
+          },
+        );
+        if (!controller.signal.aborted) onError?.();
+      } catch (error) {
+        const aborted =
+          controller.signal.aborted ||
+          (error instanceof DOMException && error.name === "AbortError");
+        if (!aborted) onError?.();
+      }
+      if (!controller.signal.aborted) await waitToReconnect();
+    }
+  })();
 
   // Remote tunnel status has no SSE stream exposed to the desktop app yet,
   // so poll it at a modest interval when a remote server is connected.
@@ -108,7 +143,7 @@ export function subscribeTunnelStatuses(
   });
 
   return () => {
-    source.close();
+    controller.abort();
     if (remotePollTimer) clearInterval(remotePollTimer);
   };
 }

--- a/src/ui/tests/api/sse-stream.test.ts
+++ b/src/ui/tests/api/sse-stream.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from "vitest";
+import { streamServerSentEvents } from "@/api/sse-stream";
+
+describe("streamServerSentEvents", () => {
+  it("sends the supplied authentication options and parses split events", async () => {
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode("event: stat"));
+        controller.enqueue(
+          new TextEncoder().encode(
+            'uses\ndata: {"tunnel":{"status":"connected"}}\n\n',
+          ),
+        );
+        controller.close();
+      },
+    });
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response(stream, { status: 200 }));
+    const onEvent = vi.fn();
+    const headers = new Headers({ Authorization: "Bearer token" });
+
+    await streamServerSentEvents(
+      "http://localhost/stream",
+      { credentials: "include", headers },
+      onEvent,
+    );
+
+    expect(fetchMock).toHaveBeenCalledWith("http://localhost/stream", {
+      credentials: "include",
+      headers,
+    });
+    expect(onEvent).toHaveBeenCalledWith({
+      event: "statuses",
+      data: '{"tunnel":{"status":"connected"}}',
+    });
+  });
+
+  it("rejects an unauthorized stream", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(null, { status: 401 }),
+    );
+
+    await expect(
+      streamServerSentEvents("http://localhost/stream", {}, vi.fn()),
+    ).rejects.toThrow("status 401");
+  });
+});


### PR DESCRIPTION
## Summary
- replace native `EventSource` with a fetch-based SSE reader that can send authentication headers
- attach the Electron bearer token and preserve cookie authentication for browser clients
- retain automatic stream reconnection and remote tunnel status merging
- add regression coverage for authenticated requests, chunked SSE parsing, and unauthorized responses

Native `EventSource` cannot attach the `Authorization` header used by standalone Electron sessions. The tunnel status stream therefore returned 401 even though normal Axios tunnel requests succeeded.

## Testing
- `npx vitest run src/ui/tests/api/sse-stream.test.ts`
- `npm run type-check`
- `npx eslint src/ui/api/tunnel-api.ts src/ui/api/sse-stream.ts src/ui/tests/api/sse-stream.test.ts`

Fixes Termix-SSH/Support#1114