### PR TITLE
feat: add trusted reverse-proxy authentication

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -12,6 +12,13 @@ services:
       GUACD_HOST: "guacd"
       GUACD_TUNNEL_HOST: "termix"
       GUACD_RECORDING_PATH: "/termix-data/session_recordings/guacamole"
+      # Trusted reverse-proxy authentication is disabled by default. When
+      # enabled, do not expose this container directly to untrusted clients.
+      # TRUSTED_PROXY_AUTH_ENABLED: "true"
+      # TRUSTED_PROXY_AUTH_TRUSTED_PROXIES: "172.16.0.0/12"
+      # TRUSTED_PROXY_AUTH_ROLE_MAP: '{"operators":["user"]}'
+      # TRUSTED_PROXY_AUTH_USERNAME_HEADER: "x-forwarded-username"
+      # TRUSTED_PROXY_AUTH_ROLE_HEADER: "x-forwarded-role"
     depends_on:
       - guacd
     networks:

--- a/src/backend/database/routes/sso-provider-routes.ts
+++ b/src/backend/database/routes/sso-provider-routes.ts
@@ -12,6 +12,11 @@ import {
   decryptSsoConfigSecrets,
   encryptSsoConfigSecrets,
 } from "../../utils/system-secret-crypto.js";
+import { isTrustedProxyAuthEnabled } from "../../utils/trusted-proxy-auth.js";
+
+function isOidcLike(type: SSOProviderType): boolean {
+  return type === "oidc" || type === "github" || type === "google";
+}
 
 const authManager = AuthManager.getInstance();
 
