### PR TITLE
fix: prompt for RDP domain credentials

### DIFF
--- a/src/backend/hosts/guacamole/rdp-settings.ts
+++ b/src/backend/hosts/guacamole/rdp-settings.ts
@@ -24,3 +24,13 @@ export function buildRdpSettings({
     ...guacdOverrides,
   };
 }
+
+export function resolveRdpDomain(
+  authType: string | null,
+  promptedDomain: unknown,
+  storedDomain: string,
+): string {
+  return authType === "none" && typeof promptedDomain === "string"
+    ? promptedDomain
+    : storedDomain;
+}

--- a/src/backend/hosts/guacamole/routes.ts
+++ b/src/backend/hosts/guacamole/routes.ts
@@ -21,7 +21,7 @@ import {
   getRequestMeta,
 } from "../../utils/audit-logger.js";
 import { resolveJumpTunnelEndpoint } from "./jump-tunnel-endpoint.js";
-import { buildRdpSettings } from "./rdp-settings.js";
+import { buildRdpSettings, resolveRdpDomain } from "./rdp-settings.js";
 
 const router = express.Router();
 const tokenService = GuacamoleTokenService.getInstance();
@@ -473,8 +473,13 @@ router.post(
           username = "";
           password = "";
       }
-      const domain =
+      const storedDomain =
         (host.rdpDomain as string) || (host.domain as string) || "";
+      const domain = resolveRdpDomain(
+        rdpAuthTypeForConnect,
+        req.body?.promptedDomain,
+        storedDomain,
+      );
 
       // Establish SSH tunnel if jump hosts are configured
       let jumpHosts: Array<{ hostId: number }> = [];

--- a/src/backend/tests/hosts/guacamole/rdp-settings.test.ts
+++ b/src/backend/tests/hosts/guacamole/rdp-settings.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { buildRdpSettings } from "../../../hosts/guacamole/rdp-settings.js";
+import {
+  buildRdpSettings,
+  resolveRdpDomain,
+} from "../../../hosts/guacamole/rdp-settings.js";
 
 describe("buildRdpSettings", () => {
   it("keeps saved RDP settings authoritative over stale advanced config", () => {
@@ -37,5 +40,15 @@ describe("buildRdpSettings", () => {
         guacdOverrides: {},
       }).security,
     ).toBe("tls");
+  });
+
+  it("uses the prompted domain for prompt-on-connect authentication", () => {
+    expect(resolveRdpDomain("none", "EXAMPLE", "OLD")).toBe("EXAMPLE");
+    expect(resolveRdpDomain("none", "", "OLD")).toBe("");
+  });
+
+  it("keeps the stored domain for saved authentication", () => {
+    expect(resolveRdpDomain("direct", "EXAMPLE", "SAVED")).toBe("SAVED");
+    expect(resolveRdpDomain("none", undefined, "SAVED")).toBe("SAVED");
   });
 });

