### PR TITLE
feat: add first-class split screen tabs

### DIFF
--- a/src/types/ui-types.ts
+++ b/src/types/ui-types.ts
@@ -260,7 +260,8 @@ export type TabType =
   | "history"
   | "ssh-tools"
   | "automations"
-  | "ai";
+  | "ai"
+  | "split-screen";
 
 export type SerialConfig = {
   path: string;
@@ -310,6 +311,10 @@ export type Tab = {
   /** Which fleet a fleet-inventory tab is currently showing (singleton tab, re-targeted on reopen). */
   fleetId?: number;
   serialConfig?: SerialConfig;
+  /** Present only on a split-screen container tab. Pane ids reference live child tabs. */
+  splitConfig?: SplitTabConfig;
+  /** Hides this session from the top-level tab bar while it belongs to a split tab. */
+  parentSplitTabId?: string;
   terminalRef?: import("react").RefObject<{
     disconnect?: () => void;
     isConnected?: () => boolean;
@@ -406,6 +411,13 @@ export type FontSizeId = "xs" | "sm" | "md" | "lg" | "xl";
 export type ToolsTab = "ssh-tools" | "snippets" | "history" | "split-screen";
 export type SplitMode =
   "none" | "2-way" | "3-way" | "3-way-horizontal" | "4-way" | "5-way" | "6-way";
+
+export type SplitTabConfig = {
+  mode: Exclude<SplitMode, "none">;
+  paneTabIds: (string | null)[];
+  rowSizes: number[];
+  rowColSizes: number[][];
+};
 
 export type WorkspaceTabSnapshot = {
   /** Stable key within the saved tab list, not the live Tab.id (which is regenerated on every open). */

--- a/src/types/ui-types.ts
+++ b/src/types/ui-types.ts
@@ -410,7 +410,14 @@ export type FontSizeId = "xs" | "sm" | "md" | "lg" | "xl";
 
 export type ToolsTab = "ssh-tools" | "snippets" | "history" | "split-screen";
 export type SplitMode =
-  "none" | "2-way" | "3-way" | "3-way-horizontal" | "4-way" | "5-way" | "6-way";
+  | "none"
+  | "2-way"
+  | "2-way-horizontal"
+  | "3-way"
+  | "3-way-horizontal"
+  | "4-way"
+  | "5-way"
+  | "6-way";
 
 export type SplitTabConfig = {
   mode: Exclude<SplitMode, "none">;

--- a/src/ui/AppShell.tsx
+++ b/src/ui/AppShell.tsx
@@ -190,6 +190,14 @@ import { resolveHostTabType } from "@/lib/host-connection-tabs";
 import { changeAppLanguage, consumeLoginLanguage } from "@/i18n/i18n";
 import { quickConnectHostToPayload } from "@/sidebar/quick-connect-host";
 import { buildHostTree } from "@/sidebar/build-host-tree";
+import {
+  assignTabsToSplit,
+  createSplitConfig,
+  releaseSplitTabs,
+  restoreSplitTabs,
+  serializeSplitTabs,
+  type PersistedSplitTab,
+} from "@/shell/splitTabUtils";
 
 export { buildHostTree } from "@/sidebar/build-host-tree";
 export { tabIcon, renderTabContent } from "@/shell/tabUtils";
@@ -223,9 +231,7 @@ export function AppShell({
   // Flips to true once the initial DB read (restore or skip) is done — sync must not fire before this
   const [tabsReady, setTabsReady] = useState(false);
   const [commandPaletteOpen, setCommandPaletteOpen] = useState(false);
-  const [splitMode, setSplitMode] = useState<SplitMode>(
-    () => (localStorage.getItem("termix_splitMode") as SplitMode) ?? "none",
-  );
+  const [splitMode, setSplitMode] = useState<SplitMode>("none");
   // paneTabIds holds live tab.id values, which change on every restore, so we
   // can't restore it from storage directly. It starts empty and gets filled in
   // once by the reconciliation effect below, keyed off the stable instanceId
@@ -234,6 +240,7 @@ export function AppShell({
     Array(6).fill(null),
   );
   const paneLayoutRestoredRef = useRef(false);
+  const splitTabsRestoredRef = useRef(false);
   useEffect(() => {
     paneTabIdsRef.current = paneTabIds;
   }, [paneTabIds]);
@@ -366,27 +373,12 @@ export function AppShell({
   }, [rightRailView]);
 
   useEffect(() => {
-    localStorage.setItem("termix_splitMode", splitMode);
-  }, [splitMode]);
-
-  useEffect(() => {
-    // Don't overwrite the saved layout with the empty initial state before
-    // reconciliation has had a chance to restore it.
-    if (!paneLayoutRestoredRef.current) return;
-    const instanceIds = paneTabIds.map((id) => {
-      if (id == null) return null;
-      return tabs.find((t) => t.id === id)?.instanceId ?? null;
-    });
-    localStorage.setItem("termix_paneInstanceIds", JSON.stringify(instanceIds));
-  }, [paneTabIds, tabs]);
-
-  useEffect(() => {
-    if (!paneLayoutRestoredRef.current) return;
+    if (!splitTabsRestoredRef.current) return;
     localStorage.setItem(
-      "termix_paneSizes",
-      JSON.stringify({ rowSizes, rowColSizes }),
+      "termix_splitTabs",
+      JSON.stringify(serializeSplitTabs(tabs)),
     );
-  }, [rowSizes, rowColSizes]);
+  }, [tabs]);
 
   const isMobile = useIsMobile();
   const isSettingsView =
@@ -473,6 +465,43 @@ export function AppShell({
   useEffect(() => {
     activeTabIdRef.current = activeTabId;
   }, [activeTabId]);
+  const skipSplitSyncRef = useRef(false);
+  useEffect(() => {
+    const active = tabsRef.current.find((tab) => tab.id === activeTabId);
+    const config = active?.type === "split-screen" ? active.splitConfig : null;
+    skipSplitSyncRef.current = true;
+    if (!config) {
+      setSplitMode("none");
+      setPaneTabIds(Array(6).fill(null));
+      setFocusedPaneIndex(null);
+      return;
+    }
+    setSplitMode(config.mode);
+    setPaneTabIds(config.paneTabIds);
+    setRowSizes(config.rowSizes);
+    setRowColSizes(config.rowColSizes);
+    setFocusedPaneIndex(0);
+  }, [activeTabId]);
+
+  useEffect(() => {
+    if (skipSplitSyncRef.current) {
+      skipSplitSyncRef.current = false;
+      return;
+    }
+    if (splitMode === "none") return;
+    setTabs((prev) => {
+      const active = prev.find((tab) => tab.id === activeTabId);
+      if (active?.type !== "split-screen") return prev;
+      const config = createSplitConfig(splitMode, paneTabIds, {
+        rowSizes,
+        rowColSizes,
+      });
+      const updated = prev.map((tab) =>
+        tab.id === activeTabId ? { ...tab, splitConfig: config } : tab,
+      );
+      return assignTabsToSplit(updated, activeTabId, paneTabIds);
+    });
+  }, [activeTabId, paneTabIds, rowColSizes, rowSizes, splitMode]);
   // Panels like history and snippets act on "the terminal you're working in".
   // Once those panels can themselves be the active tab, activeTabId points at
   // the panel and the lookup misses, so remember the last terminal instead.
@@ -603,27 +632,9 @@ export function AppShell({
       if (e.ctrlKey && e.shiftKey && !e.altKey && e.code === "Backslash") {
         e.preventDefault();
         if (splitModeRef.current !== "none") {
-          splitModeRef.current = "none";
-          changeSplitMode("none");
-          setPaneTabIds(Array(6).fill(null));
+          selectSplitMode("none");
         } else {
-          const mode = "2-way";
-          splitModeRef.current = mode;
-          const currentTabs = tabsRef.current;
-          const currentActiveId = activeTabIdRef.current;
-          const count = PANE_COUNTS[mode];
-          const next: (string | null)[] = Array(6).fill(null);
-          next[0] = currentActiveId;
-          let slot = 1;
-          for (const tab of currentTabs) {
-            if (slot >= count) break;
-            if (tab.id !== currentActiveId && tab.type !== "dashboard") {
-              next[slot] = tab.id;
-              slot++;
-            }
-          }
-          changeSplitMode(mode);
-          setPaneTabIds(next);
+          selectSplitMode("2-way");
         }
         return;
       }
@@ -632,27 +643,9 @@ export function AppShell({
       if (e.ctrlKey && e.shiftKey && !e.altKey && e.code === "Minus") {
         e.preventDefault();
         if (splitModeRef.current !== "none") {
-          splitModeRef.current = "none";
-          changeSplitMode("none");
-          setPaneTabIds(Array(6).fill(null));
+          selectSplitMode("none");
         } else {
-          const mode = "3-way-horizontal";
-          splitModeRef.current = mode;
-          const currentTabs = tabsRef.current;
-          const currentActiveId = activeTabIdRef.current;
-          const count = PANE_COUNTS[mode];
-          const next: (string | null)[] = Array(6).fill(null);
-          next[0] = currentActiveId;
-          let slot = 1;
-          for (const tab of currentTabs) {
-            if (slot >= count) break;
-            if (tab.id !== currentActiveId && tab.type !== "dashboard") {
-              next[slot] = tab.id;
-              slot++;
-            }
-          }
-          changeSplitMode(mode);
-          setPaneTabIds(next);
+          selectSplitMode("3-way-horizontal");
         }
         return;
       }
@@ -679,6 +672,10 @@ export function AppShell({
             "2-way": [
               [null, 1, null, null],
               [0, null, null, null],
+            ],
+            "2-way-horizontal": [
+              [null, null, null, 1],
+              [null, null, 0, null],
             ],
             "3-way": [
               [null, 1, null, null],
@@ -1312,45 +1309,77 @@ export function AppShell({
       .catch(() => {});
   }, [tabsReady]);
 
-  // Restore split-screen pane assignments once tabs are settled. Saved assignments are
-  // keyed by instanceId (stable across reloads) and remapped to the live tab.id here,
-  // since tab.id is regenerated every time a tab is (re)opened.
+  // Restore named split tabs once their child sessions have stable live ids. The old
+  // singleton keys are migrated once into Split #1 so existing layouts are preserved.
   useEffect(() => {
     if (!tabsReady || paneLayoutRestoredRef.current) return;
     paneLayoutRestoredRef.current = true;
 
     try {
+      const savedSplitTabs = JSON.parse(
+        localStorage.getItem("termix_splitTabs") ?? "[]",
+      ) as PersistedSplitTab[];
+      if (Array.isArray(savedSplitTabs) && savedSplitTabs.length > 0) {
+        setTabs((prev) => restoreSplitTabs(savedSplitTabs, prev));
+        splitTabsRestoredRef.current = true;
+        return;
+      }
+
       const savedInstanceIds: (string | null)[] = JSON.parse(
         localStorage.getItem("termix_paneInstanceIds") ?? "null",
       );
-      if (!Array.isArray(savedInstanceIds)) return;
+      const savedMode = localStorage.getItem("termix_splitMode") as SplitMode;
+      if (
+        !Array.isArray(savedInstanceIds) ||
+        !savedMode ||
+        savedMode === "none"
+      ) {
+        splitTabsRestoredRef.current = true;
+        return;
+      }
 
       const restored = savedInstanceIds.map((instanceId) => {
         if (instanceId == null) return null;
         return tabs.find((t) => t.instanceId === instanceId)?.id ?? null;
       });
       if (restored.some((id) => id != null)) {
-        setPaneTabIds(restored);
+        let sizes = defaultSizes(savedMode);
         try {
           const savedSizes = JSON.parse(
             localStorage.getItem("termix_paneSizes") ?? "null",
           ) as { rowSizes?: number[]; rowColSizes?: RowColSizes } | null;
-          if (Array.isArray(savedSizes?.rowSizes)) {
-            setRowSizes(savedSizes.rowSizes);
-          }
-          if (Array.isArray(savedSizes?.rowColSizes)) {
-            setRowColSizes(savedSizes.rowColSizes);
+          if (
+            Array.isArray(savedSizes?.rowSizes) &&
+            Array.isArray(savedSizes?.rowColSizes)
+          ) {
+            sizes = {
+              rowSizes: savedSizes.rowSizes,
+              rowColSizes: savedSizes.rowColSizes,
+            };
           }
         } catch {
           // silently fail
         }
-      } else {
-        // None of the saved panes could be restored (e.g. reopen-tabs-on-login
-        // is disabled), so drop back to a single view instead of an empty split.
-        changeSplitMode("none");
+        const instanceId = crypto.randomUUID();
+        const id = `split-${instanceId}`;
+        const splitTab: Tab = {
+          id,
+          instanceId,
+          type: "split-screen",
+          label: "Split #1",
+          openedAt: Date.now(),
+          splitConfig: createSplitConfig(savedMode, restored, sizes),
+        };
+        setTabs((prev) => assignTabsToSplit([...prev, splitTab], id, restored));
+        setActiveTabId(id);
       }
     } catch {
       // silently fail
+    } finally {
+      splitTabsRestoredRef.current = true;
+      localStorage.removeItem("termix_splitMode");
+      localStorage.removeItem("termix_paneInstanceIds");
+      localStorage.removeItem("termix_paneSizes");
     }
   }, [tabsReady, tabs]);
 
@@ -1743,14 +1772,33 @@ export function AppShell({
 
     terminalRefs.current.delete(id);
     if (id === activeTabId) {
-      const remaining = tabs.filter((t) => t.id !== id);
+      const remaining = tabs.filter(
+        (tab) => tab.id !== id && !tab.parentSplitTabId,
+      );
       setActiveTabId(
         remaining.length > 0 ? remaining[remaining.length - 1].id : "dashboard",
       );
     }
     setPaneTabIds((prev) => prev.map((p) => (p === id ? null : p)));
     setTabs((prev) => {
-      const next = prev.filter((t) => t.id !== id);
+      const next =
+        tabToClose?.type === "split-screen"
+          ? releaseSplitTabs(prev, id)
+          : prev
+              .filter((tab) => tab.id !== id)
+              .map((tab) =>
+                tab.type === "split-screen" && tab.splitConfig
+                  ? {
+                      ...tab,
+                      splitConfig: {
+                        ...tab.splitConfig,
+                        paneTabIds: tab.splitConfig.paneTabIds.map((paneId) =>
+                          paneId === id ? null : paneId,
+                        ),
+                      },
+                    }
+                  : tab,
+              );
       if (next.length === 0)
         return [
           {
@@ -1833,31 +1881,54 @@ export function AppShell({
       ),
     );
     const tab = tabs.find((t) => t.id === tabId);
-    if (tab?.instanceId) {
+    if (tab?.instanceId && tab.type !== "split-screen") {
       patchOpenTab(tab.instanceId, { label: newLabel }).catch(() => {});
     }
   }
 
   function splitTabQuick(tabId: string, mode: SplitMode) {
-    changeSplitMode(mode);
-    setPaneTabIds(() => {
-      const count = PANE_COUNTS[mode];
-      const next: (string | null)[] = Array(6).fill(null);
-      next[0] = tabId;
-      // Fill remaining panes with other non-dashboard tabs in order
-      let slot = 1;
-      for (const tab of tabs) {
-        if (slot >= count) break;
-        if (tab.id !== tabId && tab.type !== "dashboard") {
-          next[slot] = tab.id;
-          slot++;
-        }
+    if (mode === "none") return;
+    const count = PANE_COUNTS[mode];
+    const paneIds: (string | null)[] = Array(6).fill(null);
+    paneIds[0] = tabId;
+    let slot = 1;
+    for (const tab of tabs) {
+      if (slot >= count) break;
+      if (
+        tab.id !== tabId &&
+        tab.type !== "dashboard" &&
+        tab.type !== "split-screen" &&
+        !tab.parentSplitTabId
+      ) {
+        paneIds[slot++] = tab.id;
       }
-      return next;
-    });
+    }
+    const splitNumber =
+      tabs.filter((tab) => tab.type === "split-screen").length + 1;
+    const instanceId = crypto.randomUUID();
+    const id = `split-${instanceId}`;
+    const sizes = defaultSizes(mode);
+    const splitTab: Tab = {
+      id,
+      instanceId,
+      type: "split-screen",
+      label: `Split #${splitNumber}`,
+      openedAt: Date.now(),
+      splitConfig: createSplitConfig(mode, paneIds, sizes),
+    };
+    setTabs((prev) => assignTabsToSplit([...prev, splitTab], id, paneIds));
+    setActiveTabId(id);
+    setSplitMode(mode);
+    setPaneTabIds(paneIds);
+    setRowSizes(sizes.rowSizes);
+    setRowColSizes(sizes.rowColSizes);
   }
 
   function addTabToSplit(tabId: string) {
+    if (splitMode === "none") {
+      splitTabQuick(tabId, "2-way");
+      return;
+    }
     setPaneTabIds((prev) => {
       // Remove from any current slot first
       const next = prev.map((p) => (p === tabId ? null : p));
@@ -1875,6 +1946,29 @@ export function AppShell({
 
   function removeTabFromSplit(tabId: string) {
     setPaneTabIds((prev) => prev.map((p) => (p === tabId ? null : p)));
+  }
+
+  function selectSplitMode(mode: SplitMode) {
+    const active = tabs.find((tab) => tab.id === activeTabId);
+    if (mode === "none") {
+      if (active?.type === "split-screen") doCloseTab(active.id);
+      return;
+    }
+    if (active?.type === "split-screen") {
+      changeSplitMode(mode);
+      return;
+    }
+    if (active && active.type !== "dashboard") {
+      splitTabQuick(active.id, mode);
+      return;
+    }
+    const firstSession = tabs.find(
+      (tab) =>
+        tab.type !== "dashboard" &&
+        tab.type !== "split-screen" &&
+        !tab.parentSplitTabId,
+    );
+    if (firstSession) splitTabQuick(firstSession.id, mode);
   }
 
   function assignPane(paneIndex: number, tabId: string) {
@@ -1992,7 +2086,9 @@ export function AppShell({
     return () => cancelAnimationFrame(id);
   }, [splitMode, sidebarWidth, sidebarOpen, rightSidebarWidth, rightRailView]);
 
-  const isSplit = splitMode !== "none";
+  const isSplit =
+    splitMode !== "none" &&
+    tabs.some((tab) => tab.id === activeTabId && tab.type === "split-screen");
 
   // Move each tab's stable DOM node to the right container (pane or normal-view).
   // This is vanilla DOM so React's portal target never changes — changing the portal
@@ -2043,6 +2139,14 @@ export function AppShell({
   });
 
   const terminalTabs = tabs.filter((t) => t.type === "terminal");
+  const topLevelTabs = tabs.filter((tab) => !tab.parentSplitTabId);
+
+  function reorderTopLevelTabs(reordered: Tab[]) {
+    setTabs((prev) => [
+      ...reordered,
+      ...prev.filter((tab) => tab.parentSplitTabId),
+    ]);
+  }
 
   // What history/snippets/ssh-tools should act on. Falls back to the remembered
   // terminal when the active tab isn't one, and drops it once it's closed.
@@ -2170,9 +2274,14 @@ export function AppShell({
         {railView === "split-screen" && (
           <div className="flex-1 min-h-0 overflow-y-auto">
             <SplitScreenPanel
-              tabs={tabs}
+              tabs={tabs.filter(
+                (tab) =>
+                  tab.type !== "split-screen" &&
+                  (!tab.parentSplitTabId ||
+                    tab.parentSplitTabId === activeTabId),
+              )}
               splitMode={splitMode}
-              setSplitMode={changeSplitMode}
+              setSplitMode={selectSplitMode}
               paneTabIds={paneTabIds}
               setPaneTabIds={setPaneTabIds}
               onAssignPane={assignPane}
@@ -2550,7 +2659,7 @@ export function AppShell({
             )}
             <div className="flex flex-col flex-1 min-w-0 min-h-0 overflow-hidden">
               <TabBar
-                tabs={tabs}
+                tabs={topLevelTabs}
                 activeTabId={activeTabId}
                 splitMode={splitMode}
                 paneTabIds={paneTabIds}
@@ -2558,7 +2667,7 @@ export function AppShell({
                 onSetActiveTab={setActiveTabId}
                 onCloseTab={closeTab}
                 onRefreshTab={refreshTab}
-                onReorderTabs={setTabs}
+                onReorderTabs={reorderTopLevelTabs}
                 onSplitTab={splitTabQuick}
                 onAddToSplit={addTabToSplit}
                 onRemoveFromSplit={removeTabFromSplit}
@@ -2609,14 +2718,7 @@ export function AppShell({
                   ref={normalViewRef}
                   className="absolute inset-0"
                   style={{
-                    display:
-                      isSplit && !isMobile && paneTabIds.includes(activeTabId)
-                        ? "none"
-                        : undefined,
-                    zIndex:
-                      isSplit && !paneTabIds.includes(activeTabId)
-                        ? 10
-                        : undefined,
+                    display: isSplit && !isMobile ? "none" : undefined,
                   }}
                 >
                   {tabs.map((tab) => {

--- a/src/ui/AppShell.tsx
+++ b/src/ui/AppShell.tsx
@@ -1144,15 +1144,38 @@ export function AppShell({
       }
     }
 
-    setPaneTabIds(remapSlotIds(workspace.payload.paneTabIds, slotIdToNewTabId));
-    setSplitMode(workspace.payload.splitMode);
-    setRowSizes(workspace.payload.rowSizes);
-    setRowColSizes(workspace.payload.rowColSizes);
+    const restoredPaneIds = remapSlotIds(
+      workspace.payload.paneTabIds,
+      slotIdToNewTabId,
+    );
+    let restoredSplitTabId: string | null = null;
+    if (
+      workspace.payload.splitMode !== "none" &&
+      restoredPaneIds.some(Boolean)
+    ) {
+      const instanceId = crypto.randomUUID();
+      restoredSplitTabId = `split-${instanceId}`;
+      const splitTab: Tab = {
+        id: restoredSplitTabId,
+        instanceId,
+        type: "split-screen",
+        label: workspace.name,
+        openedAt: Date.now(),
+        splitConfig: createSplitConfig(
+          workspace.payload.splitMode,
+          restoredPaneIds,
+          workspace.payload,
+        ),
+      };
+      setTabs((prev) =>
+        assignTabsToSplit([...prev, splitTab], splitTab.id, restoredPaneIds),
+      );
+    }
 
     const activeId = workspace.payload.activeSlotId
       ? (slotIdToNewTabId.get(workspace.payload.activeSlotId) ?? "dashboard")
       : "dashboard";
-    setActiveTabId(activeId);
+    setActiveTabId(restoredSplitTabId ?? activeId);
 
     // Older payloads predate the sidebar field, so leave the docks alone then.
     const sidebar = workspace.payload.sidebar;
@@ -1974,7 +1997,7 @@ export function AppShell({
   function assignPane(paneIndex: number, tabId: string) {
     setPaneTabIds((prev) => {
       const next = prev.map((p) => (p === tabId ? null : p));
-      next[paneIndex] = tabId;
+      next[paneIndex] = tabId || null;
       return next;
     });
   }

--- a/src/ui/lib/theme.ts
+++ b/src/ui/lib/theme.ts
@@ -103,6 +103,7 @@ export const FOLDER_COLORS = [
 export const SPLIT_MODES: { id: SplitMode; label: string }[] = [
   { id: "none", label: "None" },
   { id: "2-way", label: "2-Way" },
+  { id: "2-way-horizontal", label: "2-Way (H)" },
   { id: "3-way", label: "3-Way (V)" },
   { id: "3-way-horizontal", label: "3-Way (H)" },
   { id: "4-way", label: "4-Way" },
@@ -113,6 +114,7 @@ export const SPLIT_MODES: { id: SplitMode; label: string }[] = [
 export const PANE_COUNTS: Record<SplitMode, number> = {
   none: 0,
   "2-way": 2,
+  "2-way-horizontal": 2,
   "3-way": 3,
   "3-way-horizontal": 3,
   "4-way": 4,

--- a/src/ui/shell/SplitView.tsx
+++ b/src/ui/shell/SplitView.tsx
@@ -15,6 +15,8 @@ export function defaultSizes(mode: SplitMode): {
   switch (mode) {
     case "2-way":
       return { rowSizes: [100], rowColSizes: [[50, 50]] };
+    case "2-way-horizontal":
+      return { rowSizes: [50, 50], rowColSizes: [[100], [100]] };
     case "3-way":
       return { rowSizes: [50, 50], rowColSizes: [[50, 50], [100]] };
     case "3-way-horizontal":
@@ -531,6 +533,45 @@ export const SplitView = memo(function SplitView({
           onPaneClick={onPaneClick}
           onAssignPane={onAssignPane}
         />
+      )}
+
+      {splitMode === "2-way-horizontal" && (
+        <div className="flex flex-col w-full h-full min-h-0">
+          <Row
+            rowIdx={0}
+            paneIndices={[0]}
+            rowHeight={rowSizes[0]}
+            colWidths={rowColSizes[0] ?? []}
+            paneTabIds={paneTabIds}
+            tabs={tabs}
+            isDragging={isDragging}
+            focusedPaneIndex={focusedPaneIndex ?? null}
+            onColDivider={onColDivider}
+            onColDividerTouch={onColDividerTouch}
+            onPaneContentRef={onPaneContentRef}
+            onPaneClick={onPaneClick}
+            onAssignPane={onAssignPane}
+          />
+          <RowDivider
+            onMouseDown={(e) => onRowDivider(e, 0)}
+            onTouchStart={(e) => onRowDividerTouch(e, 0)}
+          />
+          <Row
+            rowIdx={1}
+            paneIndices={[1]}
+            rowHeight={rowSizes[1]}
+            colWidths={rowColSizes[1] ?? []}
+            paneTabIds={paneTabIds}
+            tabs={tabs}
+            isDragging={isDragging}
+            focusedPaneIndex={focusedPaneIndex ?? null}
+            onColDivider={onColDivider}
+            onColDividerTouch={onColDividerTouch}
+            onPaneContentRef={onPaneContentRef}
+            onPaneClick={onPaneClick}
+            onAssignPane={onAssignPane}
+          />
+        </div>
       )}
 
       {splitMode === "3-way" && (

--- a/src/ui/shell/SplitView.tsx
+++ b/src/ui/shell/SplitView.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useRef, useEffect, memo, useCallback } from "react";
 import { useTranslation } from "react-i18next";
+import { X } from "lucide-react";
 import { splitDragState, notifyDragEnd } from "@/lib/splitDragging";
 import { tabIcon } from "@/shell/tabUtils";
 import type { Tab, SplitMode } from "@/types/ui-types";
@@ -255,10 +256,12 @@ function PaneHeader({
   tab,
   paneIndex,
   isFocused,
+  onClear,
 }: {
   tab: Tab | null;
   paneIndex: number;
   isFocused: boolean;
+  onClear?: () => void;
 }) {
   const { t } = useTranslation();
   return (
@@ -278,10 +281,22 @@ function PaneHeader({
             {tabIcon(tab.type)}
           </span>
           <span
-            className={`truncate ${isFocused ? "text-accent-brand font-semibold" : "text-foreground"}`}
+            className={`truncate flex-1 ${isFocused ? "text-accent-brand font-semibold" : "text-foreground"}`}
           >
             {tab.type === "dashboard" ? "Dashboard" : tab.label}
           </span>
+          <button
+            type="button"
+            title={t("terminal.split.removeFromSplit")}
+            aria-label={t("terminal.split.removeFromSplit")}
+            className="ml-auto flex size-5 shrink-0 items-center justify-center rounded-sm text-muted-foreground hover:bg-muted hover:text-foreground"
+            onClick={(event) => {
+              event.stopPropagation();
+              onClear?.();
+            }}
+          >
+            <X className="size-3" />
+          </button>
         </>
       ) : (
         <span className="opacity-40">
@@ -351,7 +366,12 @@ const Pane = memo(function Pane({
         if (tabId) onAssignPane?.(paneIndex, tabId);
       }}
     >
-      <PaneHeader tab={tab} paneIndex={paneIndex} isFocused={isFocused} />
+      <PaneHeader
+        tab={tab}
+        paneIndex={paneIndex}
+        isFocused={isFocused}
+        onClear={tab ? () => onAssignPane?.(paneIndex, "") : undefined}
+      />
       <div className="flex-1 min-h-0 overflow-hidden relative">
         {tab ? (
           <div ref={contentRef} className="absolute inset-0" />

--- a/src/ui/shell/TabBar.tsx
+++ b/src/ui/shell/TabBar.tsx
@@ -593,24 +593,27 @@ export function TabBar({
                 <Pencil className="size-3" />
                 {t("nav.renameTab")}
               </button>
-              <div className="h-px bg-border my-1" />
-              {/* Split submenu */}
-              <div className="px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
-                {t("terminal.split.splitTab")}
-              </div>
-              {SPLIT_MODES.filter((m) => m.id !== "none").map((mode) => (
-                <button
-                  key={mode.id}
-                  className="flex items-center gap-2 w-full px-3 py-1.5 text-xs text-left hover:bg-accent hover:text-accent-foreground"
-                  onClick={() => {
-                    onSplitTab(contextTabId, mode.id);
-                    setContextTabId(null);
-                  }}
-                >
-                  <LayoutPanelLeft className="size-3 text-muted-foreground" />
-                  {mode.label}
-                </button>
-              ))}
+              {ctxTab.type !== "split-screen" && (
+                <>
+                  <div className="h-px bg-border my-1" />
+                  <div className="px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+                    {t("terminal.split.splitTab")}
+                  </div>
+                  {SPLIT_MODES.filter((m) => m.id !== "none").map((mode) => (
+                    <button
+                      key={mode.id}
+                      className="flex items-center gap-2 w-full px-3 py-1.5 text-xs text-left hover:bg-accent hover:text-accent-foreground"
+                      onClick={() => {
+                        onSplitTab(contextTabId, mode.id);
+                        setContextTabId(null);
+                      }}
+                    >
+                      <LayoutPanelLeft className="size-3 text-muted-foreground" />
+                      {mode.label}
+                    </button>
+                  ))}
+                </>
+              )}
               {isSplit && (
                 <>
                   <div className="h-px bg-border my-1" />

--- a/src/ui/shell/splitTabUtils.ts
+++ b/src/ui/shell/splitTabUtils.ts
@@ -1,0 +1,104 @@
+import type { SplitMode, SplitTabConfig, Tab } from "@/types/ui-types";
+
+const EMPTY_PANES = 6;
+
+export type PersistedSplitTab = {
+  instanceId: string;
+  label: string;
+  mode: Exclude<SplitMode, "none">;
+  paneInstanceIds: (string | null)[];
+  rowSizes: number[];
+  rowColSizes: number[][];
+};
+
+export function createSplitConfig(
+  mode: Exclude<SplitMode, "none">,
+  paneTabIds: (string | null)[],
+  sizes: Pick<SplitTabConfig, "rowSizes" | "rowColSizes">,
+): SplitTabConfig {
+  return {
+    mode,
+    paneTabIds: [...paneTabIds, ...Array(EMPTY_PANES).fill(null)].slice(
+      0,
+      EMPTY_PANES,
+    ),
+    rowSizes: [...sizes.rowSizes],
+    rowColSizes: sizes.rowColSizes.map((row) => [...row]),
+  };
+}
+
+export function assignTabsToSplit(
+  tabs: Tab[],
+  splitTabId: string,
+  paneTabIds: (string | null)[],
+): Tab[] {
+  const assigned = new Set(paneTabIds.filter((id): id is string => !!id));
+  return tabs.map((tab) => {
+    if (tab.id === splitTabId) return tab;
+    if (assigned.has(tab.id)) return { ...tab, parentSplitTabId: splitTabId };
+    if (tab.parentSplitTabId === splitTabId) {
+      const { parentSplitTabId: _removed, ...released } = tab;
+      return released;
+    }
+    return tab;
+  });
+}
+
+export function releaseSplitTabs(tabs: Tab[], splitTabId: string): Tab[] {
+  return tabs
+    .filter((tab) => tab.id !== splitTabId)
+    .map((tab) => {
+      if (tab.parentSplitTabId !== splitTabId) return tab;
+      const { parentSplitTabId: _removed, ...released } = tab;
+      return released;
+    });
+}
+
+export function serializeSplitTabs(tabs: Tab[]): PersistedSplitTab[] {
+  const instanceIdById = new Map(tabs.map((tab) => [tab.id, tab.instanceId]));
+  return tabs.flatMap((tab) => {
+    if (tab.type !== "split-screen" || !tab.splitConfig) return [];
+    return [
+      {
+        instanceId: tab.instanceId,
+        label: tab.label,
+        mode: tab.splitConfig.mode,
+        paneInstanceIds: tab.splitConfig.paneTabIds.map((id) =>
+          id ? (instanceIdById.get(id) ?? null) : null,
+        ),
+        rowSizes: [...tab.splitConfig.rowSizes],
+        rowColSizes: tab.splitConfig.rowColSizes.map((row) => [...row]),
+      },
+    ];
+  });
+}
+
+export function restoreSplitTabs(
+  persisted: PersistedSplitTab[],
+  tabs: Tab[],
+  openedAt = Date.now(),
+): Tab[] {
+  const tabIdByInstanceId = new Map(
+    tabs.map((tab) => [tab.instanceId, tab.id]),
+  );
+  let next = [...tabs];
+
+  for (const saved of persisted) {
+    const id = `split-${saved.instanceId}`;
+    const paneTabIds = saved.paneInstanceIds.map((instanceId) =>
+      instanceId ? (tabIdByInstanceId.get(instanceId) ?? null) : null,
+    );
+    if (!paneTabIds.some(Boolean)) continue;
+    const splitTab: Tab = {
+      id,
+      instanceId: saved.instanceId,
+      type: "split-screen",
+      label: saved.label,
+      openedAt,
+      splitConfig: createSplitConfig(saved.mode, paneTabIds, saved),
+    };
+    next = assignTabsToSplit([...next, splitTab], id, paneTabIds);
+  }
+
+  return next;
+}

--- a/src/ui/shell/tabUtils.tsx
+++ b/src/ui/shell/tabUtils.tsx
@@ -6,6 +6,7 @@ import {
   HardDrive,
   LayoutDashboard,
   LayoutGrid,
+  LayoutPanelLeft,
   MessagesSquare,
   Monitor,
   MousePointerClick,
@@ -295,6 +296,8 @@ export function tabIcon(type: TabType) {
       return <Workflow className="size-3.5" />;
     case "ai":
       return <Sparkles className="size-3.5" />;
+    case "split-screen":
+      return <LayoutPanelLeft className="size-3.5" />;
   }
 }
 
@@ -601,6 +604,9 @@ export function renderTabContent(
           <AiPanel />
         </PanelTabFrame>,
       );
+
+    case "split-screen":
+      return null;
 
     case "snippets":
       return withTabSuspense(

--- a/src/ui/sidebar/SplitScreenPanel.tsx
+++ b/src/ui/sidebar/SplitScreenPanel.tsx
@@ -15,6 +15,12 @@ const LAYOUT_PREVIEWS: Record<SplitMode, React.ReactNode> = {
       <div className="flex-1 border-2 border-current" />
     </div>
   ),
+  "2-way-horizontal": (
+    <div className="flex flex-col gap-0.5 size-full">
+      <div className="flex-1 border-2 border-current" />
+      <div className="flex-1 border-2 border-current" />
+    </div>
+  ),
   "3-way": (
     <div className="flex gap-0.5 size-full">
       <div className="flex-1 border-2 border-current" />

--- a/src/ui/tests/shell/SplitView.test.tsx
+++ b/src/ui/tests/shell/SplitView.test.tsx
@@ -34,6 +34,13 @@ describe("defaultSizes", () => {
     });
   });
 
+  it("returns stacked defaults for a horizontal 2-way layout", () => {
+    expect(defaultSizes("2-way-horizontal")).toEqual({
+      rowSizes: [50, 50],
+      rowColSizes: [[100], [100]],
+    });
+  });
+
   it("returns a single full pane for 'none'", () => {
     expect(defaultSizes("none")).toEqual({
       rowSizes: [100],
@@ -84,6 +91,25 @@ describe("SplitView - controlled rowSizes/rowColSizes", () => {
 
     fireEvent.click(screen.getByTitle("Reset to equal split"));
     expect(onReset).toHaveBeenCalledTimes(1);
+  });
+
+  it("releases a session from its pane from the pane header", () => {
+    const onAssignPane = vi.fn();
+    render(
+      <SplitView
+        tabs={[makeTab({ id: "t1" })]}
+        paneTabIds={["t1", null, null, null, null, null]}
+        splitMode="2-way"
+        rowSizes={[100]}
+        rowColSizes={[[50, 50]]}
+        onRowSizesChange={() => {}}
+        onRowColSizesChange={() => {}}
+        onAssignPane={onAssignPane}
+      />,
+    );
+
+    fireEvent.click(screen.getByLabelText("terminal.split.removeFromSplit"));
+    expect(onAssignPane).toHaveBeenCalledWith(0, "");
   });
 
   it("does not mutate rowSizes/rowColSizes props locally - reflects prop changes on rerender", () => {

--- a/src/ui/tests/shell/splitTabUtils.test.ts
+++ b/src/ui/tests/shell/splitTabUtils.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+import type { Tab } from "@/types/ui-types";
+import {
+  assignTabsToSplit,
+  createSplitConfig,
+  releaseSplitTabs,
+  restoreSplitTabs,
+  serializeSplitTabs,
+} from "@/shell/splitTabUtils";
+
+const session = (id: string): Tab => ({
+  id,
+  instanceId: `instance-${id}`,
+  type: "terminal",
+  label: id,
+  openedAt: 1,
+});
+
+describe("split tab state", () => {
+  it("moves assigned sessions under a split tab and releases removed panes", () => {
+    const split: Tab = {
+      id: "split-1",
+      instanceId: "split-instance",
+      type: "split-screen",
+      label: "Split #1",
+      openedAt: 1,
+      splitConfig: createSplitConfig("2-way", ["a", "b"], {
+        rowSizes: [100],
+        rowColSizes: [[50, 50]],
+      }),
+    };
+
+    const assigned = assignTabsToSplit(
+      [session("a"), session("b"), split],
+      split.id,
+      ["a", "b"],
+    );
+    expect(assigned.slice(0, 2).map((tab) => tab.parentSplitTabId)).toEqual([
+      split.id,
+      split.id,
+    ]);
+
+    const updated = assignTabsToSplit(assigned, split.id, ["a", null]);
+    expect(updated.find((tab) => tab.id === "a")?.parentSplitTabId).toBe(
+      split.id,
+    );
+    expect(updated.find((tab) => tab.id === "b")?.parentSplitTabId).toBe(
+      undefined,
+    );
+  });
+
+  it("releases child sessions when the split tab closes", () => {
+    const tabs = assignTabsToSplit(
+      [
+        session("a"),
+        {
+          id: "split-1",
+          instanceId: "split-instance",
+          type: "split-screen",
+          label: "Split #1",
+          openedAt: 1,
+        },
+      ],
+      "split-1",
+      ["a"],
+    );
+    expect(releaseSplitTabs(tabs, "split-1")).toEqual([session("a")]);
+  });
+
+  it("persists pane membership by stable instance id", () => {
+    const members = [session("a"), session("b")];
+    const split: Tab = {
+      id: "split-1",
+      instanceId: "workspace-1",
+      type: "split-screen",
+      label: "Production",
+      openedAt: 1,
+      splitConfig: createSplitConfig("2-way", ["a", "b"], {
+        rowSizes: [100],
+        rowColSizes: [[40, 60]],
+      }),
+    };
+    const saved = serializeSplitTabs([...members, split]);
+    const restoredMembers = [
+      { ...session("new-a"), instanceId: "instance-a" },
+      { ...session("new-b"), instanceId: "instance-b" },
+    ];
+    const restored = restoreSplitTabs(saved, restoredMembers, 2);
+    const restoredSplit = restored.find((tab) => tab.type === "split-screen");
+
+    expect(restoredSplit?.label).toBe("Production");
+    expect(restoredSplit?.splitConfig?.paneTabIds.slice(0, 2)).toEqual([
+      "new-a",
+      "new-b",
+    ]);
+    expect(restoredMembers.map((tab) => tab.id)).toEqual(["new-a", "new-b"]);
+    expect(
+      restored
+        .filter((tab) => tab.type === "terminal")
+        .map((tab) => tab.parentSplitTabId),
+    ).toEqual(["split-workspace-1", "split-workspace-1"]);
+  });
+});


### PR DESCRIPTION
## Summary

- promote split-screen layouts to first-class, renameable top-level tabs
- support multiple independent split tabs while keeping assigned sessions alive and hiding their duplicate top-level tabs
- persist split layouts by stable session instance IDs and migrate the previous singleton split layout
- restore saved Workspaces as named split tabs
- add a 2-way horizontal layout and pane-header controls for releasing sessions
- preserve layout sizes and assignments independently for every split tab

## Commit structure

1. `feat: add split tab data model`
2. `feat: make split screens top-level tabs`
3. `feat: persist and manage split layouts`

## Verification

- `npm run type-check`
- `npm run lint` (0 errors; existing warnings only)
- `npm test -- --run` (292 files, 2,226 passed, 1 skipped)
- `npm run build`
- `git diff upstream/dev-2.7.0...HEAD --check`

Closes Termix-SSH/Support#1142
Closes Termix-SSH/Support#952
Closes Termix-SSH/Support#1071