### PR TITLE
fix: restore Node 24 for Docker SSH performance

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Install dependencies
-FROM node:26-slim AS deps
+FROM node:24-slim AS deps
 WORKDIR /app
 
 RUN apt-get update && apt-get install -y python3 make g++ && rm -rf /var/lib/apt/lists/*
@@ -36,7 +36,7 @@ RUN npm rebuild better-sqlite3
 RUN npm run build:backend
 
 # Stage 4: Production dependencies only
-FROM node:26-slim AS production-deps
+FROM node:24-slim AS production-deps
 WORKDIR /app
 
 RUN apt-get update && apt-get install -y python3 make g++ && rm -rf /var/lib/apt/lists/*
@@ -53,7 +53,7 @@ RUN npm ci --omit=dev --ignore-scripts && \
     npm cache clean --force
 
 # Stage 5: Final optimized image
-FROM node:26-slim
+FROM node:24-slim
 WORKDIR /app
 
 ENV DATA_DIR=/app/data \


### PR DESCRIPTION
## Summary
- use `node:24-slim` for all Docker build and runtime stages
- restore compatibility with the native crypto addon in `ssh2@1.17.0`
- keep Docker aligned with the repository Node 24 baseline

## Testing
- `npm run build`
- `npm rebuild ssh2` produces `lib/protocol/crypto/build/Release/sshcrypto.node` on a supported Node version
- verified all three Docker stages use `node:24-slim`
- `git diff --check`

Docker image build was not run locally because the Docker daemon was unavailable.

Fixes Termix-SSH/Support#1104