### PR TITLE
fix: route status checks by connection origin

### DIFF
--- a/src/backend/hosts/metrics/helpers.ts
+++ b/src/backend/hosts/metrics/helpers.ts
@@ -21,6 +21,18 @@ export function isTcpPingEnabled(statsConfig: TcpPingStatsConfig): boolean {
   return statsConfig.statusCheckEnabled && !statsConfig.disableTcpPing;
 }
 
+export function parseStatusHostIds(value: unknown): Set<number> | null {
+  if (value === undefined) return null;
+  if (typeof value !== "string") return new Set();
+
+  return new Set(
+    value
+      .split(",")
+      .map(Number)
+      .filter((id) => Number.isSafeInteger(id) && id > 0),
+  );
+}
+
 export function tcpPingThroughJumpHost(
   jumpClient: Pick<Client, "forwardOut" | "end">,
   host: string,

--- a/src/backend/hosts/metrics/index.ts
+++ b/src/backend/hosts/metrics/index.ts
@@ -60,6 +60,7 @@ import { createJumpHostChain } from "../jump-host-chain.js";
 import { resolveHostById } from "../host-resolver.js";
 import {
   isTcpPingEnabled,
+  parseStatusHostIds,
   supportsMetrics,
   tcpPingThroughJumpHost,
 } from "./helpers.js";
@@ -799,6 +800,24 @@ class PollingManager {
 
     for (const host of hosts) {
       await this.startPollingForHost(host, { statusOnly: true });
+    }
+  }
+
+  async reconcileStatusPolling(
+    userId: string,
+    allowedHostIds: Set<number>,
+  ): Promise<void> {
+    const hosts = await fetchAllHosts(userId);
+
+    for (const host of hosts) {
+      if (allowedHostIds.has(host.id)) {
+        if (!this.pollingConfigs.has(host.id)) {
+          await this.startPollingForHost(host, { statusOnly: true });
+        }
+        continue;
+      }
+
+      this.stopPollingForHost(host.id, true);
     }
   }
 
@@ -1887,8 +1906,10 @@ app.get("/status", async (req, res) => {
     });
   }
 
