### PR TITLE
feat: tune host transfers adaptively

### DIFF
--- a/src/backend/hosts/file-manager/index.ts
+++ b/src/backend/hosts/file-manager/index.ts
@@ -2986,7 +2986,7 @@ app.post("/ssh/file_manager/ssh/transferToHost", async (req, res) => {
     const rawParallel = Number(parallelSegmentCountRaw);
     const parallelSegmentCount = Number.isFinite(rawParallel)
       ? Math.max(1, Math.min(8, Math.floor(rawParallel)))
-      : 2;
+      : undefined;
 
     const { transferId } = startHostTransfer(hostTransferDeps, {
       sourceSessionId,

--- a/src/backend/hosts/file-manager/transfer-engine.ts
+++ b/src/backend/hosts/file-manager/transfer-engine.ts
@@ -19,6 +19,7 @@ import {
 } from "../transfer-paths.js";
 import {
   buildTransferScanSummary,
+  estimateIncompressibleSample,
   getArchiveTransferReasonKey,
   resolveArchiveTransferMethod,
   type TransferMethodPreference,
@@ -33,6 +34,11 @@ import {
   shouldUseDirectTransfer,
   type DirectTransferEndpoint,
 } from "./direct-transfer-routing.js";
+import {
+  getTransferProfile,
+  recordTransferProfile,
+  selectTransferTuning,
+} from "./transfer-tuning.js";
 
 export type {
   TransferMethodPreference,
@@ -175,7 +181,7 @@ export interface TransferRequest {
   move?: boolean;
   userId: string;
   methodPreference?: TransferMethodPreference;
-  /** Parallel 256 MiB segment lanes for single-file SFTP copy (default 2). */
+  /** Explicit parallel lane override; omitted values are tuned automatically. */
   parallelSegmentCount?: number;
 }
 
@@ -338,6 +344,7 @@ interface TransferReconnectContext {
   dedicatedSourceSessionId: string;
   dedicatedDestSessionId: string;
   transferId: string;
+  profileKey?: string;
 }
 
 type TransferReconnectMeta = Omit<
@@ -1393,7 +1400,52 @@ async function scanSourcePathsForRouting(
       ...work.map((w) => ({ sourcePath: w.sourcePath, size: w.size })),
     );
   }
-  return buildTransferScanSummary(scanItems);
+  const summary = buildTransferScanSummary(scanItems);
+  const candidates = [...scanItems]
+    .filter((item) => item.size > 0)
+    .sort((a, b) => b.size - a.size)
+    .slice(0, 3);
+  let sampledBytes = 0;
+  let sampledIncompressibleBytes = 0;
+  for (const item of candidates) {
+    throwIfCancelled(transferId);
+    try {
+      const sample = await readSftpSample(sftp, item.sourcePath, item.size);
+      sampledBytes += sample.length;
+      if (estimateIncompressibleSample(sample)) {
+        sampledIncompressibleBytes += sample.length;
+      }
+    } catch {
+      /* Extension-based routing remains the safe fallback. */
+    }
+  }
+  if (sampledBytes > 0) {
+    summary.sampledIncompressibleRatio =
+      sampledIncompressibleBytes / sampledBytes;
+  }
+  return summary;
+}
+
+async function readSftpSample(
+  sftp: SFTPWrapper,
+  path: string,
+  fileSize: number,
+): Promise<Buffer> {
+  const sampleSize = Math.min(64 * 1024, fileSize);
+  const position = Math.max(0, Math.floor((fileSize - sampleSize) / 2));
+  const handle = await promisifySftpOpen(sftp, path, SFTP_OPEN_READ, 0o666);
+  try {
+    const buffer = Buffer.alloc(sampleSize);
+    const bytesRead = await new Promise<number>((resolve, reject) => {
+      sftp.read(handle, buffer, 0, sampleSize, position, (err, count) => {
+        if (err) reject(err);
+        else resolve(count);
+      });
+    });
+    return buffer.subarray(0, bytesRead);
+  } finally {
+    await promisifySftpClose(sftp, handle).catch(() => {});
+  }
 }
 
 function promisifySftpOpen(
@@ -1435,6 +1487,7 @@ interface PipelinedXferOptions {
   fileSize?: number;
   initialOffset?: number;
   parallelSegmentCount?: number;
+  pipelineConcurrency?: number;
   onProgress?: (bytes: number) => void;
   shouldAbort?: () => boolean;
   transferId?: string;
@@ -1549,7 +1602,7 @@ async function runFastSftpCopy(
   sourceReadClock: ReturnType<typeof createHopWallClock>,
   destWriteClock: ReturnType<typeof createHopWallClock>,
 ): Promise<void> {
-  let concurrency = SFTP_XFER_CONCURRENCY;
+  let concurrency = options.pipelineConcurrency ?? SFTP_XFER_CONCURRENCY;
   let chunkSize = SFTP_XFER_CHUNK_SIZE;
   let bufsize = chunkSize * concurrency;
   while (bufsize > byteLength && concurrency > 1) {
@@ -2437,7 +2490,7 @@ async function pipelinedSftpToLocalFile(
   const transferStart = Date.now();
 
   await promisifyFastGet(sourceSftp, sourcePath, localPath, {
-    concurrency: SFTP_XFER_CONCURRENCY,
+    concurrency: options.pipelineConcurrency ?? SFTP_XFER_CONCURRENCY,
     chunkSize: SFTP_XFER_CHUNK_SIZE,
     fileSize,
     step: (_total, chunk) => {
@@ -2468,6 +2521,13 @@ async function transferFileData(
   onResumeOffset?: (offset: number) => void,
   parallelSegmentCount?: number,
 ): Promise<PipelinedXferStats> {
+  const tuning = selectTransferTuning(
+    fileSize,
+    reconnect?.profileKey
+      ? getTransferProfile(reconnect.profileKey)
+      : undefined,
+    parallelSegmentCount,
+  );
   const pipeOptions: PipelinedXferOptions = {
     fileSize,
     onProgress,
@@ -2475,25 +2535,66 @@ async function transferFileData(
     transferId,
     reconnect,
     onResumeOffset,
-    parallelSegmentCount,
+    parallelSegmentCount: tuning.parallelSegmentCount,
+    pipelineConcurrency: tuning.pipelineConcurrency,
   };
 
-  if (isLocalSshEndpoint(destSession.ip)) {
-    return pipelinedSftpToLocalFile(
-      sourceSftp,
-      sourcePath,
-      destPath,
-      pipeOptions,
-    );
+  if (transferId) {
+    updateTransfer(transferId, {
+      parallelSegmentCount: tuning.parallelSegmentCount,
+    });
   }
 
-  return pipelinedSftpFile(
-    sourceSftp,
-    destSftp,
-    sourcePath,
-    destPath,
-    pipeOptions,
-  );
+  const startedAt = Date.now();
+  const shouldProfile = fileSize >= SFTP_XFER_SEGMENT_THRESHOLD;
+  fileLogger.info("Selected adaptive transfer tuning", {
+    operation: "host_transfer_tuning",
+    transferId,
+    fileSize,
+    parallelSegmentCount: tuning.parallelSegmentCount,
+    pipelineConcurrency: tuning.pipelineConcurrency,
+    profileSamples: reconnect?.profileKey
+      ? getTransferProfile(reconnect.profileKey)?.samples
+      : undefined,
+    explicitParallelOverride: parallelSegmentCount !== undefined,
+  });
+  try {
+    const stats = isLocalSshEndpoint(destSession.ip)
+      ? await pipelinedSftpToLocalFile(
+          sourceSftp,
+          sourcePath,
+          destPath,
+          pipeOptions,
+        )
+      : await pipelinedSftpFile(
+          sourceSftp,
+          destSftp,
+          sourcePath,
+          destPath,
+          pipeOptions,
+        );
+    if (shouldProfile && reconnect?.profileKey) {
+      recordTransferProfile(reconnect.profileKey, {
+        bytes: stats.bytes,
+        durationMs: Math.max(1, Date.now() - startedAt),
+        lanes: tuning.parallelSegmentCount,
+        pipelineConcurrency: tuning.pipelineConcurrency,
+        failed: false,
+      });
+    }
+    return stats;
+  } catch (err) {
+    if (shouldProfile && reconnect?.profileKey) {
+      recordTransferProfile(reconnect.profileKey, {
+        bytes: 0,
+        durationMs: Math.max(1, Date.now() - startedAt),
+        lanes: tuning.parallelSegmentCount,
+        pipelineConcurrency: tuning.pipelineConcurrency,
+        failed: true,
+      });
+    }
+    throw err;
+  }
 }
 
 const DIRECT_BENCHMARK_BYTES = 8 * 1024 * 1024;
@@ -2525,6 +2626,13 @@ function directRouteKey(
   endpoint: DirectTransferEndpoint,
 ): string {
   return `${sourceSession.username ?? ""}@${sourceSession.ip}->${endpoint.username}@${endpoint.host}:${endpoint.port}`;
+}
+
+function transferProfileKey(
+  sourceSession: SSHSessionLike,
+  destSession: SSHSessionLike,
+): string {
+  return `${sourceSession.username ?? ""}@${sourceSession.ip ?? "local"}:${sourceSession.port ?? 22}->${destSession.username ?? ""}@${destSession.ip ?? "local"}:${destSession.port ?? 22}`;
 }
 
 async function benchmarkTransferRoutes(
@@ -2786,6 +2894,7 @@ async function transferSingleFile(
   destPath: string,
   move: boolean,
   reconnectMeta: TransferReconnectMeta,
+  requestedParallelSegments?: number,
 ): Promise<TransferProgress> {
   const sourceSftp = await deps.getSessionSftp(sourceSession);
   const destSftp = await deps.getSessionSftp(destSession);
@@ -2827,9 +2936,12 @@ async function transferSingleFile(
     updateTransfer(transferId, { bytesTransferred: absoluteOffset });
   };
 
-  const parallelLanes = clampParallelSegmentCount(
-    activeTransfers.get(transferId)?.parallelSegmentCount,
+  const tuning = selectTransferTuning(
+    stats.size,
+    reconnect.profileKey ? getTransferProfile(reconnect.profileKey) : undefined,
+    requestedParallelSegments,
   );
+  const parallelLanes = tuning.parallelSegmentCount;
   const useAbsoluteProgressOnly = parallelLanes > 1;
 
   throwIfCancelled(transferId);
@@ -2851,7 +2963,7 @@ async function transferSingleFile(
     transferId,
     reconnect,
     syncProgress,
-    parallelLanes,
+    requestedParallelSegments,
   );
 
   await verifyTransferredFile(
@@ -3229,13 +3341,10 @@ async function runTransfer(
     move = false,
     userId,
     methodPreference = "auto",
-    parallelSegmentCount:
-      requestParallelSegments = DEFAULT_PARALLEL_SEGMENT_COUNT,
+    parallelSegmentCount: requestParallelSegments,
   } = request;
 
-  const parallelSegmentCount = clampParallelSegmentCount(
-    requestParallelSegments,
-  );
+  const parallelSegmentCount = requestParallelSegments;
 
   const dedicatedSourceSessionId = `xfer:${transferId}:src`;
   const dedicatedDestSessionId = `xfer:${transferId}:dst`;
@@ -3262,11 +3371,14 @@ async function runTransfer(
       transferId,
     );
 
+    reconnectMeta.profileKey = transferProfileKey(sourceSession, destSession);
+
     sourceSession.lastActive = Date.now();
     destSession.lastActive = Date.now();
 
     updateTransfer(transferId, {
-      parallelSegmentCount,
+      parallelSegmentCount:
+        parallelSegmentCount ?? DEFAULT_PARALLEL_SEGMENT_COUNT,
       dedicatedSourceSessionId,
       dedicatedDestSessionId,
     });
@@ -3341,6 +3453,7 @@ async function runTransfer(
         destPath,
         move,
         reconnectMeta,
+        parallelSegmentCount,
       );
     } else {
       const prepareStart = Date.now();
@@ -3691,10 +3804,7 @@ export function retryHostTransfer(
     await runTransfer(deps, transferId, {
       ...latest.requestSnapshot,
       userId,
-      parallelSegmentCount:
-        latest.requestSnapshot?.parallelSegmentCount ??
-        latest.parallelSegmentCount ??
-        DEFAULT_PARALLEL_SEGMENT_COUNT,
+      parallelSegmentCount: latest.requestSnapshot.parallelSegmentCount,
     });
   })();
 
@@ -3748,14 +3858,11 @@ export async function previewArchiveTransferMethod(
   );
 
   const sourceSftp = await deps.getSessionSftp(sourceSession);
-  const scanItems: Array<{ sourcePath: string; size: number }> = [];
-  for (const sourcePath of sourcePaths) {
-    const work = await collectFileWorkItems(sourceSftp, sourcePath, "/");
-    scanItems.push(
-      ...work.map((w) => ({ sourcePath: w.sourcePath, size: w.size })),
-    );
-  }
-  const scanSummary = buildTransferScanSummary(scanItems);
+  const scanSummary = await scanSourcePathsForRouting(
+    sourceSftp,
+    sourcePaths,
+    "preview",
+  );
 
   const sourceHasTar =
     sourcePlatform === "unix" && (await checkTarAvailable(deps, sourceSession));
@@ -3821,9 +3928,7 @@ export function startHostTransfer(
       destPath: request.destPath,
       move: request.move,
       methodPreference: request.methodPreference,
-      parallelSegmentCount: clampParallelSegmentCount(
-        request.parallelSegmentCount,
-      ),
+      parallelSegmentCount: request.parallelSegmentCount,
     },
   });
 

--- a/src/backend/hosts/file-manager/transfer-routing.ts
+++ b/src/backend/hosts/file-manager/transfer-routing.ts
@@ -1,4 +1,5 @@
 import type { TransferPlatform } from "../transfer-paths.js";
+import { deflateRawSync } from "node:zlib";
 
 export type TransferMethodPreference = "auto" | "tar" | "item_sftp";
 
@@ -8,6 +9,8 @@ export interface TransferScanSummary {
   largestFileBytes: number;
   /** Share of total bytes in likely incompressible file types (0–1). */
   incompressibleRatio: number;
+  /** Share inferred from bounded content samples, when available. */
+  sampledIncompressibleRatio?: number;
 }
 
 const INCOMPRESSIBLE_EXT =
@@ -43,6 +46,15 @@ export function buildTransferScanSummary(
   };
 }
 
+export function estimateIncompressibleSample(data: Buffer): boolean {
+  if (data.length === 0) return false;
+  return deflateRawSync(data, { level: 1 }).length / data.length >= 0.9;
+}
+
+function effectiveIncompressibleRatio(summary: TransferScanSummary): number {
+  return summary.sampledIncompressibleRatio ?? summary.incompressibleRatio;
+}
+
 /**
  * Choose tar vs per-item SFTP for directory / multi-file transfers.
  * Single-file stream transfers bypass this entirely.
@@ -72,8 +84,8 @@ export function resolveArchiveTransferMethod(
     return "item_sftp";
   }
 
-  const { fileCount, totalBytes, largestFileBytes, incompressibleRatio } =
-    summary;
+  const { fileCount, totalBytes, largestFileBytes } = summary;
+  const incompressibleRatio = effectiveIncompressibleRatio(summary);
 
   if (fileCount === 0) {
     return "item_sftp";
@@ -154,8 +166,8 @@ export function getArchiveTransferReasonKey(
     return "tar_unavailable";
   }
 
-  const { fileCount, totalBytes, largestFileBytes, incompressibleRatio } =
-    summary;
+  const { fileCount, totalBytes, largestFileBytes } = summary;
+  const incompressibleRatio = effectiveIncompressibleRatio(summary);
 
   if (
     fileCount > 1 &&

--- a/src/backend/hosts/file-manager/transfer-tuning.ts
+++ b/src/backend/hosts/file-manager/transfer-tuning.ts
@@ -1,0 +1,125 @@
+export interface TransferPerformanceProfile {
+  throughputBps: number;
+  failureRate: number;
+  samples: number;
+  preferredLanes: number;
+  pipelineConcurrency: number;
+  updatedAt: number;
+}
+
+export interface TransferTuning {
+  parallelSegmentCount: number;
+  pipelineConcurrency: number;
+}
+
+const MB = 1024 * 1024;
+const PROFILE_TTL_MS = 24 * 60 * 60 * 1000;
+const profiles = new Map<string, TransferPerformanceProfile>();
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, Math.floor(value)));
+}
+
+export function selectTransferTuning(
+  fileSize: number,
+  profile?: TransferPerformanceProfile,
+  requestedLanes?: number,
+): TransferTuning {
+  if (fileSize < 32 * MB) {
+    return { parallelSegmentCount: 1, pipelineConcurrency: 8 };
+  }
+
+  let lanes = fileSize >= 1024 * MB ? 4 : 2;
+  let pipelineConcurrency = fileSize >= 256 * MB ? 32 : 16;
+
+  if (profile) {
+    lanes = profile.preferredLanes;
+    pipelineConcurrency = profile.pipelineConcurrency;
+    if (profile.failureRate >= 0.2) {
+      lanes = Math.min(lanes, 2);
+      pipelineConcurrency = Math.min(pipelineConcurrency, 16);
+    }
+  }
+
+  if (requestedLanes !== undefined) lanes = requestedLanes;
+
+  const segmentCapacity = Math.max(1, Math.ceil(fileSize / (256 * MB)));
+  return {
+    parallelSegmentCount: clamp(lanes, 1, Math.min(8, segmentCapacity)),
+    pipelineConcurrency: clamp(pipelineConcurrency, 8, 64),
+  };
+}
+
+export function updateTransferProfile(
+  previous: TransferPerformanceProfile | undefined,
+  observation: {
+    bytes: number;
+    durationMs: number;
+    lanes: number;
+    pipelineConcurrency: number;
+    failed: boolean;
+    now?: number;
+  },
+): TransferPerformanceProfile {
+  const now = observation.now ?? Date.now();
+  const throughputBps =
+    observation.durationMs > 0
+      ? (observation.bytes * 1000) / observation.durationMs
+      : 0;
+  const weight = previous ? 0.25 : 1;
+  const smoothedThroughput = previous
+    ? previous.throughputBps * (1 - weight) + throughputBps * weight
+    : throughputBps;
+  const failure = observation.failed ? 1 : 0;
+  const failureRate = previous
+    ? previous.failureRate * (1 - weight) + failure * weight
+    : failure;
+
+  let preferredLanes = observation.lanes;
+  let pipelineConcurrency = observation.pipelineConcurrency;
+  if (failureRate >= 0.2) {
+    preferredLanes = Math.max(1, Math.floor(preferredLanes / 2));
+    pipelineConcurrency = Math.max(8, Math.floor(pipelineConcurrency / 2));
+  } else if (
+    !observation.failed &&
+    previous &&
+    previous.samples >= 2 &&
+    throughputBps > previous.throughputBps * 1.25
+  ) {
+    preferredLanes = Math.min(8, preferredLanes + 1);
+    pipelineConcurrency = Math.min(64, pipelineConcurrency + 8);
+  }
+
+  return {
+    throughputBps: smoothedThroughput,
+    failureRate,
+    samples: (previous?.samples ?? 0) + 1,
+    preferredLanes,
+    pipelineConcurrency,
+    updatedAt: now,
+  };
+}
+
+export function getTransferProfile(
+  key: string,
+  now = Date.now(),
+): TransferPerformanceProfile | undefined {
+  const profile = profiles.get(key);
+  if (!profile) return undefined;
+  if (now - profile.updatedAt <= PROFILE_TTL_MS) return profile;
+  profiles.delete(key);
+  return undefined;
+}
+
+export function recordTransferProfile(
+  key: string,
+  observation: Parameters<typeof updateTransferProfile>[1],
+): TransferPerformanceProfile {
+  const profile = updateTransferProfile(getTransferProfile(key), observation);
+  profiles.set(key, profile);
+  return profile;
+}
+
+export function clearTransferProfiles(): void {
+  profiles.clear();
+}

--- a/src/backend/tests/hosts/file-manager/transfer-routing.test.ts
+++ b/src/backend/tests/hosts/file-manager/transfer-routing.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import {
+  estimateIncompressibleSample,
+  resolveArchiveTransferMethod,
+  type TransferScanSummary,
+} from "../../../hosts/file-manager/transfer-routing.js";
+
+describe("transfer content sampling", () => {
+  it("recognizes repetitive content as compressible", () => {
+    expect(estimateIncompressibleSample(Buffer.alloc(64 * 1024, 65))).toBe(
+      false,
+    );
+  });
+
+  it("recognizes high-entropy content as incompressible", () => {
+    const sample = Buffer.alloc(64 * 1024);
+    let state = 0x12345678;
+    for (let i = 0; i < sample.length; i++) {
+      state ^= state << 13;
+      state ^= state >>> 17;
+      state ^= state << 5;
+      sample[i] = state & 0xff;
+    }
+    expect(estimateIncompressibleSample(sample)).toBe(true);
+  });
+
+  it("prefers sampled content over a misleading extension", () => {
+    const summary: TransferScanSummary = {
+      fileCount: 120,
+      totalBytes: 1024 * 1024 * 1024,
+      largestFileBytes: 32 * 1024 * 1024,
+      incompressibleRatio: 0,
+      sampledIncompressibleRatio: 1,
+    };
+    expect(
+      resolveArchiveTransferMethod("auto", summary, "unix", "unix", true, true),
+    ).toBe("item_sftp");
+  });
+});

--- a/src/backend/tests/hosts/file-manager/transfer-tuning.test.ts
+++ b/src/backend/tests/hosts/file-manager/transfer-tuning.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  clearTransferProfiles,
+  getTransferProfile,
+  recordTransferProfile,
+  selectTransferTuning,
+  updateTransferProfile,
+} from "../../../hosts/file-manager/transfer-tuning.js";
+
+const MB = 1024 * 1024;
+
+describe("adaptive transfer tuning", () => {
+  beforeEach(clearTransferProfiles);
+
+  it("keeps small files on one conservative lane", () => {
+    expect(selectTransferTuning(8 * MB)).toEqual({
+      parallelSegmentCount: 1,
+      pipelineConcurrency: 8,
+    });
+  });
+
+  it("uses more lanes for large transfers without exceeding segment count", () => {
+    expect(selectTransferTuning(2 * 1024 * MB)).toEqual({
+      parallelSegmentCount: 4,
+      pipelineConcurrency: 32,
+    });
+    expect(selectTransferTuning(300 * MB).parallelSegmentCount).toBe(2);
+  });
+
+  it("honours an explicit lane selection", () => {
+    expect(selectTransferTuning(2 * 1024 * MB, undefined, 3)).toMatchObject({
+      parallelSegmentCount: 3,
+    });
+  });
+
+  it("backs off after failures", () => {
+    const profile = updateTransferProfile(undefined, {
+      bytes: 256 * MB,
+      durationMs: 1000,
+      lanes: 4,
+      pipelineConcurrency: 32,
+      failed: true,
+      now: 1,
+    });
+    expect(profile.preferredLanes).toBe(2);
+    expect(profile.pipelineConcurrency).toBe(16);
+  });
+
+  it("learns and expires host-pair profiles", () => {
+    recordTransferProfile("a->b", {
+      bytes: 256 * MB,
+      durationMs: 2000,
+      lanes: 2,
+      pipelineConcurrency: 32,
+      failed: false,
+      now: 100,
+    });
+    expect(getTransferProfile("a->b", 101)?.samples).toBe(1);
+    expect(getTransferProfile("a->b", 25 * 60 * 60 * 1000)).toBeUndefined();
+  });
+});

--- a/src/ui/features/file-manager/FileManager.tsx
+++ b/src/ui/features/file-manager/FileManager.tsx
@@ -1846,7 +1846,7 @@ function FileManagerContent({
     destPath: string,
     destPathLabel: string,
     methodPreference: TransferMethodPreference,
-    parallelSegmentCount: number,
+    parallelSegmentCount?: number,
   ) {
     if (!sshSessionId || !currentHost?.id || transferFiles.length === 0) return;
 

--- a/src/ui/features/file-manager/components/TransferToHostDialog.tsx
+++ b/src/ui/features/file-manager/components/TransferToHostDialog.tsx
@@ -75,7 +75,7 @@ interface TransferToHostDialogProps {
     destPath: string,
     destPathLabel: string,
     methodPreference: TransferMethodPreference,
-    parallelSegmentCount: number,
+    parallelSegmentCount?: number,
   ) => void;
 }
 
@@ -190,7 +190,7 @@ export function TransferToHostDialog({
   const destPathInputRef = useRef<HTMLInputElement>(null);
   const [methodPreference, setMethodPreference] =
     useState<TransferMethodPreference>("auto");
-  const [parallelSegmentCount, setParallelSegmentCount] = useState("2");
+  const [parallelSegmentCount, setParallelSegmentCount] = useState("auto");
   const [methodPreview, setMethodPreview] =
     useState<TransferMethodPreview | null>(null);
   const [methodPreviewLoading, setMethodPreviewLoading] = useState(false);
@@ -664,7 +664,9 @@ export function TransferToHostDialog({
       fullPath,
       destPath.trim(),
       methodPreference,
-      Math.max(1, Math.min(8, parseInt(parallelSegmentCount, 10) || 2)),
+      parallelSegmentCount === "auto"
+        ? undefined
+        : Math.max(1, Math.min(8, parseInt(parallelSegmentCount, 10))),
     );
     onOpenChange(false);
   };
@@ -981,6 +983,7 @@ export function TransferToHostDialog({
                         }
                         className="w-full appearance-none px-2.5 py-1.5 text-xs bg-background border border-border text-foreground outline-none focus:ring-1 focus:ring-ring pr-7"
                       >
+                        <option value="auto">{t("transfer.methodAuto")}</option>
                         {[1, 2, 3, 4].map((n) => (
                           <option key={n} value={n.toString()}>
                             {t("transfer.parallelSegmentsOption", { count: n })}

--- a/src/ui/main-axios.ts
+++ b/src/ui/main-axios.ts
@@ -1315,7 +1315,7 @@ export async function transferToHost(
   destPath: string,
   move?: boolean,
   methodPreference?: TransferMethodPreference,
-  parallelSegmentCount = 2,
+  parallelSegmentCount?: number,
 ): Promise<{ transferId: string }> {
   try {
     fileLogger.info("Starting host transfer", {


### PR DESCRIPTION
## Summary

- make automatic lane selection the default while preserving explicit overrides
- tune SFTP pipeline depth and lane count from file size plus a bounded host-pair EWMA profile
- back off concurrency after failures and expire learned profiles after 24 hours
- sample at most three 64 KiB file regions to improve tar routing beyond filename extensions
- keep SHA-256 verification and existing relay/direct fallback behavior unchanged

Closes Termix-SSH/Support#1150

## Validation

- `npm run lint` (0 errors; existing warnings only)
- `npm run type-check`
- `npm run build`
- targeted transfer tests: 13 passed
- full suite: 2262 passed, 1 skipped; one unrelated session-log test timed out under full-suite load and passed twice when rerun in isolation