### PR TITLE
fix: stagger initial metrics collection

### DIFF
--- a/src/backend/hosts/metrics/index.ts
+++ b/src/backend/hosts/metrics/index.ts
@@ -79,7 +79,9 @@ import {
 } from "./sessions.js";
 import {
   authFailureTracker,
+  canStartInitialMetrics,
   hostPollCache,
+  initialMetricsPollLimiter,
   metricsCache,
   metricsPollLimiter,
   metricsConcurrencyFor,
@@ -195,6 +197,7 @@ class PollingManager {
   /** Skip stacking another status/metrics poll while one is already running. */
   private statusInFlight = new Set<number>();
   private metricsInFlight = new Set<number>();
+  private initialMetricsRequested = new Set<number>();
 
   constructor() {
     this.viewerCleanupInterval = setInterval(() => {
@@ -298,6 +301,54 @@ class PollingManager {
       })
       .finally(() => {
         this.metricsInFlight.delete(host.id);
+      });
+  }
+
+  private scheduleInitialMetricsPoll(
+    host: SSHHostWithCredentials,
+    viewerUserId?: string,
+  ): void {
+    if (
+      this.metricsStore.has(host.id) ||
+      this.initialMetricsRequested.has(host.id)
+    ) {
+      return;
+    }
+
+    this.initialMetricsRequested.add(host.id);
+    void initialMetricsPollLimiter
+      .run(async () => {
+        if (
+          !canStartInitialMetrics(
+            this.statusStore.get(host.id)?.status,
+            this.activeViewers.has(host.id),
+            isTcpPingEnabled(
+              this.pollingConfigs.get(host.id)?.statsConfig ??
+                this.parseStatsConfig(host.statsConfig),
+            ),
+          )
+        ) {
+          return;
+        }
+        if (this.metricsInFlight.has(host.id)) return;
+
+        this.metricsInFlight.add(host.id);
+        try {
+          await metricsPollLimiter.run(() =>
+            this.pollHostMetrics(host, viewerUserId),
+          );
+        } finally {
+          this.metricsInFlight.delete(host.id);
+        }
+      })
+      .catch((err) => {
+        statsLogger.error("Initial metrics polling failed", err, {
+          operation: "initial_metrics_poll_unhandled",
+          hostId: host.id,
+        });
+      })
+      .finally(() => {
+        this.initialMetricsRequested.delete(host.id);
       });
   }
 
@@ -423,6 +474,7 @@ class PollingManager {
       statsConfig,
       viewerUserId,
     };
+    this.pollingConfigs.set(host.id, config);
 
     if (isTcpPingEnabled(statsConfig)) {
       const intervalMs = this.intervalWithJitter(
@@ -448,21 +500,18 @@ class PollingManager {
         host.id,
       );
 
-      // First sample still awaited (gated) so callers can rely on a warm cache.
-      if (!this.metricsInFlight.has(host.id)) {
-        this.metricsInFlight.add(host.id);
-        try {
-          await metricsPollLimiter.run(() =>
-            this.pollHostMetrics(host, viewerUserId),
-          );
-        } catch (err) {
-          statsLogger.error("Metrics polling failed", err, {
-            operation: "metrics_poll_unhandled",
-            hostId: host.id,
-          });
-        } finally {
-          this.metricsInFlight.delete(host.id);
-        }
+      // Viewer registration can arrive for an entire fleet at once. Only
+      // collect the first heavy SSH sample after the cheap status probe has
+      // confirmed the host is reachable; the status completion path below
+      // starts it when the result was not already cached.
+      if (
+        canStartInitialMetrics(
+          this.statusStore.get(host.id)?.status,
+          this.activeViewers.has(host.id),
+          isTcpPingEnabled(statsConfig),
+        )
+      ) {
+        this.scheduleInitialMetricsPoll(host, viewerUserId);
       }
 
       config.metricsTimer = setInterval(() => {
@@ -481,8 +530,6 @@ class PollingManager {
     } else {
       this.metricsStore.delete(host.id);
     }
-
-    this.pollingConfigs.set(host.id, config);
 
     this.syncPollConcurrency();
   }
@@ -530,6 +577,12 @@ class PollingManager {
         lastChecked: new Date().toISOString(),
       };
       this.statusStore.set(refreshedHost.id, statusEntry);
+      if (isOnline && this.activeViewers.has(refreshedHost.id)) {
+        const config = this.pollingConfigs.get(refreshedHost.id);
+        if (config?.statsConfig.metricsEnabled) {
+          this.scheduleInitialMetricsPoll(config.host, config.viewerUserId);
+        }
+      }
       AlertEngine.getInstance()
         .evaluateStatus(refreshedHost.id, isOnline)
         .catch(() => {});

--- a/src/backend/hosts/metrics/state.ts
+++ b/src/backend/hosts/metrics/state.ts
@@ -408,11 +408,14 @@ export const metricsPollLimiter = new ConcurrentLimiter(5);
 export const initialMetricsPollLimiter = new ConcurrentLimiter(2);
 
 export function canStartInitialMetrics(
-  status: "online" | "offline" | undefined,
+  status: HostStatus | undefined,
   hasViewers: boolean,
   statusCheckEnabled = true,
 ): boolean {
-  return hasViewers && (!statusCheckEnabled || status === "online");
+  return (
+    hasViewers &&
+    (!statusCheckEnabled || status === "reachable" || status === "online")
+  );
 }
 export const hostPollCache = new HostPollCache(30_000);
 
@@ -420,3 +423,4 @@ export const requestQueue = new RequestQueue();
 export const metricsCache = new MetricsCache();
 export const authFailureTracker = new AuthFailureTracker();
 export const pollingBackoff = new PollingBackoff();
+import type { HostStatus } from "./host-status.js";

--- a/src/backend/hosts/metrics/state.ts
+++ b/src/backend/hosts/metrics/state.ts
@@ -404,6 +404,16 @@ export class HostPollCache<THost extends { id: number } = { id: number }> {
 export const statusPollLimiter = new ConcurrentLimiter(20);
 /** SSH metrics execs are expensive; keep concurrency tight. */
 export const metricsPollLimiter = new ConcurrentLimiter(5);
+/** Viewer registration is bursty; admit only two first samples at a time. */
+export const initialMetricsPollLimiter = new ConcurrentLimiter(2);
+
+export function canStartInitialMetrics(
+  status: "online" | "offline" | undefined,
+  hasViewers: boolean,
+  statusCheckEnabled = true,
+): boolean {
+  return hasViewers && (!statusCheckEnabled || status === "online");
+}
 export const hostPollCache = new HostPollCache(30_000);
 
 export const requestQueue = new RequestQueue();

--- a/src/backend/tests/hosts/metrics/state.test.ts
+++ b/src/backend/tests/hosts/metrics/state.test.ts
@@ -1,9 +1,20 @@
 import { describe, expect, it, vi } from "vitest";
 import {
+  canStartInitialMetrics,
   ConcurrentLimiter,
   HostPollCache,
   metricsConcurrencyFor,
 } from "../../../hosts/metrics/state.js";
+
+describe("initial metrics admission", () => {
+  it("requires both an active viewer and a confirmed online status", () => {
+    expect(canStartInitialMetrics("online", true)).toBe(true);
+    expect(canStartInitialMetrics("offline", true)).toBe(false);
+    expect(canStartInitialMetrics(undefined, true)).toBe(false);
+    expect(canStartInitialMetrics("online", false)).toBe(false);
+    expect(canStartInitialMetrics(undefined, true, false)).toBe(true);
+  });
+});
 
 describe("ConcurrentLimiter", () => {
   it("never exceeds max concurrent runners", async () => {

--- a/src/backend/tests/hosts/metrics/state.test.ts
+++ b/src/backend/tests/hosts/metrics/state.test.ts
@@ -9,6 +9,7 @@ import {
 describe("initial metrics admission", () => {
   it("requires both an active viewer and a confirmed online status", () => {
     expect(canStartInitialMetrics("online", true)).toBe(true);
+    expect(canStartInitialMetrics("reachable", true)).toBe(true);
     expect(canStartInitialMetrics("offline", true)).toBe(false);
     expect(canStartInitialMetrics(undefined, true)).toBe(false);
     expect(canStartInitialMetrics("online", false)).toBe(false);


### PR DESCRIPTION
## Summary
- cap first-time viewer metrics collection at two concurrent hosts
- require a successful lightweight status probe before the first SSH metrics session
- start the first sample when an unknown host is confirmed online
- preserve metrics collection when TCP status checks are explicitly disabled
- prevent duplicate initial samples while registrations and status probes overlap

Viewer registrations can arrive for an entire fleet at once. Previously each registration immediately queued a full SSH metrics session, allowing the normal recurring-poll concurrency to create a large startup burst. Recurring polling behavior and its configurable concurrency remain unchanged.

## Testing
- `npx vitest run src/backend/tests/hosts/metrics` (99 tests)
- `npm run type-check`
- `npx eslint src/backend/hosts/metrics/index.ts src/backend/hosts/metrics/state.ts src/backend/tests/hosts/metrics/state.test.ts`

Fixes Termix-SSH/Support#1110