### PR TITLE
Fix RDP toolbar Windows key mapping

### DIFF
--- a/src/ui/features/guacamole/GuacamoleToolbar.tsx
+++ b/src/ui/features/guacamole/GuacamoleToolbar.tsx
@@ -44,7 +44,7 @@ const MODIFIER_KEYSYMS = {
   ctrl: 0xffe3,
   alt: 0xffe9,
   shift: 0xffe1,
-  win: 0xff67,
+  win: 0xffeb,
 } as const;
 
 const FKEY_KEYSYMS = Array.from({ length: 12 }, (_, i) => 0xffbe + i);
@@ -362,13 +362,13 @@ export const GuacamoleToolbar: React.FC<GuacamoleToolbarProps> = ({
                 </TipBtn>
                 <TipBtn
                   tooltip={t("guacamole.toolbar.winL")}
-                  onClick={() => sendCombo(0xff67, 0x006c)}
+                  onClick={() => sendCombo(MODIFIER_KEYSYMS.win, 0x006c)}
                 >
                   Win+L
                 </TipBtn>
                 <TipBtn
                   tooltip={t("guacamole.toolbar.winKey")}
-                  onClick={() => sendCombo(0xff67)}
+                  onClick={() => sendCombo(MODIFIER_KEYSYMS.win)}
                 >
                   Win
                 </TipBtn>

--- a/src/ui/tests/features/guacamole/GuacamoleToolbar.test.tsx
+++ b/src/ui/tests/features/guacamole/GuacamoleToolbar.test.tsx
@@ -1,0 +1,47 @@
+import React from "react";
+import { fireEvent, render } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { GuacamoleToolbar } from "../../../features/guacamole/GuacamoleToolbar.js";
+import type { GuacamoleDisplayHandle } from "../../../features/guacamole/GuacamoleDisplay.js";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+describe("GuacamoleToolbar Windows key", () => {
+  it("sends Super_L for Win shortcuts and the sticky modifier", () => {
+    const sendKey = vi.fn();
+    const displayRef = {
+      current: {
+        disconnect: vi.fn(),
+        isConnected: () => true,
+        sendKey,
+        sendMouse: vi.fn(),
+        setClipboard: vi.fn(),
+        getFilesystem: () => null,
+      } satisfies GuacamoleDisplayHandle,
+    } as React.RefObject<GuacamoleDisplayHandle>;
+    const { getByText } = render(
+      <GuacamoleToolbar displayRef={displayRef} protocol="rdp" />,
+    );
+
+    fireEvent.click(getByText("Win+L"));
+    expect(sendKey.mock.calls).toEqual([
+      [0xffeb, true],
+      [0x006c, true],
+      [0x006c, false],
+      [0xffeb, false],
+    ]);
+
+    sendKey.mockClear();
+    fireEvent.click(getByText("Win"));
+    expect(sendKey.mock.calls).toEqual([
+      [0xffeb, true],
+      [0xffeb, false],
+    ]);
+
+    sendKey.mockClear();
+    fireEvent.click(getByText("guacamole.toolbar.win"));
+    expect(sendKey).toHaveBeenCalledWith(0xffeb, true);
+  });
+});


### PR DESCRIPTION
## Summary
- send the X11 `Super_L` keysym for toolbar Windows-key actions
- share the Windows modifier mapping across Win, Win+L, and sticky Win controls
- add regression coverage for all three event sequences

## Testing
- `npx vitest run src/ui/tests/features/guacamole/GuacamoleToolbar.test.tsx`
- `npm run type-check`
- `npx eslint src/ui/features/guacamole/GuacamoleToolbar.tsx src/ui/tests/features/guacamole/GuacamoleToolbar.test.tsx`
- `git diff --check`

Fixes Termix-SSH/Support#1105