-  const statuses = pollingManager.getAllStatuses();
-  if (statuses.size === 0) {
+  const requestedHostIds = parseStatusHostIds(req.query.hostIds);
+  if (requestedHostIds !== null) {
+    await pollingManager.reconcileStatusPolling(userId, requestedHostIds);
+  } else if (pollingManager.getAllStatuses().size === 0) {
     await pollingManager.initializePolling(userId);
   }
 
@@ -1903,7 +1924,10 @@ app.get("/status", async (req, res) => {
 
   const result: Record<number, StatusEntry> = {};
   for (const [id, entry] of entries) {
-    if (allowed.has(id)) {
+    if (
+      allowed.has(id) &&
+      (requestedHostIds === null || requestedHostIds.has(id))
+    ) {
       result[id] = entry;
     }
   }

--- a/src/backend/tests/hosts/metrics/helpers.test.ts
+++ b/src/backend/tests/hosts/metrics/helpers.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, vi } from "vitest";
 import {
   supportsMetrics,
   isTcpPingEnabled,
+  parseStatusHostIds,
   tcpPingThroughJumpHost,
 } from "../../../hosts/metrics/helpers.js";
 import { createConnectionLog } from "../../../hosts/connection-log.js";
@@ -50,6 +51,17 @@ describe("isTcpPingEnabled", () => {
     expect(
       isTcpPingEnabled({ statusCheckEnabled: true, disableTcpPing: true }),
     ).toBe(false);
+  });
+});
+
+describe("parseStatusHostIds", () => {
+  it("distinguishes an unrestricted request from an empty host set", () => {
+    expect(parseStatusHostIds(undefined)).toBeNull();
+    expect(parseStatusHostIds("")).toEqual(new Set());
+  });
+
+  it("keeps only valid positive host IDs", () => {
+    expect(parseStatusHostIds("7,2,7,-1,nope,1.5")).toEqual(new Set([7, 2]));
   });
 });
 

--- a/src/ui/api/host-metrics-status-api.ts
+++ b/src/ui/api/host-metrics-status-api.ts
@@ -4,9 +4,12 @@ import {
   statsApi,
   getRemoteStatsApi,
   isElectron,
+  sshHostApi,
 } from "@/main-axios";
 import type { ServerMetrics, ServerStatus } from "@/main-axios";
 import { getCachedServerStatuses } from "@/lib/hosts-request-cache";
+import { resolveConnectionOrigin } from "@/lib/connection-origin";
+import type { SSHHost } from "@/types/index";
 
 // Metrics collection/viewer registration below (startMetricsPolling,
 // registerMetricsViewer, etc.) is NOT origin-routed: the backend that
@@ -100,6 +103,26 @@ export async function getAllServerStatuses(): Promise<
   return getCachedServerStatuses(async () => {
     let lastError: unknown = null;
     let localStatuses: Record<number, ServerStatus> = {};
+    let localHostIds: number[] | null = null;
+
+    if (isElectron()) {
+      try {
+        const response = await sshHostApi.get<SSHHost[]>("/db/host");
+        const defaultOrigin = await resolveConnectionOrigin({
+          connectionType: "ssh",
+          connectionOrigin: null,
+        });
+        localHostIds = (response.data || [])
+          .filter(
+            (host) => (host.connectionOrigin ?? defaultOrigin) === "local",
+          )
+          .map((host) => host.id);
+      } catch {
+        // A host-list failure must not start local probes for hosts whose
+        // configured origin may be remote.
+        localHostIds = [];
+      }
+    }
 
     for (let i = 0; i < STATUS_RETRY_SCHEDULE.length; i++) {
       const { timeoutMs, pauseAfterMs } = STATUS_RETRY_SCHEDULE[i];
@@ -108,6 +131,9 @@ export async function getAllServerStatuses(): Promise<
       try {
         const response = await statsApi.get("/status", {
           timeout: timeoutMs,
+          ...(localHostIds === null
+            ? {}
+            : { params: { hostIds: localHostIds.join(",") } }),
           // Silence per-attempt interceptor logging & health-monitor side
           // effects on all attempts except the final one, so background
           // blips don't look like real outages.

--- a/src/ui/settings/RemoteSyncPanel.tsx
+++ b/src/ui/settings/RemoteSyncPanel.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/components/dialog.tsx";
 import { RemoteSyncServerPicker } from "./RemoteSyncServerPicker.tsx";
 import { ElectronLoginForm } from "@/auth/ElectronLoginForm.tsx";
+import { invalidateServerStatusCache } from "@/lib/hosts-request-cache.ts";
 
 interface RemoteSyncConfig {
   serverUrl: string;
@@ -109,6 +110,8 @@ export function RemoteSyncPanel({ initialServerUrl }: RemoteSyncPanelProps) {
     const next = { ...desktopSettings, defaultConnectionOrigin: origin };
     setDesktopSettings(next);
     await window.electronAPI?.invoke?.("save-desktop-settings", next);
+    invalidateServerStatusCache();
+    window.dispatchEvent(new CustomEvent("hosts:refresh"));
   };
 
   const isConnected = !!config?.serverUrl;

--- a/src/ui/tests/api/host-metrics-status-api.test.ts
+++ b/src/ui/tests/api/host-metrics-status-api.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const statsApiMock = vi.hoisted(() => ({ get: vi.fn() }));
+const remoteStatsApiMock = vi.hoisted(() => ({ get: vi.fn() }));
+const sshHostApiMock = vi.hoisted(() => ({ get: vi.fn() }));
+const resolveConnectionOriginMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/main-axios", () => ({
+  statsApi: statsApiMock,
+  sshHostApi: sshHostApiMock,
+  getRemoteStatsApi: () => remoteStatsApiMock,
+  isElectron: () => true,
+  handleApiError: vi.fn(),
+}));
+
+vi.mock("@/lib/hosts-request-cache", () => ({
+  getCachedServerStatuses: (loader: () => Promise<unknown>) => loader(),
+}));
+
+vi.mock("@/lib/connection-origin", () => ({
+  resolveConnectionOrigin: resolveConnectionOriginMock,
+}));
+
+import { getAllServerStatuses } from "../../api/host-metrics-status-api";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  window.electronAPI = {
+    invoke: vi.fn(async (channel: string) =>
+      channel === "get-remote-sync-config"
+        ? { serverUrl: "https://termix.example.test" }
+        : null,
+    ),
+  } as unknown as NonNullable<typeof window.electronAPI>;
+  statsApiMock.get.mockResolvedValue({ data: { 1: { status: "online" } } });
+  remoteStatsApiMock.get.mockResolvedValue({
+    data: { 2: { status: "reachable" } },
+  });
+});
+
+describe("status check origin routing", () => {
+  it("only asks the embedded backend to poll local-origin hosts", async () => {
+    sshHostApiMock.get.mockResolvedValue({
+      data: [
+        { id: 1, connectionOrigin: "local" },
+        { id: 2, connectionOrigin: "remote" },
+      ],
+    });
+    resolveConnectionOriginMock.mockImplementation(async (host) =>
+      host.connectionOrigin === "local" ? "local" : "remote",
+    );
+
+    await expect(getAllServerStatuses()).resolves.toEqual({
+      1: { status: "online" },
+      2: { status: "reachable" },
+    });
+
+    expect(statsApiMock.get).toHaveBeenCalledWith("/status", {
+      timeout: 2000,
+      params: { hostIds: "1" },
+      __silentRetry: true,
+    });
+  });
+
+  it("sends an empty allowlist when every host uses the remote server", async () => {
+    sshHostApiMock.get.mockResolvedValue({
+      data: [{ id: 2, connectionOrigin: "remote" }],
+    });
+    resolveConnectionOriginMock.mockResolvedValue("remote");
+
+    await getAllServerStatuses();
+
+    expect(statsApiMock.get).toHaveBeenCalledWith("/status", {
+      timeout: 2000,
+      params: { hostIds: "" },
+      __silentRetry: true,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- resolve the desktop-wide and per-host connection origin before polling statuses
- allow the embedded status backend to poll only local-origin host IDs
- stop existing local polling timers when hosts move to the remote origin
- refresh status routing immediately when the desktop default changes

## Tests
- `npx vitest run src/ui/tests/api/host-metrics-status-api.test.ts src/backend/tests/hosts/metrics/helpers.test.ts src/ui/tests/lib/connection-origin.test.ts src/backend/tests/hosts/metrics/state.test.ts src/ui/tests/settings/remote-sync-state.test.ts`
- `npm run type-check`
- targeted ESLint and Prettier checks

Fixes Termix-SSH/Support#1108