### PR TITLE
fix: restore desktop Tailscale configuration

### DIFF
--- a/src/backend/database/routes/tailscale-routes.ts
+++ b/src/backend/database/routes/tailscale-routes.ts
@@ -1,7 +1,7 @@
 import { Router } from "express";
 import type { RequestHandler, Router as ExpressRouter } from "express";
 import { apiLogger } from "../../utils/logger.js";
-import { getProxyAgent } from "../../utils/proxy-agent.js";
+import { getFetchDispatcher } from "../../utils/proxy-agent.js";
 import { createCurrentSettingsRepository } from "../repositories/factory.js";
 
 interface TailscaleDevice {
@@ -76,7 +76,7 @@ export function registerTailscaleRoutes(
           Authorization: `Bearer ${apiKey}`,
           "User-Agent": "Termix/1.0",
         },
-        dispatcher: getProxyAgent(url),
+        dispatcher: getFetchDispatcher(url),
       });
 
       if (!response.ok) {
@@ -85,13 +85,17 @@ export function registerTailscaleRoutes(
           status: response.status,
         });
         if (response.status === 401 || response.status === 403) {
-          return res
-            .status(401)
-            .json({ error: "Invalid Tailscale API key", devices: [] });
+          return res.status(401).json({
+            error: "Invalid Tailscale API key",
+            devices: [],
+            hasApiKey: true,
+          });
         }
-        return res
-          .status(502)
-          .json({ error: "Tailscale API error", devices: [] });
+        return res.status(502).json({
+          error: "Tailscale API error",
+          devices: [],
+          hasApiKey: true,
+        });
       }
 
       const data = (await response.json()) as { devices: TailscaleAPIDevice[] };
@@ -110,9 +114,11 @@ export function registerTailscaleRoutes(
       apiLogger.error("Failed to fetch Tailscale devices", err, {
         operation: "tailscale_devices",
       });
-      res
-        .status(500)
-        .json({ error: "Failed to fetch Tailscale devices", devices: [] });
+      res.status(500).json({
+        error: "Failed to fetch Tailscale devices",
+        devices: [],
+        hasApiKey: true,
+      });
     }
   });
 

--- a/src/backend/utils/proxy-agent.ts
+++ b/src/backend/utils/proxy-agent.ts
@@ -1,5 +1,12 @@
-import { ProxyAgent } from "undici";
+import { Agent, ProxyAgent } from "undici";
 import type { Dispatcher } from "undici-types";
+
+const directAgent = new Agent({
+  connect: {
+    autoSelectFamily: true,
+    autoSelectFamilyAttemptTimeout: 250,
+  },
+});
 
 export function getProxyAgent(targetUrl?: string): Dispatcher | undefined {
   const proxyUrl =
@@ -27,4 +34,8 @@ export function getProxyAgent(targetUrl?: string): Dispatcher | undefined {
   }
 
   return new ProxyAgent(proxyUrl) as unknown as Dispatcher;
+}
+
+export function getFetchDispatcher(targetUrl: string): Dispatcher {
+  return getProxyAgent(targetUrl) ?? (directAgent as unknown as Dispatcher);
 }

