### PR TITLE
fix: select quick-created credentials

### DIFF
--- a/src/ui/sidebar/HostEditor.tsx
+++ b/src/ui/sidebar/HostEditor.tsx
@@ -84,6 +84,10 @@ import {
 import { HostStatsTab } from "./HostEditorStatsTab";
 import { VaultProfileManager } from "./VaultProfileManager";
 import { findHostByTunnelEndpoint } from "@/features/tunnel/tunnel-endpoints";
+import {
+  toCredentialOption,
+  type CredentialOption,
+} from "./quick-created-credential";
 
 export function HostEditor({
   host,
@@ -148,6 +152,8 @@ export function HostEditor({
   const [creatingQuickCredential, setCreatingQuickCredential] = useState(false);
   const [showQuickCredentialDialog, setShowQuickCredentialDialog] =
     useState(false);
+  const [quickCreatedCredential, setQuickCreatedCredential] =
+    useState<CredentialOption | null>(null);
   const [savedThemes, setSavedThemes] = useState<SavedCustomTheme[]>([]);
   const [savingTheme, setSavingTheme] = useState(false);
 
@@ -298,7 +304,14 @@ export function HostEditor({
   };
 
   const authMethod = form.authType;
-  const selectedCredential = credentials.find(
+  const availableCredentials =
+    quickCreatedCredential &&
+    !credentials.some(
+      (credential) => credential.id === quickCreatedCredential.id,
+    )
+      ? [...credentials, quickCreatedCredential]
+      : credentials;
+  const selectedCredential = availableCredentials.find(
     (c) => c.id === form.credentialId,
   );
 
@@ -361,11 +374,18 @@ export function HostEditor({
             : null;
       }
 
-      if (adminTargetUserId) {
-        await adminCreateUserCredential(adminTargetUserId, data);
-      } else {
-        await createCredential(data);
-      }
+      const created = adminTargetUserId
+        ? await adminCreateUserCredential(adminTargetUserId, data)
+        : await createCredential(data);
+      const credential = toCredentialOption(created);
+      if (!credential) throw new Error(t("hosts.failedToSaveCredential"));
+
+      setQuickCreatedCredential(credential);
+      setForm((current) => ({
+        ...current,
+        authType: "credential",
+        credentialId: credential.id,
+      }));
       toast.success(t("hosts.credentialCreated"));
       if (!adminTargetUserId) {
         window.dispatchEvent(new CustomEvent("termix:credentials-changed"));
@@ -837,7 +857,7 @@ export function HostEditor({
                               const newId = e.target.value;
                               setField("credentialId", newId);
                               if (!form.overrideCredentialUsername) {
-                                const cred = credentials.find(
+                                const cred = availableCredentials.find(
                                   (c) => c.id === newId,
                                 );
                                 if (cred?.username)
@@ -849,7 +869,7 @@ export function HostEditor({
                             <option value="">
                               {t("hosts.selectACredential")}
                             </option>
-                            {credentials.map((c) => (
+                            {availableCredentials.map((c) => (
                               <option key={c.id} value={c.id}>
                                 {c.username
                                   ? `${c.name} (${c.username})`
@@ -2375,7 +2395,7 @@ export function HostEditor({
               setField={setField}
               setGuacField={setGuacField}
               host={host}
-              credentials={credentials}
+              credentials={availableCredentials}
             />
           )}
 
@@ -2385,7 +2405,7 @@ export function HostEditor({
               setField={setField}
               setGuacField={setGuacField}
               host={host}
-              credentials={credentials}
+              credentials={availableCredentials}
             />
           )}
 
@@ -2395,7 +2415,7 @@ export function HostEditor({
               setField={setField}
               setGuacField={setGuacField}
               host={host}
-              credentials={credentials}
+              credentials={availableCredentials}
             />
           )}
         </div>

--- a/src/ui/sidebar/quick-created-credential.ts
+++ b/src/ui/sidebar/quick-created-credential.ts
@@ -1,0 +1,23 @@
+export interface CredentialOption {
+  id: string;
+  name: string;
+  username: string;
+}
+
+export function toCredentialOption(
+  credential: Record<string, unknown>,
+): CredentialOption | null {
+  if (
+    (typeof credential.id !== "number" && typeof credential.id !== "string") ||
+    typeof credential.name !== "string"
+  ) {
+    return null;
+  }
+
+  return {
+    id: String(credential.id),
+    name: credential.name,
+    username:
+      typeof credential.username === "string" ? credential.username : "",
+  };
+}

--- a/src/ui/tests/sidebar/quick-created-credential.test.ts
+++ b/src/ui/tests/sidebar/quick-created-credential.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { toCredentialOption } from "@/sidebar/quick-created-credential";
+
+describe("toCredentialOption", () => {
+  it("normalizes a newly created credential for immediate selection", () => {
+    expect(
+      toCredentialOption({ id: 42, name: "Production", username: "root" }),
+    ).toEqual({ id: "42", name: "Production", username: "root" });
+  });
+
+  it("rejects a malformed create response", () => {
+    expect(toCredentialOption({ name: "Missing ID" })).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- switch the host authentication method to Credential after quick creation
- immediately select the credential returned by the create endpoint
- keep the new option available while the parent credential list refreshes
- cover normal and malformed create responses

This also works for admin-managed users, where the signed-in user credential refresh event cannot populate the target user's credential list.

## Testing
- `npx vitest run src/ui/tests/sidebar/quick-created-credential.test.ts src/ui/tests/sidebar/HostEditorData.test.ts`
- `npm run type-check`
- `npx eslint src/ui/sidebar/HostEditor.tsx src/ui/sidebar/quick-created-credential.ts src/ui/tests/sidebar/quick-created-credential.test.ts`

Fixes Termix-SSH/Support#1111