### PR TITLE
fix: normalize OIDC discovery issuer URLs

### DIFF
--- a/src/backend/database/routes/user-oidc-utils.ts
+++ b/src/backend/database/routes/user-oidc-utils.ts
@@ -23,7 +23,10 @@ export class OIDCTokenFormatError extends Error {
 }
 
 function normalizeIssuer(url: string): string {
-  return url.trim().replace(/\/+$/, "");
+  return url
+    .trim()
+    .replace(/\/+$/, "")
+    .replace(/\/\.well-known\/openid-configuration$/, "");
 }
 
 export type OIDCConfig = {
@@ -276,14 +279,12 @@ export async function verifyOIDCToken(
   }
 
   const fetchOptions = buildFetchOptions(caCert);
-  const normalizedIssuerUrl = issuerUrl.endsWith("/")
-    ? issuerUrl.slice(0, -1)
-    : issuerUrl;
+  const configuredIssuerUrl = issuerUrl.trim().replace(/\/+$/, "");
+  const normalizedIssuerUrl = normalizeIssuer(issuerUrl);
   const possibleIssuers = [
-    issuerUrl,
     normalizedIssuerUrl,
-    issuerUrl.replace(/\/application\/o\/[^/]+$/, ""),
     normalizedIssuerUrl.replace(/\/application\/o\/[^/]+$/, ""),
+    ...(configuredIssuerUrl === normalizedIssuerUrl ? [issuerUrl] : []),
   ];
 
   const jwksUrls = [

--- a/src/backend/tests/database/routes/user-oidc-utils.test.ts
+++ b/src/backend/tests/database/routes/user-oidc-utils.test.ts
@@ -127,6 +127,46 @@ describe("verifyOIDCToken JWKS diagnostics", () => {
 });
 
 describe("verifyOIDCToken", () => {
+  it("accepts a discovery document URL as the configured issuer", async () => {
+    const { exportJWK, generateKeyPair, SignJWT } = await import("jose");
+    const { publicKey, privateKey } = await generateKeyPair("RS256");
+    const jwk = await exportJWK(publicKey);
+    jwk.kid = "google-key";
+
+    const issuer = "https://accounts.google.com";
+    const clientId = "termix-client";
+    const token = await new SignJWT({ sub: "user-1" })
+      .setProtectedHeader({ alg: "RS256", kid: jwk.kid })
+      .setIssuer(issuer)
+      .setAudience(clientId)
+      .setExpirationTime("5m")
+      .sign(privateKey);
+
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ jwks_uri: `${issuer}/keys` }), {
+          status: 200,
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ keys: [jwk] }), { status: 200 }),
+      );
+
+    const payload = await verifyOIDCToken(
+      token,
+      `${issuer}/.well-known/openid-configuration`,
+      clientId,
+    );
+
+    expect(payload.sub).toBe("user-1");
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      `${issuer}/.well-known/openid-configuration`,
+      {},
+    );
+  });
+
   it("uses the protected-header algorithm when the provider JWK omits alg", async () => {
     const { exportJWK, generateKeyPair, SignJWT } = await import("jose");
     const { publicKey, privateKey } = await generateKeyPair("RS256");


### PR DESCRIPTION
## Summary
- accept issuer settings that point at the standard OIDC discovery document
- derive discovery and JWKS endpoints from the canonical issuer URL
- verify tokens against the canonical issuer instead of the discovery document URL
- reuse the same normalization for provider lookup and back-channel logout routing

## Testing
- `npx vitest run src/backend/tests/database/routes/user-oidc-utils.test.ts`
- `npm run type-check`
- targeted ESLint and Prettier checks
- `git diff --check`

Fixes Termix-SSH/Support#1124