--- a/src/ui/api/guacamole-api.ts
+++ b/src/ui/api/guacamole-api.ts
@@ -180,7 +180,11 @@ export async function getGuacamoleToken(
 export async function getGuacamoleTokenFromHost(
   hostId: number,
   protocol?: "rdp" | "vnc" | "telnet",
-  promptedCredentials?: { username?: string; password?: string },
+  promptedCredentials?: {
+    username?: string;
+    password?: string;
+    domain?: string;
+  },
 ): Promise<GuacamoleTokenResponse> {
   try {
     const response = await guacamoleApi().post(
@@ -192,6 +196,9 @@ export async function getGuacamoleTokenFromHost(
           : {}),
         ...(promptedCredentials?.password
           ? { promptedPassword: promptedCredentials.password }
+          : {}),
+        ...(promptedCredentials
+          ? { promptedDomain: promptedCredentials.domain ?? "" }
           : {}),
       },
     );

--- a/src/ui/features/guacamole/GuacamoleApp.tsx
+++ b/src/ui/features/guacamole/GuacamoleApp.tsx
@@ -116,7 +116,7 @@ interface GuacamoleAppInnerProps {
   hostId: number;
   hostConfig: Pick<
     SSHHost,
-    "connectionType" | "guacamoleConfig" | "rdpAuthType"
+    "connectionType" | "domain" | "guacamoleConfig" | "rdpAuthType"
   >;
   hostName: string;
   tabId?: string;
@@ -172,10 +172,12 @@ const GuacamoleAppInner = React.forwardRef<
   const [promptedCredentials, setPromptedCredentials] = useState<{
     username: string;
     password: string;
+    domain: string;
   } | null>(null);
   const [promptOpen, setPromptOpen] = useState(needsCredentialPrompt);
   const [promptUsername, setPromptUsername] = useState("");
   const [promptPassword, setPromptPassword] = useState("");
+  const [promptDomain, setPromptDomain] = useState(hostConfig.domain ?? "");
 
   useImperativeHandle(ref, () => ({
     disconnect: () => displayRef.current?.disconnect(),
@@ -281,13 +283,14 @@ const GuacamoleAppInner = React.forwardRef<
       setPromptedCredentials(null);
       setPromptUsername("");
       setPromptPassword("");
+      setPromptDomain(hostConfig.domain ?? "");
       setPromptOpen(true);
       return;
     }
     clearLogs();
     tokenRetryRef.current.reset();
     tokenRetryRef.current.retryNow();
-  }, [needsCredentialPrompt, clearLogs]);
+  }, [needsCredentialPrompt, hostConfig.domain, clearLogs]);
 
   useEffect(() => {
     if (!tabId) return;
@@ -324,6 +327,7 @@ const GuacamoleAppInner = React.forwardRef<
               setPromptedCredentials({
                 username: promptUsername,
                 password: promptPassword,
+                domain: promptDomain,
               });
               setPromptOpen(false);
             }}
@@ -337,6 +341,16 @@ const GuacamoleAppInner = React.forwardRef<
                 placeholder="Administrator"
                 value={promptUsername}
                 onChange={(e) => setPromptUsername(e.target.value)}
+              />
+            </div>
+            <div className="flex flex-col gap-1.5">
+              <label className="text-xs font-semibold">
+                {t("hosts.guac.domain")}
+              </label>
+              <Input
+                placeholder="WORKGROUP"
+                value={promptDomain}
+                onChange={(e) => setPromptDomain(e.target.value)}
               />
             </div>
             <div className="flex flex-col gap-1.5">

--- a/src/ui/tests/api/guacamole-api.test.ts
+++ b/src/ui/tests/api/guacamole-api.test.ts
@@ -64,6 +64,7 @@ describe("guacamole API origin", () => {
     await getGuacamoleTokenFromHost(9, "rdp", {
       username: "admin",
       password: "secret",
+      domain: "EXAMPLE",
     });
 
     expect(remoteApiMock.post).toHaveBeenCalledWith(
@@ -72,7 +73,25 @@ describe("guacamole API origin", () => {
         protocol: "rdp",
         promptedUsername: "admin",
         promptedPassword: "secret",
+        promptedDomain: "EXAMPLE",
       },
     );
+  });
+
+  it("sends an empty prompted domain for local RDP accounts", async () => {
+    isElectronMock.mockReturnValue(false);
+
+    await getGuacamoleTokenFromHost(9, "rdp", {
+      username: "local-admin",
+      password: "secret",
+      domain: "",
+    });
+
+    expect(authApiMock.post).toHaveBeenCalledWith("/guacamole/connect-host/9", {
+      protocol: "rdp",
+      promptedUsername: "local-admin",
+      promptedPassword: "secret",
+      promptedDomain: "",
+    });
   });
 });


### PR DESCRIPTION
## Summary
- add a Domain/Workgroup field to prompt-on-connect RDP credentials
- forward the prompted domain through the API into guacd settings
- preserve saved-domain behavior for older clients and saved authentication modes

## Tests
- `npx vitest run src/ui/tests/api/guacamole-api.test.ts src/backend/tests/hosts/guacamole/rdp-settings.test.ts src/backend/tests/hosts/guacamole/token-service.test.ts`
- `npm run type-check`
- targeted ESLint and Prettier checks

Fixes Termix-SSH/Support#1131