--- a/src/ui/AppShell.tsx
+++ b/src/ui/AppShell.tsx
@@ -236,13 +236,9 @@ export function AppShell({
   const [hostsLoading, setHostsLoading] = useState(true);
   const [allHosts, setAllHosts] = useState<Host[]>([]);
   const [isAdmin, setIsAdmin] = useState(false);
-  // Remote sync is not yet configurable (added in a later phase), so this
-  // is always false for now -- admin/user-management UI stays hidden until
-  // the desktop app is connected to a remote Termix server, since a
-  // standalone local install has exactly one implicit user and nothing to
-  // administer.
-  const [isRemoteSyncConnected] = useState(false);
-  const showMultiUserUI = isAdmin && (!isElectron() || isRemoteSyncConnected);
+  // The standalone desktop backend still owns system settings such as the
+  // Tailscale API key, even though it has only one implicit user.
+  const showAdminUI = isAdmin;
   const [userId, setUserId] = useState<string | null>(null);
   const [showDonationModal, setShowDonationModal] = useState(false);
   const [showOnboarding, setShowOnboarding] = useState(false);
@@ -2095,7 +2091,7 @@ export function AppShell({
           </div>
         )}
 
-        {railView === "admin-settings" && showMultiUserUI && (
+        {railView === "admin-settings" && showAdminUI && (
           <div className="flex flex-col flex-1 min-h-0 overflow-y-auto">
             <AdminSettingsPanel
               onEditingChange={setSidebarEditing}
@@ -2209,7 +2205,7 @@ export function AppShell({
               sidebarOpen={sidebarOpen}
               splitMode={splitMode}
               username={username}
-              isAdmin={showMultiUserUI}
+              isAdmin={showAdminUI}
               onRailClick={handleRailClick}
               onOpenTab={openSingletonTab}
               onLogout={onLogout}

--- a/src/ui/api/settings-api.ts
+++ b/src/ui/api/settings-api.ts
@@ -1,3 +1,4 @@
+import axios from "axios";
 import { authApi, handleApiError, statsApi } from "@/main-axios";
 
 // GLOBAL MONITORING SETTINGS
@@ -112,12 +113,29 @@ export async function getTailscaleDevices(): Promise<{
     lastSeen: string;
   }>;
   hasApiKey: boolean;
+  error?: string;
 }> {
   try {
     const response = await authApi.get("/tailscale/devices");
     return response.data;
   } catch (error) {
+    if (axios.isAxiosError(error)) {
+      const data = error.response?.data;
+      if (
+        data &&
+        typeof data === "object" &&
+        "hasApiKey" in data &&
+        typeof data.hasApiKey === "boolean"
+      ) {
+        return data as {
+          devices: [];
+          hasApiKey: boolean;
+          error?: string;
+        };
+      }
+    }
     handleApiError(error, "fetch Tailscale devices");
+    throw error;
   }
 }
 

--- a/src/ui/locales/en.json
+++ b/src/ui/locales/en.json
@@ -857,6 +857,7 @@
     "tailscaleNoApiKey": "No Tailscale API key configured. Add one in Admin Settings to enable device discovery.",
     "tailscaleDocsLink": "View docs",
     "tailscaleLoadingDevices": "Loading devices...",
+    "tailscaleDeviceLoadFailed": "Failed to load Tailscale devices. Check the API URL and network connection.",
     "tailscaleNoDevices": "No devices found in your tailnet.",
     "tailscaleDeviceAutoFill": "Selecting a device will auto-fill the host IP address.",
     "forceKeyboardInteractiveLabel": "Force Keyboard Interactive",

--- a/src/ui/sidebar/HostEditor.tsx
+++ b/src/ui/sidebar/HostEditor.tsx
@@ -144,6 +144,7 @@ export function HostEditor({
   >([]);
   const [tailscaleHasApiKey, setTailscaleHasApiKey] = useState(false);
   const [tailscaleLoading, setTailscaleLoading] = useState(false);
+  const [tailscaleDeviceError, setTailscaleDeviceError] = useState(false);
   const [connectingTunnel, setConnectingTunnel] = useState<number | null>(null);
   const [isOidcUser, setIsOidcUser] = useState(false);
   const [vaultProfiles, setVaultProfiles] = useState<VaultProfile[]>([]);
@@ -267,12 +268,14 @@ export function HostEditor({
   useEffect(() => {
     if (form.authType !== "tailscale") return;
     setTailscaleLoading(true);
+    setTailscaleDeviceError(false);
     getTailscaleDevices()
       .then((res) => {
         setTailscaleDevices(res?.devices ?? []);
         setTailscaleHasApiKey(res?.hasApiKey ?? false);
+        setTailscaleDeviceError(!!res?.error);
       })
-      .catch(() => {})
+      .catch(() => setTailscaleDeviceError(true))
       .finally(() => setTailscaleLoading(false));
   }, [form.authType]);
 
@@ -965,13 +968,17 @@ export function HostEditor({
                           {t("hosts.tailscaleDocsLink")}
                         </a>
                       </div>
-                      {!tailscaleHasApiKey && !tailscaleLoading ? (
-                        <p className="text-[10px] text-muted-foreground">
-                          {t("hosts.tailscaleNoApiKey")}
-                        </p>
-                      ) : tailscaleLoading ? (
+                      {tailscaleLoading ? (
                         <p className="text-[10px] text-muted-foreground">
                           {t("hosts.tailscaleLoadingDevices")}
+                        </p>
+                      ) : tailscaleDeviceError ? (
+                        <p className="text-[10px] text-destructive">
+                          {t("hosts.tailscaleDeviceLoadFailed")}
+                        </p>
+                      ) : !tailscaleHasApiKey ? (
+                        <p className="text-[10px] text-muted-foreground">
+                          {t("hosts.tailscaleNoApiKey")}
                         </p>
                       ) : tailscaleDevices.length === 0 ? (
                         <p className="text-[10px] text-muted-foreground">

--- a/src/ui/tests/api/tailscale-settings-api.test.ts
+++ b/src/ui/tests/api/tailscale-settings-api.test.ts
@@ -1,0 +1,49 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const authApiMock = vi.hoisted(() => ({ get: vi.fn(), patch: vi.fn() }));
+const handleApiErrorMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/main-axios", () => ({
+  authApi: authApiMock,
+  statsApi: { get: vi.fn(), patch: vi.fn() },
+  handleApiError: handleApiErrorMock,
+}));
+
+import { getTailscaleDevices } from "../../api/settings-api";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("getTailscaleDevices", () => {
+  it("preserves configured-key state when discovery fails", async () => {
+    authApiMock.get.mockRejectedValue({
+      isAxiosError: true,
+      response: {
+        data: {
+          devices: [],
+          hasApiKey: true,
+          error: "Failed to fetch Tailscale devices",
+        },
+      },
+    });
+
+    await expect(getTailscaleDevices()).resolves.toEqual({
+      devices: [],
+      hasApiKey: true,
+      error: "Failed to fetch Tailscale devices",
+    });
+    expect(handleApiErrorMock).not.toHaveBeenCalled();
+  });
+
+  it("uses normal API error handling when no structured state is available", async () => {
+    const error = { isAxiosError: true, response: { data: {} } };
+    authApiMock.get.mockRejectedValue(error);
+
+    await expect(getTailscaleDevices()).rejects.toBe(error);
+    expect(handleApiErrorMock).toHaveBeenCalledWith(
+      error,
+      "fetch Tailscale devices",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- expose Admin Settings to standalone desktop administrators so they can manage the Tailscale API key
- preserve configured-key state when upstream device discovery fails
- show a distinct discovery/network error instead of claiming the key is missing
- use Undici dual-stack address selection for direct Tailscale API requests while preserving proxy precedence

## Tests
- `npx vitest run src/ui/tests/api/tailscale-settings-api.test.ts src/ui/tests/sidebar/HostEditorData.test.ts`
- `npm run type-check`
- targeted ESLint and Prettier checks

Fixes Termix-SSH/Support#1106