@@ -188,6 +193,12 @@ export function registerSSOProviderRoutes(router: Router): void {
       if (!validTypes.includes(type)) {
         return res.status(400).json({ error: "Invalid provider type" });
       }
+      if (isTrustedProxyAuthEnabled() && enabled && isOidcLike(type)) {
+        return res.status(409).json({
+          error:
+            "OIDC providers cannot be enabled with trusted proxy authentication",
+        });
+      }
 
       const configWithDefaults =
         type === "github" || type === "google"
@@ -316,6 +327,19 @@ export function registerSSOProviderRoutes(router: Router): void {
         displayOrder?: number;
         config?: Record<string, unknown>;
       };
+
+      const effectiveType = type ?? (existing.type as SSOProviderType);
+      const effectiveEnabled = enabled ?? existing.enabled;
+      if (
+        isTrustedProxyAuthEnabled() &&
+        effectiveEnabled &&
+        isOidcLike(effectiveType)
+      ) {
+        return res.status(409).json({
+          error:
+            "OIDC providers cannot be enabled with trusted proxy authentication",
+        });
+      }
 
       let encryptedConfig = existing.config;
       if (rawConfig !== undefined) {

--- a/src/backend/database/routes/user-totp-routes.ts
+++ b/src/backend/database/routes/user-totp-routes.ts
@@ -9,6 +9,7 @@ import { FieldCrypto } from "../../utils/field-crypto.js";
 import { LazyFieldEncryption } from "../../utils/lazy-field-encryption.js";
 import { authLogger } from "../../utils/logger.js";
 import { loginRateLimiter } from "../../utils/login-rate-limiter.js";
+import { isTrustedProxyAuthEnabled } from "../../utils/trusted-proxy-auth.js";
 import {
   generateDeviceFingerprint,
   getDeviceId,
@@ -183,6 +184,11 @@ export function registerUserTotpRoutes(
    *         description: Failed to enable TOTP.
    */
   router.post("/totp/enable", authenticateJWT, async (req, res) => {
+    if (isTrustedProxyAuthEnabled()) {
+      return res.status(409).json({
+        error: "TOTP is disabled while trusted proxy authentication is enabled",
+      });
+    }
     const userId = (req as AuthenticatedRequest).userId;
     const sessionId = (req as AuthenticatedRequest).sessionId;
     const { totp_code } = req.body;

--- a/src/backend/database/routes/users.ts
+++ b/src/backend/database/routes/users.ts
@@ -58,13 +58,29 @@ import {
   createCurrentSettingsRepository,
   getCurrentSettingValue,
   createCurrentRoleRepository,
+  createCurrentSsoProviderRepository,
   createCurrentUserRepository,
 } from "../repositories/factory.js";
 import type { UserRecord } from "../repositories/user-repository.js";
+import {
+  getTrustedProxyAuthConfig,
+  isTrustedProxyAddress,
+  isTrustedProxyAuthEnabled,
+  resolveTrustedProxyRoles,
+} from "../../utils/trusted-proxy-auth.js";
 
 const authManager = AuthManager.getInstance();
 
 const router = express.Router();
+
+router.use((req, res, next) => {
+  if (isTrustedProxyAuthEnabled() && req.path.startsWith("/oidc")) {
+    return res.status(409).json({
+      error: "OIDC is disabled while trusted proxy authentication is enabled",
+    });
+  }
+  next();
+});
 
 async function syncSharedCredentialsForUserRoles(
   userId: string,
@@ -1558,7 +1574,179 @@ router.get("/oidc/callback", async (req, res) => {
  *       500:
  *         description: Login failed.
  */
+router.post("/proxy-login", async (req, res) => {
+  let config;
+  try {
+    config = getTrustedProxyAuthConfig();
+  } catch (error) {
+    authLogger.error(
+      "Invalid trusted proxy authentication configuration",
+      error,
+    );
+    return res
+      .status(503)
+      .json({ error: "Proxy authentication is misconfigured" });
+  }
+  if (!config.enabled) return res.json({ enabled: false });
+
+  const sourceAddress = req.socket.remoteAddress;
+  try {
+    if (!isTrustedProxyAddress(sourceAddress, config.trustedProxies)) {
+      authLogger.warn(
+        "Rejected proxy authentication from an untrusted source",
+        {
+          operation: "trusted_proxy_auth_rejected",
+          sourceAddress,
+        },
+      );
+      return res.status(403).json({ error: "Untrusted authentication proxy" });
+    }
+  } catch (error) {
+    authLogger.error("Invalid trusted proxy allowlist", error);
+    return res
+      .status(503)
+      .json({ error: "Proxy authentication is misconfigured" });
+  }
+
+  const usernameValue = req.headers[config.usernameHeader];
+  const roleValue = req.headers[config.roleHeader];
+  const username = Array.isArray(usernameValue)
+    ? usernameValue[0]
+    : usernameValue;
+  const roleHeader = Array.isArray(roleValue) ? roleValue[0] : roleValue;
+  if (!isNonEmptyString(username) || !isNonEmptyString(roleHeader)) {
+    return res
+      .status(401)
+      .json({ error: "Proxy authentication headers are missing" });
+  }
+
+  const mappedRoles = resolveTrustedProxyRoles(roleHeader, config.roleMap);
+  if (!mappedRoles) {
+    return res.status(403).json({ error: "Proxy role is not mapped" });
+  }
+
+  try {
+    const [legacyOidc, enabledProviders, userRecord] = await Promise.all([
+      createCurrentSettingsRepository().get("oidc_config"),
+      createCurrentSsoProviderRepository().listEnabled(),
+      createCurrentUserRepository().findByUsername(username),
+    ]);
+    const hasOidc =
+      Boolean(getOIDCConfigFromEnv() || legacyOidc) ||
+      enabledProviders.some((provider) =>
+        ["oidc", "github", "google"].includes(provider.type),
+      );
+    if (hasOidc) {
+      return res
+        .status(409)
+        .json({ error: "Proxy authentication cannot be used with OIDC" });
+    }
+    if (!userRecord) {
+      return res.status(403).json({ error: "Proxy user must already exist" });
+    }
+    if (userRecord.isOidc || userRecord.totpEnabled) {
+      return res.status(409).json({
+        error: "Proxy authentication cannot be used with OIDC or TOTP users",
+      });
+    }
+
+    const roleRepository = createCurrentRoleRepository();
+    const managedRoles = new Set([...config.roleMap.values()].flat());
+    for (const roleName of managedRoles) {
+      if (!(await roleRepository.findRoleByName(roleName))) {
+        authLogger.error("Trusted proxy role map references a missing role", {
+          operation: "trusted_proxy_auth_missing_role",
+          roleName,
+        });
+        return res
+          .status(503)
+          .json({ error: "Proxy role mapping is misconfigured" });
+      }
+    }
+
+    const currentRoles = await roleRepository.listUserRoles(userRecord.id);
+    const currentNames = new Set(currentRoles.map((role) => role.roleName));
+    for (const roleName of mappedRoles) {
+      if (!currentNames.has(roleName)) {
+        await roleRepository.assignRoleNameToUser({
+          userId: userRecord.id,
+          roleName,
+          grantedBy: userRecord.id,
+        });
+      }
+    }
+    for (const role of currentRoles) {
+      if (
+        managedRoles.has(role.roleName) &&
+        !mappedRoles.includes(role.roleName)
+      ) {
+        await roleRepository.removeRoleFromUser(userRecord.id, role.roleId);
+      }
+    }
+    PermissionManager.getInstance().invalidateUserPermissionCache(
+      userRecord.id,
+    );
+
+    const deviceInfo = parseUserAgent(req);
+    if (
+      !(await authManager.authenticateWebAuthnUser(
+        userRecord.id,
+        deviceInfo.type,
+      ))
+    ) {
+      return res
+        .status(409)
+        .json({ error: "User encryption data is unavailable" });
+    }
+    await syncSharedCredentialsForUserRoles(
+      userRecord.id,
+      "trusted_proxy_login_role_shared_credentials",
+    );
+    const token = await authManager.generateJWTToken(userRecord.id, {
+      deviceType: deviceInfo.type,
+      deviceInfo: deviceInfo.deviceInfo,
+    });
+    const payload = await authManager.verifyJWTToken(token);
+    const { ipAddress, userAgent } = getRequestMeta(req);
+    await logAudit({
+      userId: userRecord.id,
+      username: userRecord.username,
+      action: "trusted_proxy_login",
+      resourceType: "session",
+      ipAddress,
+      userAgent,
+      success: true,
+    });
+    authLogger.success("Trusted proxy login successful", {
+      operation: "trusted_proxy_login",
+      userId: userRecord.id,
+      sessionId: payload?.sessionId,
+      mappedRoles,
+    });
+
+    return res
+      .cookie("jwt", token, authManager.getSecureCookieOptions(req))
+      .json({
+        enabled: true,
+        success: true,
+        username: userRecord.username,
+        userId: userRecord.id,
+        is_admin: !!userRecord.isAdmin,
+        ...(isNativeAppRequest(req) ? { token } : {}),
+      });
+  } catch (error) {
+    authLogger.error("Trusted proxy login failed", error);
+    return res.status(500).json({ error: "Proxy authentication failed" });
+  }
+});
+
 router.post("/login", async (req, res) => {
+  if (isTrustedProxyAuthEnabled()) {
+    return res.status(403).json({
+      error:
+        "Password login is disabled while trusted proxy authentication is enabled",
+    });
+  }
   const { username, password, rememberMe } = req.body;
   const clientIp = req.ip || req.socket.remoteAddress || "unknown";
   authLogger.info("User login request received", {

--- a/src/backend/starter.ts
+++ b/src/backend/starter.ts
@@ -14,6 +14,7 @@ import {
   versionLogger,
   setGlobalLogLevel,
 } from "./utils/logger.js";
+import { getTrustedProxyAuthConfig } from "./utils/trusted-proxy-auth.js";
 
 /**
  * host:port from DATABASE_URL for the startup log. Parsed rather than printed
@@ -152,6 +153,8 @@ async function provisionLocalDesktopUserIfNeeded(): Promise<void> {
       version: version,
     });
 
+    const trustedProxyAuth = getTrustedProxyAuthConfig();
+
     const systemCrypto = SystemCrypto.getInstance();
     await systemCrypto.initializeJWTSecret();
     await systemCrypto.initializeDatabaseKey();
@@ -195,6 +198,41 @@ async function provisionLocalDesktopUserIfNeeded(): Promise<void> {
         ? {}
         : { host: describeDatabaseHost() }),
     });
+
+    if (trustedProxyAuth.enabled) {
+      const {
+        createCurrentSettingsRepository,
+        createCurrentSsoProviderRepository,
+        createCurrentUserRepository,
+      } = await import("./database/repositories/factory.js");
+      const [legacyOidc, providers, users] = await Promise.all([
+        createCurrentSettingsRepository().get("oidc_config"),
+        createCurrentSsoProviderRepository().listEnabled(),
+        createCurrentUserRepository().listAll(),
+      ]);
+      const conflictingProvider = providers.some((provider) =>
+        ["oidc", "github", "google"].includes(provider.type),
+      );
+      const conflictingUser = users.some(
+        (user) => user.isOidc || user.totpEnabled,
+      );
+      if (
+        legacyOidc ||
+        process.env.OIDC_CLIENT_ID ||
+        conflictingProvider ||
+        conflictingUser
+      ) {
+        throw new Error(
+          "Trusted proxy authentication cannot start while OIDC or TOTP is enabled",
+        );
+      }
+      systemLogger.info("Trusted proxy authentication enabled", {
+        operation: "trusted_proxy_auth_enabled",
+        usernameHeader: trustedProxyAuth.usernameHeader,
+        roleHeader: trustedProxyAuth.roleHeader,
+        trustedProxyCount: trustedProxyAuth.trustedProxies.length,
+      });
+    }
 
     const { UserKeyManager } = await import("./utils/user-keys.js");
     await UserKeyManager.getInstance().initialize();

--- a/src/backend/tests/utils/trusted-proxy-auth.test.ts
+++ b/src/backend/tests/utils/trusted-proxy-auth.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import {
+  getTrustedProxyAuthConfig,
+  isTrustedProxyAddress,
+  parseTrustedProxyRoleMap,
+  resolveTrustedProxyRoles,
+} from "../../utils/trusted-proxy-auth.js";
+
+describe("trusted proxy authentication config", () => {
+  it("requires an explicit proxy allowlist and role map", () => {
+    expect(() =>
+      getTrustedProxyAuthConfig({ TRUSTED_PROXY_AUTH_ENABLED: "true" }),
+    ).toThrow(/requires/);
+    expect(() =>
+      getTrustedProxyAuthConfig({
+        TRUSTED_PROXY_AUTH_ENABLED: "true",
+        TRUSTED_PROXY_AUTH_TRUSTED_PROXIES: "not-a-cidr",
+        TRUSTED_PROXY_AUTH_ROLE_MAP: '{"operators":"user"}',
+      }),
+    ).toThrow(/Invalid trusted proxy/);
+  });
+
+  it("matches exact addresses, CIDRs, and IPv4-mapped addresses", () => {
+    const trusted = ["10.20.0.0/16", "2001:db8::/32"];
+    expect(isTrustedProxyAddress("10.20.1.4", trusted)).toBe(true);
+    expect(isTrustedProxyAddress("::ffff:10.20.1.4", trusted)).toBe(true);
+    expect(isTrustedProxyAddress("10.21.1.4", trusted)).toBe(false);
+    expect(isTrustedProxyAddress("2001:db8::5", trusted)).toBe(true);
+  });
+
+  it("fails closed when a supplied external role is not mapped", () => {
+    const roleMap = parseTrustedProxyRoleMap(
+      JSON.stringify({ operators: ["operator"], viewers: "readonly" }),
+    );
+    expect(resolveTrustedProxyRoles("operators, viewers", roleMap)).toEqual([
+      "operator",
+      "readonly",
+    ]);
+    expect(resolveTrustedProxyRoles("operators, admins", roleMap)).toBeNull();
+  });
+});

--- a/src/backend/utils/trusted-proxy-auth.ts
+++ b/src/backend/utils/trusted-proxy-auth.ts
@@ -1,0 +1,131 @@
+import { BlockList, isIP } from "node:net";
+
+export interface TrustedProxyAuthConfig {
+  enabled: boolean;
+  usernameHeader: string;
+  roleHeader: string;
+  trustedProxies: string[];
+  roleMap: Map<string, string[]>;
+}
+
+function enabled(value: string | undefined): boolean {
+  return value?.trim().toLowerCase() === "true";
+}
+
+export function parseTrustedProxyRoleMap(
+  value: string | undefined,
+): Map<string, string[]> {
+  if (!value?.trim()) return new Map();
+  const parsed = JSON.parse(value) as Record<string, unknown>;
+  const result = new Map<string, string[]>();
+  for (const [externalRole, mapped] of Object.entries(parsed)) {
+    const roles = (Array.isArray(mapped) ? mapped : [mapped])
+      .filter((role): role is string => typeof role === "string")
+      .map((role) => role.trim())
+      .filter(Boolean);
+    if (externalRole.trim() && roles.length > 0) {
+      result.set(externalRole.trim(), [...new Set(roles)]);
+    }
+  }
+  return result;
+}
+
+export function getTrustedProxyAuthConfig(
+  env: NodeJS.ProcessEnv = process.env,
+): TrustedProxyAuthConfig {
+  const config = {
+    enabled: enabled(env.TRUSTED_PROXY_AUTH_ENABLED),
+    usernameHeader: (
+      env.TRUSTED_PROXY_AUTH_USERNAME_HEADER || "x-forwarded-username"
+    ).toLowerCase(),
+    roleHeader: (
+      env.TRUSTED_PROXY_AUTH_ROLE_HEADER || "x-forwarded-role"
+    ).toLowerCase(),
+    trustedProxies: (env.TRUSTED_PROXY_AUTH_TRUSTED_PROXIES || "")
+      .split(",")
+      .map((entry) => entry.trim())
+      .filter(Boolean),
+    roleMap: parseTrustedProxyRoleMap(env.TRUSTED_PROXY_AUTH_ROLE_MAP),
+  };
+
+  if (
+    config.enabled &&
+    (config.trustedProxies.length === 0 || config.roleMap.size === 0)
+  ) {
+    throw new Error(
+      "Trusted proxy auth requires TRUSTED_PROXY_AUTH_TRUSTED_PROXIES and TRUSTED_PROXY_AUTH_ROLE_MAP",
+    );
+  }
+  if (
+    config.enabled &&
+    (!/^[a-z0-9-]+$/.test(config.usernameHeader) ||
+      !/^[a-z0-9-]+$/.test(config.roleHeader))
+  ) {
+    throw new Error("Trusted proxy auth header names are invalid");
+  }
+  if (config.enabled) {
+    // Build the allowlist during configuration parsing so an invalid CIDR
+    // fails startup rather than surfacing on the first login attempt.
+    isTrustedProxyAddress("127.0.0.1", config.trustedProxies);
+  }
+  return config;
+}
+
+function normalizeAddress(address: string): string {
+  const withoutZone = address.split("%")[0];
+  return withoutZone.startsWith("::ffff:")
+    ? withoutZone.slice("::ffff:".length)
+    : withoutZone;
+}
+
+export function isTrustedProxyAddress(
+  address: string | undefined,
+  trustedProxies: string[],
+): boolean {
+  if (!address) return false;
+  const blockList = new BlockList();
+  for (const entry of trustedProxies) {
+    const [rawAddress, rawPrefix] = entry.split("/");
+    const normalized = normalizeAddress(rawAddress);
+    const family = isIP(normalized);
+    if (!family) throw new Error(`Invalid trusted proxy address: ${entry}`);
+    const type = family === 4 ? "ipv4" : "ipv6";
+    if (rawPrefix === undefined) {
+      blockList.addAddress(normalized, type);
+      continue;
+    }
+    const prefix = Number(rawPrefix);
+    const max = family === 4 ? 32 : 128;
+    if (!Number.isInteger(prefix) || prefix < 0 || prefix > max) {
+      throw new Error(`Invalid trusted proxy CIDR: ${entry}`);
+    }
+    blockList.addSubnet(normalized, prefix, type);
+  }
+  const normalized = normalizeAddress(address);
+  const family = isIP(normalized);
+  return (
+    family !== 0 && blockList.check(normalized, family === 4 ? "ipv4" : "ipv6")
+  );
+}
+
+export function resolveTrustedProxyRoles(
+  header: string,
+  roleMap: Map<string, string[]>,
+): string[] | null {
+  const externalRoles = header
+    .split(",")
+    .map((role) => role.trim())
+    .filter(Boolean);
+  if (externalRoles.length === 0) return null;
+  const resolved = new Set<string>();
+  for (const externalRole of externalRoles) {
+    const mapped = roleMap.get(externalRole);
+    if (!mapped) return null;
+    mapped.forEach((role) => resolved.add(role));
+  }
+  return [...resolved];
+}
+
+export function isTrustedProxyAuthEnabled(): boolean {
+  return enabled(process.env.TRUSTED_PROXY_AUTH_ENABLED);
+}

--- a/src/ui/auth/Auth.tsx
+++ b/src/ui/auth/Auth.tsx
@@ -33,6 +33,7 @@ import {
   getCurrentToken,
   getOidcSilentLoginDefault,
   requestDesktopAutoSession,
+  requestTrustedProxyLogin,
 } from "@/main-axios";
 import { getSSOProviders, ldapLogin } from "@/api/sso-provider-api";
 import type { SSOProviderPublic } from "@/types/index";
@@ -258,6 +259,7 @@ export function Auth({ onLogin }: AuthProps) {
   const [ldapUsername, setLdapUsername] = useState("");
   const [ldapPassword, setLdapPassword] = useState("");
   const silentSigninHandledRef = useRef(false);
+  const proxySigninHandledRef = useRef(false);
   const [oidcSilentLoginDefault, setOidcSilentLoginDefault] = useState(false);
   const [oidcSilentLoginDefaultLoaded, setOidcSilentLoginDefaultLoaded] =
     useState(false);
@@ -280,6 +282,25 @@ export function Auth({ onLogin }: AuthProps) {
     boolean | null
   >(!isElectron() || isInElectronWebView() ? true : null);
   const [desktopAutoSessionRetries, setDesktopAutoSessionRetries] = useState(0);
+
+  useEffect(() => {
+    if (proxySigninHandledRef.current || isElectron()) return;
+    proxySigninHandledRef.current = true;
+    requestTrustedProxyLogin()
+      .then((result) => {
+        if (!result.enabled || !result.success) return;
+        storeAuth(result.username || "");
+        onLogin(
+          result.username || "",
+          result.userId || undefined,
+          !!result.is_admin,
+        );
+      })
+      .catch(() => {
+        // Leave the login screen visible. The backend logs the reason without
+        // exposing trusted proxy configuration to an untrusted client.
+      });
+  }, [onLogin]);
 
   useEffect(() => {
     try {

--- a/src/ui/main-axios.ts
+++ b/src/ui/main-axios.ts
@@ -1702,6 +1702,20 @@ export async function loginUser(
   }
 }
 
+export async function requestTrustedProxyLogin(): Promise<{
+  enabled: boolean;
+  success?: boolean;
+  username?: string;
+  userId?: string;
+  is_admin?: boolean;
+  token?: string;
+}> {
+  const response = await authApi.post("/users/proxy-login");
+  if (response.data.token) localStorage.setItem("jwt", response.data.token);
+  if (response.data.success) markUserAuthenticated();
+  return response.data;
+}
+
 export async function logoutUser(): Promise<{
   success: boolean;
   message: string;


### PR DESCRIPTION
## Summary

- add opt-in authentication from configurable username and role headers
- trust headers only when the direct socket peer matches an explicit IP/CIDR allowlist
- require pre-existing Termix users and map external roles through an explicit allowlist
- create a normal Termix session so HTTP, WebSocket, SSE, and download flows keep using the existing authorization layer
- synchronize only roles managed by the configured proxy role map; header values never set `isAdmin`
- automatically attempt proxy login from the web login screen

## Security

- disabled by default
- invalid/missing allowlist or role-map configuration fails startup
- unknown external roles, missing users, untrusted peers, and missing roles fail closed
- password login is disabled while proxy auth is enabled
- startup rejects installations with OIDC providers or OIDC/TOTP users
- OIDC provider activation and TOTP enablement are blocked at runtime
- login success and rejection are logged and successful sessions enter the audit log

## Configuration

```yaml
TRUSTED_PROXY_AUTH_ENABLED: "true"
TRUSTED_PROXY_AUTH_TRUSTED_PROXIES: "172.16.0.0/12"
TRUSTED_PROXY_AUTH_ROLE_MAP: '{"operators":["user"]}'\nTRUSTED_PROXY_AUTH_USERNAME_HEADER: "x-forwarded-username"\nTRUSTED_PROXY_AUTH_ROLE_HEADER: "x-forwarded-role"\n```\n\nThe Termix backend must not be directly exposed when this mode is enabled. Users and mapped Termix roles must exist before enabling it.\n\n## Verification\n\n- `npm run type-check`\n- 61 related authentication/configuration tests\n- targeted ESLint\n- `npm run build`\n\nCloses Termix-SSH/Support#444