### PR TITLE
fix: keep host list row sizing stable after deletion

### DIFF
--- a/src/ui/sidebar/tree/SidebarTree.tsx
+++ b/src/ui/sidebar/tree/SidebarTree.tsx
@@ -713,11 +713,11 @@ export function SidebarTree({
     },
   });
 
-  // Fixed heights mean estimateSize already IS the real size, so there is
-  // nothing for measureElement/ResizeObserver to correct -- but the
-  // virtualizer still needs telling when a row's height classification
-  // changes (tray opened/closed, tree reshaped, density/trigger changed),
-  // since it otherwise keeps using the size it last computed for that key.
+  // Fixed heights mean estimateSize already IS the real size. Do not attach
+  // measureElement here: its index-based ResizeObserver measurements can be
+  // reused for a different row after a deletion and override the fixed size.
+  // The virtualizer still needs telling when a row's height classification
+  // changes (tray opened/closed, tree reshaped, density/trigger changed).
   useLayoutEffect(() => {
     virtualizer.measure();
   }, [
@@ -818,8 +818,6 @@ export function SidebarTree({
               return (
                 <div
                   key={vItem.key}
-                  data-index={vItem.index}
-                  ref={virtualizer.measureElement}
                   className="absolute top-0 left-0 w-full"
                   style={{
                     transform: `translateY(${vItem.start}px)`,


### PR DESCRIPTION
## Summary
- keep the host virtualizer on its existing fixed row-height model
- stop ResizeObserver measurements from being reassigned after host deletion
- preserve explicit virtualizer recalculation for tray and preference changes

## Tests
- `npx vitest run src/ui/tests/sidebar/sidebar-tree-visible-rows.test.ts src/ui/tests/sidebar/build-host-tree.test.ts src/ui/tests/sidebar/tree/HostItem/HostItem.test.tsx`
- `npm run type-check`
- targeted ESLint and Prettier checks

Fixes Termix-SSH/Support#1117