### PR TITLE
feat: adapt background polling to activity

### DIFF
--- a/src/ui/api/tunnel-api.ts
+++ b/src/ui/api/tunnel-api.ts
@@ -13,6 +13,7 @@ import type {
   TunnelStatus,
 } from "@/types/index";
 import { streamServerSentEvents } from "./sse-stream";
+import { runAdaptivePolling } from "@/lib/adaptive-polling";
 
 // TUNNEL MANAGEMENT
 // ============================================================================
@@ -70,7 +71,7 @@ export function subscribeTunnelStatuses(
 
   let latestLocal: Record<string, TunnelStatus> = {};
   let latestRemote: Record<string, TunnelStatus> = {};
-  let remotePollTimer: ReturnType<typeof setInterval> | null = null;
+  let stopRemotePolling: (() => void) | null = null;
 
   const emitMerged = () => {
     onStatuses({ ...latestLocal, ...latestRemote });
@@ -128,23 +129,31 @@ export function subscribeTunnelStatuses(
   // Remote tunnel status has no SSE stream exposed to the desktop app yet,
   // so poll it at a modest interval when a remote server is connected.
   isRemoteSyncConnected().then((connected) => {
-    if (!connected) return;
-    const pollRemote = async () => {
-      try {
+    if (!connected || controller.signal.aborted) return;
+    let signature = "";
+    stopRemotePolling = runAdaptivePolling(
+      async () => {
         const result = await getRemoteTunnelApi().get("/tunnel/status");
-        latestRemote = result.data || {};
+        const next = result.data || {};
+        const nextSignature = JSON.stringify(next);
+        const changed = nextSignature !== signature;
+        signature = nextSignature;
+        latestRemote = next;
         emitMerged();
-      } catch {
-        // remote unreachable this tick -- keep last known remote statuses
-      }
-    };
-    pollRemote();
-    remotePollTimer = setInterval(pollRemote, 5000);
+        return changed;
+      },
+      {
+        minIntervalMs: 5000,
+        maxIntervalMs: 30000,
+        stablePollsPerStep: 3,
+      },
+      { enabled: () => !controller.signal.aborted },
+    );
   });
 
   return () => {
     controller.abort();
-    if (remotePollTimer) clearInterval(remotePollTimer);
+    stopRemotePolling?.();
   };
 }
 

--- a/src/ui/features/docker/DockerManager.tsx
+++ b/src/ui/features/docker/DockerManager.tsx
@@ -39,6 +39,7 @@ import {
 } from "@/ssh/connection-log/ConnectionLogContext.tsx";
 import { ConnectionScreen } from "@/components/connection/ConnectionScreen.tsx";
 import { useConnectionRetry } from "@/lib/useConnectionRetry.ts";
+import { useAdaptivePolling } from "@/hooks/use-adaptive-polling.ts";
 import type { LogEntry } from "@/types/connection-log.ts";
 
 interface DockerManagerProps {
@@ -72,6 +73,7 @@ function DockerManagerInner({
   const [currentHostConfig, setCurrentHostConfig] = React.useState(hostConfig);
   const [sessionId, setSessionId] = React.useState<string | null>(null);
   const [containers, setContainers] = React.useState<DockerContainer[]>([]);
+  const containersSignatureRef = React.useRef("");
   const [selectedContainer, setSelectedContainer] = React.useState<
     string | null
   >(null);
@@ -319,39 +321,34 @@ function DockerManagerInner({
     setHasLoadedContainersOnce(false);
   }, [sessionId]);
 
-  React.useEffect(() => {
-    if (!sessionId || !isVisible || !dockerValidation?.available) return;
-
-    let cancelled = false;
-
-    const pollContainers = async () => {
-      try {
-        setIsLoadingContainers(true);
-        const data = await listDockerContainers(sessionId, true);
-        if (!cancelled) {
-          setContainers(data);
-        }
-      } catch {
-        // Silently handle polling errors
-      } finally {
-        if (!cancelled) {
-          setIsLoadingContainers(false);
-          setHasLoadedContainersOnce(true);
-        }
-      }
-    };
-
-    pollContainers();
-    const interval = setInterval(() => {
-      if (document.visibilityState === "hidden") return;
-      void pollContainers();
-    }, 5000);
-
-    return () => {
-      cancelled = true;
-      clearInterval(interval);
-    };
-  }, [sessionId, isVisible, dockerValidation?.available]);
+  useAdaptivePolling(
+    async () => {
+      if (!sessionId) return;
+      setIsLoadingContainers((loading) =>
+        hasLoadedContainersOnce ? loading : true,
+      );
+      const data = await listDockerContainers(sessionId, true);
+      const signature = JSON.stringify(data);
+      const changed = signature !== containersSignatureRef.current;
+      containersSignatureRef.current = signature;
+      setContainers(data);
+      setIsLoadingContainers(false);
+      setHasLoadedContainersOnce(true);
+      return changed;
+    },
+    {
+      minIntervalMs: 5000,
+      maxIntervalMs: 30000,
+      stablePollsPerStep: 3,
+    },
+    !!sessionId && isVisible && !!dockerValidation?.available,
+    {
+      onError: () => {
+        setIsLoadingContainers(false);
+        setHasLoadedContainersOnce(true);
+      },
+    },
+  );
 
   const handleBack = React.useCallback(() => {
     setViewMode("list");

--- a/src/ui/features/file-manager/TransferMonitor.tsx
+++ b/src/ui/features/file-manager/TransferMonitor.tsx
@@ -12,6 +12,7 @@ import {
   getPendingTransferIds,
   isTransferNotified,
 } from "./transferNotificationStore.ts";
+import { runAdaptivePolling } from "@/lib/adaptive-polling.ts";
 
 const POLL_INTERVAL_MS = 2000;
 
@@ -24,8 +25,10 @@ export function TransferMonitor() {
 
   useEffect(() => {
     const reconcileTransfers = async () => {
+      let hasWork = false;
       try {
         const { transfers } = await listActiveTransfers();
+        hasWork = transfers.length > 0;
         for (const transfer of transfers) {
           if (isTransferBeingMonitored(transfer.transferId)) continue;
           beginTransferProgressMonitoring(transfer.transferId, t, {
@@ -38,13 +41,15 @@ export function TransferMonitor() {
         // Non-fatal: file-manager service may be unavailable briefly
       }
 
-      for (const transferId of getPendingTransferIds()) {
+      const pendingTransferIds = getPendingTransferIds();
+      for (const transferId of pendingTransferIds) {
         if (
           isTransferBeingMonitored(transferId) ||
           isTransferNotified(transferId)
         ) {
           continue;
         }
+        hasWork = true;
 
         try {
           const status = await getTransferStatus(transferId);
@@ -69,36 +74,14 @@ export function TransferMonitor() {
           clearStalePendingTransfer(transferId);
         }
       }
+      return hasWork;
     };
 
-    let intervalId: ReturnType<typeof setInterval> | null = null;
-
-    const start = () => {
-      if (intervalId !== null) return;
-      intervalId = setInterval(reconcileTransfers, POLL_INTERVAL_MS);
-    };
-    const stop = () => {
-      if (intervalId === null) return;
-      clearInterval(intervalId);
-      intervalId = null;
-    };
-    const onVisibility = () => {
-      if (document.visibilityState === "hidden") {
-        stop();
-        return;
-      }
-      void reconcileTransfers();
-      start();
-    };
-
-    void reconcileTransfers();
-    if (document.visibilityState !== "hidden") start();
-    document.addEventListener("visibilitychange", onVisibility);
-
-    return () => {
-      stop();
-      document.removeEventListener("visibilitychange", onVisibility);
-    };
+    return runAdaptivePolling(reconcileTransfers, {
+      minIntervalMs: POLL_INTERVAL_MS,
+      maxIntervalMs: 30_000,
+      stablePollsPerStep: 1,
+    });
   }, [t, formatTransferMetrics]);
 
   return null;

--- a/src/ui/features/host-metrics/HostMetricsTab.tsx
+++ b/src/ui/features/host-metrics/HostMetricsTab.tsx
@@ -40,6 +40,7 @@ import {
 } from "@/ssh/connection-log/ConnectionLogContext.tsx";
 import { ConnectionScreen } from "@/components/connection/ConnectionScreen.tsx";
 import { useConnectionRetry } from "@/lib/useConnectionRetry.ts";
+import { runAdaptivePolling } from "@/lib/adaptive-polling.ts";
 import type { LogEntry } from "@/types/connection-log.ts";
 import {
   CardGridCanvas,
@@ -57,6 +58,19 @@ import {
 } from "./cards";
 
 const HISTORY_LEN = 30;
+
+function metricsChangeKey(data: ServerMetrics): string {
+  const bucket = (value: number | null | undefined) =>
+    value == null ? null : Math.round(value / 5) * 5;
+  return JSON.stringify({
+    cpu: bucket(data.cpu.percent),
+    memory: bucket(data.memory.percent),
+    disk: bucket(data.disk.percent),
+    running: data.processes?.running ?? null,
+    ports: data.ports?.ports?.length ?? 0,
+    firewall: data.firewall?.status ?? null,
+  });
+}
 
 interface QuickAction {
   name: string;
@@ -305,24 +319,31 @@ function HostMetricsInner({
       return;
     }
     let cancelled = false;
+    let lastStatus = serverStatus;
     const fetchStatus = async () => {
       try {
         const res = await getServerStatusById(currentHostConfig.id);
+        const nextStatus = res?.status === "online" ? "online" : "offline";
         if (!cancelled) {
-          setServerStatus(res?.status === "online" ? "online" : "offline");
+          setServerStatus(nextStatus);
         }
+        const changed = nextStatus !== lastStatus;
+        lastStatus = nextStatus;
+        return changed;
       } catch {
         if (!cancelled) setServerStatus("offline");
+        throw new Error("Host status check failed");
       }
     };
-    fetchStatus();
-    const id = window.setInterval(
-      fetchStatus,
-      statsConfig.statusCheckInterval * 1000,
-    );
+    const minIntervalMs = statsConfig.statusCheckInterval * 1000;
+    const stop = runAdaptivePolling(fetchStatus, {
+      minIntervalMs,
+      maxIntervalMs: Math.min(120_000, minIntervalMs * 6),
+      stablePollsPerStep: 3,
+    });
     return () => {
       cancelled = true;
-      window.clearInterval(id);
+      stop();
     };
   }, [
     currentHostConfig?.id,
@@ -331,7 +352,7 @@ function HostMetricsInner({
     isActuallyVisible,
   ]);
 
-  const metricsPollingIdRef = React.useRef<number | undefined>(undefined);
+  const stopMetricsPollingRef = React.useRef<(() => void) | null>(null);
 
   const fetchMetrics = React.useCallback(async (): Promise<void> => {
     if (!currentHostConfig?.id) return;
@@ -375,17 +396,27 @@ function HostMetricsInner({
       message: t("terminal.connected"),
     });
 
-    metricsPollingIdRef.current = window.setInterval(async () => {
-      try {
+    let signature = metricsChangeKey(data);
+    const minIntervalMs = statsConfig.metricsInterval * 1000;
+    stopMetricsPollingRef.current?.();
+    stopMetricsPollingRef.current = runAdaptivePolling(
+      async () => {
         const next = await getServerMetricsById(currentHostConfig.id);
-        if (next) {
-          setMetrics(next);
-          pushHistory(next);
-        }
-      } catch {
-        /* keep prior */
-      }
-    }, statsConfig.metricsInterval * 1000);
+        if (!next) throw new Error(t("hostMetrics.connectionFailed"));
+        const nextSignature = metricsChangeKey(next);
+        const changed = nextSignature !== signature;
+        signature = nextSignature;
+        setMetrics(next);
+        pushHistory(next);
+        return changed;
+      },
+      {
+        minIntervalMs,
+        maxIntervalMs: Math.min(120_000, minIntervalMs * 6),
+        stablePollsPerStep: 3,
+      },
+      { runImmediately: false },
+    );
   }, [
     currentHostConfig,
     totpVerified,
@@ -436,10 +467,8 @@ function HostMetricsInner({
     let cancelled = false;
 
     const stopMetrics = async () => {
-      if (metricsPollingIdRef.current) {
-        window.clearInterval(metricsPollingIdRef.current);
-        metricsPollingIdRef.current = undefined;
-      }
+      stopMetricsPollingRef.current?.();
+      stopMetricsPollingRef.current = null;
       if (currentHostConfig?.id) {
         await stopMetricsPolling(
           currentHostConfig.id,
@@ -462,10 +491,8 @@ function HostMetricsInner({
     return () => {
       cancelled = true;
       clearTimeout(debounce);
-      if (metricsPollingIdRef.current) {
-        window.clearInterval(metricsPollingIdRef.current);
-        metricsPollingIdRef.current = undefined;
-      }
+      stopMetricsPollingRef.current?.();
+      stopMetricsPollingRef.current = null;
       if (currentHostConfig?.id) {
         stopMetricsPolling(currentHostConfig.id).catch(() => {});
       }

--- a/src/ui/features/proxmox-stats/ProxmoxStatsTab.tsx
+++ b/src/ui/features/proxmox-stats/ProxmoxStatsTab.tsx
@@ -23,8 +23,21 @@ import {
   useConnectionLog,
 } from "@/ssh/connection-log/ConnectionLogContext.tsx";
 import { useConnectionRetry } from "@/lib/useConnectionRetry.ts";
+import { runAdaptivePolling } from "@/lib/adaptive-polling.ts";
 
 const HISTORY_LEN = 30;
+
+function statsChangeKey(data: ProxmoxStatsSnapshot): string {
+  const bucket = (value: number | null | undefined) =>
+    value == null ? null : Math.round(value / 5) * 5;
+  return JSON.stringify({
+    cpu: bucket(data.node.cpu.percent),
+    memory: bucket(data.node.memory.percent),
+    disk: bucket(data.node.disk.percent),
+    guests: data.guests.counts,
+    cluster: data.cluster,
+  });
+}
 const DEFAULT_POLL_INTERVAL = 60;
 
 interface HostConfig {
@@ -158,7 +171,7 @@ function ProxmoxStatsInner({
   }, []);
 
   const notEnabled = currentHostConfig?.enableProxmoxStats !== true;
-  const pollingIdRef = React.useRef<number | undefined>(undefined);
+  const stopPollingRef = React.useRef<(() => void) | null>(null);
 
   const fetchSnapshot = React.useCallback(async (): Promise<void> => {
     if (!currentHostConfig?.id) return;
@@ -192,17 +205,26 @@ function ProxmoxStatsInner({
 
     const intervalMs =
       (statsConfig.pollInterval ?? DEFAULT_POLL_INTERVAL) * 1000;
-    pollingIdRef.current = window.setInterval(async () => {
-      try {
+    let signature = statsChangeKey(data);
+    stopPollingRef.current?.();
+    stopPollingRef.current = runAdaptivePolling(
+      async () => {
         const next = await getProxmoxStats(currentHostConfig.id);
-        if (next) {
-          setSnapshot(next);
-          pushHistory(next);
-        }
-      } catch {
-        /* keep prior */
-      }
-    }, intervalMs);
+        if (!next) throw new Error(t("proxmoxStats.connectionFailed"));
+        const nextSignature = statsChangeKey(next);
+        const changed = nextSignature !== signature;
+        signature = nextSignature;
+        setSnapshot(next);
+        pushHistory(next);
+        return changed;
+      },
+      {
+        minIntervalMs: intervalMs,
+        maxIntervalMs: Math.min(120_000, intervalMs * 6),
+        stablePollsPerStep: 3,
+      },
+      { runImmediately: false },
+    );
   }, [currentHostConfig?.id, statsConfig.pollInterval, addLog, t, pushHistory]);
 
   const retry = useConnectionRetry({
@@ -239,10 +261,8 @@ function ProxmoxStatsInner({
         retryRef.current.reset();
         retryRef.current.retryNow();
       } else if (!isActuallyVisible) {
-        if (pollingIdRef.current) {
-          window.clearInterval(pollingIdRef.current);
-          pollingIdRef.current = undefined;
-        }
+        stopPollingRef.current?.();
+        stopPollingRef.current = null;
         if (currentHostConfig?.id) {
           stopProxmoxStatsPolling(currentHostConfig.id, undefined).catch(
             () => {},
@@ -254,10 +274,8 @@ function ProxmoxStatsInner({
     return () => {
       cancelled = true;
       clearTimeout(debounce);
-      if (pollingIdRef.current) {
-        window.clearInterval(pollingIdRef.current);
-        pollingIdRef.current = undefined;
-      }
+      stopPollingRef.current?.();
+      stopPollingRef.current = null;
       if (currentHostConfig?.id) {
         stopProxmoxStatsPolling(currentHostConfig.id).catch(() => {});
       }

--- a/src/ui/features/tmux-monitor/TmuxMonitor.tsx
+++ b/src/ui/features/tmux-monitor/TmuxMonitor.tsx
@@ -47,6 +47,7 @@ import {
   type TmuxSearchResult,
 } from "@/api/tmux-monitor-api";
 import type { TerminalHandle } from "@/features/terminal/Terminal";
+import { useAdaptivePolling } from "@/hooks/use-adaptive-polling";
 import { SessionTree, type SessionMetricsAgg } from "./SessionTree";
 import { SearchResults } from "./SearchResults";
 import { PanePreview } from "./PanePreview";
@@ -116,6 +117,8 @@ export function TmuxMonitor({
   // stale (the user switched away while the request was in flight) and must
   // not overwrite the current tree.
   const activeHostRef = useRef<number | null>(null);
+  const overviewSignatureRef = useRef("");
+  const metricsSignatureRef = useRef("");
   // True when the expanded-session set for the current host was restored from
   // localStorage (or touched by the user) and must not be overwritten by the
   // default expand-all behavior.
@@ -256,12 +259,15 @@ export function TmuxMonitor({
       try {
         const data = await getTmuxOverview(hostId);
         if (activeHostRef.current !== hostId) return true;
+        const signature = JSON.stringify(data);
+        const changed = signature !== overviewSignatureRef.current;
+        overviewSignatureRef.current = signature;
         setOverview(data);
         setExpandedSessions((prev) => {
           if (expandedRestoredRef.current || prev.size > 0) return prev;
           return new Set(data.sessions.map((s) => s.name));
         });
-        return true;
+        return changed;
       } catch (err) {
         if (activeHostRef.current !== hostId) return true;
         if (!silent) {
@@ -293,6 +299,7 @@ export function TmuxMonitor({
             );
           }
         }
+        if (silent) throw err;
         return false;
       } finally {
         if (!silent && activeHostRef.current === hostId)
@@ -343,33 +350,36 @@ export function TmuxMonitor({
   // Poll only while this app tab is shown: the component stays mounted when
   // the user switches tabs (AppShell keeps tab content alive) and would
   // otherwise keep running SSH execs against the host forever.
-  useEffect(() => {
-    if (selectedHostId === null || !isVisible) return;
-    const interval = setInterval(() => {
-      if (!document.hidden) loadOverview(selectedHostId, true);
-    }, OVERVIEW_POLL_MS);
-    return () => clearInterval(interval);
-  }, [selectedHostId, isVisible, loadOverview]);
+  useAdaptivePolling(
+    () =>
+      selectedHostId === null ? undefined : loadOverview(selectedHostId, true),
+    {
+      minIntervalMs: OVERVIEW_POLL_MS,
+      maxIntervalMs: 60_000,
+      stablePollsPerStep: 3,
+    },
+    selectedHostId !== null && isVisible,
+    { runImmediately: false },
+  );
 
   // -- metrics polling ------------------------------------------------------
-  useEffect(() => {
-    if (selectedHostId === null || !overview?.available || !isVisible) return;
-    let cancelled = false;
-    const load = () => {
-      if (document.hidden) return;
-      getTmuxMetrics(selectedHostId)
-        .then((m) => {
-          if (!cancelled) setMetrics(m);
-        })
-        .catch(() => {});
-    };
-    load();
-    const interval = setInterval(load, METRICS_POLL_MS);
-    return () => {
-      cancelled = true;
-      clearInterval(interval);
-    };
-  }, [selectedHostId, overview?.available, isVisible]);
+  useAdaptivePolling(
+    async () => {
+      if (selectedHostId === null) return;
+      const next = await getTmuxMetrics(selectedHostId);
+      const signature = JSON.stringify(next);
+      const changed = signature !== metricsSignatureRef.current;
+      metricsSignatureRef.current = signature;
+      setMetrics(next);
+      return changed;
+    },
+    {
+      minIntervalMs: METRICS_POLL_MS,
+      maxIntervalMs: 60_000,
+      stablePollsPerStep: 3,
+    },
+    selectedHostId !== null && !!overview?.available && isVisible,
+  );
 
   // -- keyboard shortcuts -----------------------------------------------------
   // Gated on isVisible: the listener is global, and a hidden-but-mounted tab

--- a/src/ui/hooks/use-adaptive-polling.ts
+++ b/src/ui/hooks/use-adaptive-polling.ts
@@ -1,0 +1,50 @@
+import { useEffect, useRef } from "react";
+import {
+  runAdaptivePolling,
+  type AdaptivePollResult,
+  type AdaptivePollingPolicy,
+} from "@/lib/adaptive-polling.ts";
+
+export function useAdaptivePolling(
+  poll: () => AdaptivePollResult | Promise<AdaptivePollResult>,
+  policy: AdaptivePollingPolicy,
+  enabled = true,
+  options: {
+    runImmediately?: boolean;
+    onError?: (error: unknown) => void;
+  } = {},
+): void {
+  const pollRef = useRef(poll);
+  const errorRef = useRef(options.onError);
+  pollRef.current = poll;
+  errorRef.current = options.onError;
+  const { minIntervalMs, maxIntervalMs, stablePollsPerStep, jitterRatio } =
+    policy;
+  const runImmediately = options.runImmediately;
+
+  useEffect(
+    () =>
+      runAdaptivePolling(
+        () => pollRef.current(),
+        {
+          minIntervalMs,
+          maxIntervalMs,
+          stablePollsPerStep,
+          jitterRatio,
+        },
+        {
+          enabled: () => enabled,
+          runImmediately,
+          onError: (error) => errorRef.current?.(error),
+        },
+      ),
+    [
+      enabled,
+      jitterRatio,
+      maxIntervalMs,
+      minIntervalMs,
+      runImmediately,
+      stablePollsPerStep,
+    ],
+  );
+}

--- a/src/ui/lib/ServerStatusContext.tsx
+++ b/src/ui/lib/ServerStatusContext.tsx
@@ -16,6 +16,7 @@ import {
   type ServerStatusEntry,
   type StatusValue,
 } from "./server-status-store";
+import { runAdaptivePolling } from "./adaptive-polling";
 
 interface ServerStatusContextType {
   statuses: Map<number, ServerStatusEntry>;
@@ -47,7 +48,7 @@ export function ServerStatusProvider({
   // Bumps only full-context consumers (dashboard, folder counts, etc.).
   const [version, setVersion] = useState(0);
   const mountedRef = useRef(true);
-  const refreshInFlightRef = useRef<Promise<void> | null>(null);
+  const refreshInFlightRef = useRef<Promise<boolean | void> | null>(null);
 
   useEffect(() => {
     return store.subscribeAll(() => {
@@ -96,65 +97,82 @@ export function ServerStatusProvider({
     }
   }, [isAuthenticated, store]);
 
-  const refreshStatuses = useCallback(async () => {
-    if (!mountedRef.current || !isAuthenticated) return;
-    if (
-      typeof document !== "undefined" &&
-      document.visibilityState === "hidden"
-    ) {
-      return;
-    }
-
-    if (refreshInFlightRef.current) {
-      return refreshInFlightRef.current;
-    }
-
-    const showLoading = !store.getInitialLoadComplete();
-    if (showLoading) store.setLoading(true);
-
-    const run = (async () => {
-      try {
-        const data = await getAllServerStatuses();
-        if (!mountedRef.current) return;
-
-        const newStatuses = new Map<number, ServerStatusEntry>();
-        const now = new Date().toISOString();
-
-        if (data && typeof data === "object") {
-          Object.entries(data).forEach(([idStr, statusData]) => {
-            const id = parseInt(idStr, 10);
-            if (!isNaN(id)) {
-              const status =
-                statusData?.status === "online" ||
-                statusData?.status === "reachable"
-                  ? statusData.status
-                  : "offline";
-              newStatuses.set(id, {
-                status,
-                lastChecked: statusData?.lastChecked || now,
-              });
-            }
-          });
-        }
-
-        store.applyStatuses(newStatuses);
-      } catch {
-        if (mountedRef.current) {
-          store.markDegraded(store.getEnabledHostIds());
-        }
-      } finally {
-        if (mountedRef.current) {
-          if (showLoading) store.setLoading(false);
-          store.setInitialLoadComplete(true);
-        }
+  const refreshStatusesImpl = useCallback(
+    async (rethrow = false) => {
+      if (!mountedRef.current || !isAuthenticated) return;
+      if (
+        typeof document !== "undefined" &&
+        document.visibilityState === "hidden"
+      ) {
+        return;
       }
-    })();
 
-    refreshInFlightRef.current = run.finally(() => {
-      refreshInFlightRef.current = null;
-    });
-    return refreshInFlightRef.current;
-  }, [isAuthenticated, store]);
+      if (refreshInFlightRef.current) {
+        return refreshInFlightRef.current;
+      }
+
+      const showLoading = !store.getInitialLoadComplete();
+      if (showLoading) store.setLoading(true);
+
+      const run = (async () => {
+        try {
+          const data = await getAllServerStatuses();
+          if (!mountedRef.current) return;
+
+          const newStatuses = new Map<number, ServerStatusEntry>();
+          const now = new Date().toISOString();
+
+          if (data && typeof data === "object") {
+            Object.entries(data).forEach(([idStr, statusData]) => {
+              const id = parseInt(idStr, 10);
+              if (!isNaN(id)) {
+                const status =
+                  statusData?.status === "online" ||
+                  statusData?.status === "reachable"
+                    ? statusData.status
+                    : "offline";
+                newStatuses.set(id, {
+                  status,
+                  lastChecked: statusData?.lastChecked || now,
+                });
+              }
+            });
+          }
+
+          const previousStatuses = store.getStatuses();
+          const changed =
+            previousStatuses.size !== newStatuses.size ||
+            [...newStatuses].some(
+              ([id, entry]) =>
+                previousStatuses.get(id)?.status !== entry.status,
+            );
+          store.applyStatuses(newStatuses);
+          return changed;
+        } catch (error) {
+          if (mountedRef.current) {
+            store.markDegraded(store.getEnabledHostIds());
+          }
+          if (rethrow) throw error;
+          return false;
+        } finally {
+          if (mountedRef.current) {
+            if (showLoading) store.setLoading(false);
+            store.setInitialLoadComplete(true);
+          }
+        }
+      })();
+
+      refreshInFlightRef.current = run.finally(() => {
+        refreshInFlightRef.current = null;
+      });
+      return refreshInFlightRef.current;
+    },
+    [isAuthenticated, store],
+  );
+
+  const refreshStatuses = useCallback(async () => {
+    await refreshStatusesImpl();
+  }, [refreshStatusesImpl]);
 
   const getStatus = useCallback(
     (hostId: number): StatusValue => store.getStatus(hostId),
@@ -164,52 +182,29 @@ export function ServerStatusProvider({
   useEffect(() => {
     mountedRef.current = true;
 
-    let intervalId: ReturnType<typeof setInterval> | null = null;
-
-    const startPolling = () => {
-      if (intervalId !== null) return;
-      intervalId = setInterval(() => {
-        void refreshStatuses();
-      }, POLL_INTERVAL);
-    };
-
-    const stopPolling = () => {
-      if (intervalId === null) return;
-      clearInterval(intervalId);
-      intervalId = null;
-    };
+    let stopPolling: (() => void) | null = null;
 
     const init = async () => {
       await fetchEnabledHosts();
-      await refreshStatuses();
-      if (
-        mountedRef.current &&
-        (typeof document === "undefined" ||
-          document.visibilityState !== "hidden")
-      ) {
-        startPolling();
-      }
+      if (!mountedRef.current) return;
+      stopPolling = runAdaptivePolling(
+        () => refreshStatusesImpl(true),
+        {
+          minIntervalMs: POLL_INTERVAL,
+          maxIntervalMs: 120_000,
+          stablePollsPerStep: 3,
+        },
+        { enabled: () => isAuthenticated },
+      );
     };
 
     void init();
 
-    const onVisibility = () => {
-      if (document.visibilityState === "hidden") {
-        stopPolling();
-        return;
-      }
-      void refreshStatuses();
-      startPolling();
-    };
-
-    document.addEventListener("visibilitychange", onVisibility);
-
     return () => {
       mountedRef.current = false;
-      stopPolling();
-      document.removeEventListener("visibilitychange", onVisibility);
+      stopPolling?.();
     };
-  }, [fetchEnabledHosts, refreshStatuses]);
+  }, [fetchEnabledHosts, isAuthenticated, refreshStatusesImpl]);
 
   useEffect(() => {
     const handleHostsChanged = async () => {

--- a/src/ui/lib/adaptive-polling.ts
+++ b/src/ui/lib/adaptive-polling.ts
@@ -1,0 +1,111 @@
+export interface AdaptivePollingPolicy {
+  minIntervalMs: number;
+  maxIntervalMs: number;
+  stablePollsPerStep?: number;
+  jitterRatio?: number;
+}
+
+export interface AdaptivePollingState {
+  stablePolls: number;
+  consecutiveFailures: number;
+}
+
+export type AdaptivePollResult = boolean | void;
+
+export function computeAdaptivePollDelay(
+  policy: AdaptivePollingPolicy,
+  state: AdaptivePollingState,
+  random = Math.random,
+): number {
+  const min = Math.max(250, policy.minIntervalMs);
+  const max = Math.max(min, policy.maxIntervalMs);
+  const stableStep = Math.floor(
+    state.stablePolls / Math.max(1, policy.stablePollsPerStep ?? 3),
+  );
+  const exponent = state.consecutiveFailures || stableStep;
+  const base = Math.min(max, min * 2 ** Math.min(exponent, 10));
+  const jitterRatio = Math.max(0, Math.min(0.5, policy.jitterRatio ?? 0.1));
+  const jitter = base * jitterRatio * (random() * 2 - 1);
+  return Math.max(min, Math.min(max, Math.round(base + jitter)));
+}
+
+export function runAdaptivePolling(
+  poll: () => AdaptivePollResult | Promise<AdaptivePollResult>,
+  policy: AdaptivePollingPolicy,
+  options: {
+    enabled?: () => boolean;
+    visible?: () => boolean;
+    runImmediately?: boolean;
+    random?: () => number;
+    onError?: (error: unknown) => void;
+  } = {},
+): () => void {
+  const enabled = options.enabled ?? (() => true);
+  const visible =
+    options.visible ??
+    (() =>
+      typeof document === "undefined" || document.visibilityState !== "hidden");
+  const state: AdaptivePollingState = {
+    stablePolls: 0,
+    consecutiveFailures: 0,
+  };
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  let stopped = false;
+  let inFlight = false;
+
+  const clearTimer = () => {
+    if (!timer) return;
+    clearTimeout(timer);
+    timer = null;
+  };
+
+  const schedule = () => {
+    clearTimer();
+    if (stopped || !enabled() || !visible()) return;
+    timer = setTimeout(
+      () => void tick(),
+      computeAdaptivePollDelay(policy, state, options.random),
+    );
+  };
+
+  const tick = async () => {
+    if (stopped || inFlight || !enabled() || !visible()) return;
+    inFlight = true;
+    try {
+      const changed = await poll();
+      state.consecutiveFailures = 0;
+      state.stablePolls = changed === false ? state.stablePolls + 1 : 0;
+    } catch (error) {
+      state.stablePolls = 0;
+      state.consecutiveFailures += 1;
+      options.onError?.(error);
+    } finally {
+      inFlight = false;
+      schedule();
+    }
+  };
+
+  const onVisibility = () => {
+    if (!visible()) {
+      clearTimer();
+      return;
+    }
+    state.stablePolls = 0;
+    state.consecutiveFailures = 0;
+    void tick();
+  };
+
+  if (typeof document !== "undefined") {
+    document.addEventListener("visibilitychange", onVisibility);
+  }
+  if (options.runImmediately ?? true) void tick();
+  else schedule();
+
+  return () => {
+    stopped = true;
+    clearTimer();
+    if (typeof document !== "undefined") {
+      document.removeEventListener("visibilitychange", onVisibility);
+    }
+  };
+}

--- a/src/ui/lib/useConnectionRetry.ts
+++ b/src/ui/lib/useConnectionRetry.ts
@@ -22,6 +22,21 @@ interface UseConnectionRetryResult {
 }
 
 const COUNTDOWN_TICK_MS = 250;
+const RETRY_JITTER_RATIO = 0.1;
+
+export function computeReconnectDelay(
+  attempt: number,
+  baseDelayMs: number,
+  maxDelayMs: number,
+  random = Math.random,
+): number {
+  const base = Math.min(
+    baseDelayMs * Math.pow(2, Math.max(0, attempt - 1)),
+    maxDelayMs,
+  );
+  const jitter = base * RETRY_JITTER_RATIO * (random() * 2 - 1);
+  return Math.max(baseDelayMs, Math.min(maxDelayMs, Math.round(base + jitter)));
+}
 
 // Backoff curve mirrors Terminal.tsx's proven attemptReconnection(): 2s, 4s,
 // 8s, capped at 8s, up to 8 attempts before falling back to a manual retry.
@@ -77,8 +92,9 @@ export function useConnectionRetry({
     attemptRef.current += 1;
     setAttempt(attemptRef.current);
 
-    const delay = Math.min(
-      baseDelayMs * Math.pow(2, attemptRef.current - 1),
+    const delay = computeReconnectDelay(
+      attemptRef.current,
+      baseDelayMs,
       maxDelayMs,
     );
 

--- a/src/ui/sidebar/ConnectionsPanel.tsx
+++ b/src/ui/sidebar/ConnectionsPanel.tsx
@@ -19,6 +19,7 @@ import {
   TooltipTrigger,
 } from "@/components/tooltip";
 import { usePageVisibleInterval } from "@/hooks/use-page-visible-interval";
+import { useAdaptivePolling } from "@/hooks/use-adaptive-polling";
 
 const CONNECTION_TAB_TYPES: TabType[] = [
   "terminal",
@@ -314,6 +315,8 @@ export function ConnectionsPanel({
   const { t } = useTranslation();
   const [now, setNow] = useState(Date.now());
   const [activeSessions, setActiveSessions] = useState<ActiveSessionInfo[]>([]);
+  const activeSessionsRef = useRef(activeSessions);
+  activeSessionsRef.current = activeSessions;
   const [search, setSearch] = useState("");
 
   // Drag-to-reorder state
@@ -371,22 +374,21 @@ export function ConnectionsPanel({
   usePageVisibleInterval(() => setNow(Date.now()), 15_000);
 
   const refresh = useCallback(async () => {
-    try {
-      const sessions = await getActiveSessions();
-      setActiveSessions((prev) => {
-        const next = Array.isArray(sessions) ? sessions : [];
-        if (sessionsUnchanged(prev, next)) return prev;
-        return next;
-      });
-    } catch {
-      // silently ignore
+    const sessions = await getActiveSessions();
+    const next = Array.isArray(sessions) ? sessions : [];
+    const changed = !sessionsUnchanged(activeSessionsRef.current, next);
+    if (changed) {
+      activeSessionsRef.current = next;
+      setActiveSessions(next);
     }
+    return changed;
   }, []);
 
-  // Initial fetch + visibility-aware poll (hook fires once on mount).
-  usePageVisibleInterval(() => {
-    void refresh();
-  }, 5_000);
+  useAdaptivePolling(refresh, {
+    minIntervalMs: 5_000,
+    maxIntervalMs: 30_000,
+    stablePollsPerStep: 3,
+  });
 
   // Global pointer listeners for drag reorder
   useEffect(() => {

--- a/src/ui/sidebar/SessionLogsPanel.tsx
+++ b/src/ui/sidebar/SessionLogsPanel.tsx
@@ -1,7 +1,7 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { copyToClipboard } from "@/lib/clipboard";
-import { usePageVisibleInterval } from "@/hooks/use-page-visible-interval";
+import { useAdaptivePolling } from "@/hooks/use-adaptive-polling";
 import { Input } from "@/components/input";
 import {
   Tooltip,
@@ -221,46 +221,51 @@ export function SessionLogsPanel() {
   const [copied, setCopied] = useState(false);
   const [retentionDays, setRetentionDays] = useState<number | null>(null);
   const [savingRetention, setSavingRetention] = useState(false);
+  const logsRef = useRef(logs);
+  logsRef.current = logs;
 
   const load = useCallback(
-    (initial = false) => {
+    async (initial = false) => {
       if (initial) setLoading(true);
-      getSessionLogs()
-        .then((fresh) => {
-          setLogs((prev) => {
-            if (
-              prev.length === fresh.length &&
-              prev.every((log, i) => log.id === fresh[i]?.id)
-            ) {
-              return prev;
-            }
-            return fresh;
-          });
-        })
-        .catch(() => {
-          if (initial) toast.error(t("sessionLogs.loadError"));
-        })
-        .finally(() => {
-          if (initial) setLoading(false);
-        });
+      try {
+        const fresh = await getSessionLogs();
+        const changed =
+          logsRef.current.length !== fresh.length ||
+          logsRef.current.some((log, i) => log.id !== fresh[i]?.id);
+        if (changed) {
+          logsRef.current = fresh;
+          setLogs(fresh);
+        }
+        return changed;
+      } catch (error) {
+        if (initial) {
+          toast.error(t("sessionLogs.loadError"));
+          return false;
+        }
+        throw error;
+      } finally {
+        if (initial) setLoading(false);
+      }
     },
     [t],
   );
 
   useEffect(() => {
-    load(true);
+    void load(true);
     getSessionRecordingRetention()
       .then(setRetentionDays)
       .catch(() => setRetentionDays(null));
   }, [load]);
 
-  usePageVisibleInterval(
-    () => {
-      void load(false);
+  useAdaptivePolling(
+    () => load(false),
+    {
+      minIntervalMs: 5_000,
+      maxIntervalMs: 30_000,
+      stablePollsPerStep: 3,
     },
-    5_000,
     true,
-    { runOnMount: false },
+    { runImmediately: false },
   );
 
   const q = filter.trim().toLowerCase();

--- a/src/ui/tests/lib/adaptive-polling.test.ts
+++ b/src/ui/tests/lib/adaptive-polling.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  computeAdaptivePollDelay,
+  runAdaptivePolling,
+} from "../../lib/adaptive-polling.ts";
+
+describe("adaptive polling", () => {
+  afterEach(() => vi.useRealTimers());
+
+  it("slows down after stable results and backs off after failures", () => {
+    const policy = {
+      minIntervalMs: 1000,
+      maxIntervalMs: 16000,
+      stablePollsPerStep: 2,
+      jitterRatio: 0,
+    };
+    expect(
+      computeAdaptivePollDelay(policy, {
+        stablePolls: 4,
+        consecutiveFailures: 0,
+      }),
+    ).toBe(4000);
+    expect(
+      computeAdaptivePollDelay(policy, {
+        stablePolls: 0,
+        consecutiveFailures: 3,
+      }),
+    ).toBe(8000);
+  });
+
+  it("adds bounded jitter", () => {
+    const policy = {
+      minIntervalMs: 1000,
+      maxIntervalMs: 10000,
+      jitterRatio: 0.1,
+    };
+    const state = { stablePolls: 0, consecutiveFailures: 2 };
+    expect(computeAdaptivePollDelay(policy, state, () => 0)).toBe(3600);
+    expect(computeAdaptivePollDelay(policy, state, () => 1)).toBe(4400);
+  });
+
+  it("never overlaps requests", async () => {
+    vi.useFakeTimers();
+    let resolvePoll!: () => void;
+    const poll = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolvePoll = resolve;
+        }),
+    );
+    const stop = runAdaptivePolling(
+      poll,
+      { minIntervalMs: 1000, maxIntervalMs: 4000, jitterRatio: 0 },
+      { runImmediately: true },
+    );
+
+    expect(poll).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(poll).toHaveBeenCalledTimes(1);
+    resolvePoll();
+    await Promise.resolve();
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(poll).toHaveBeenCalledTimes(2);
+    stop();
+  });
+
+  it("slows stable data and resets when data changes", async () => {
+    vi.useFakeTimers();
+    const poll = vi
+      .fn<() => Promise<boolean>>()
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(true)
+      .mockResolvedValue(false);
+    const stop = runAdaptivePolling(
+      poll,
+      {
+        minIntervalMs: 1000,
+        maxIntervalMs: 8000,
+        stablePollsPerStep: 1,
+        jitterRatio: 0,
+      },
+      { runImmediately: true },
+    );
+
+    await Promise.resolve();
+    await vi.advanceTimersByTimeAsync(2000);
+    expect(poll).toHaveBeenCalledTimes(2);
+    await vi.advanceTimersByTimeAsync(4000);
+    expect(poll).toHaveBeenCalledTimes(3);
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(poll).toHaveBeenCalledTimes(4);
+    stop();
+  });
+});

--- a/src/ui/tests/lib/useConnectionRetry.test.ts
+++ b/src/ui/tests/lib/useConnectionRetry.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { computeReconnectDelay } from "../../lib/useConnectionRetry.ts";
+
+describe("connection retry delay", () => {
+  it("uses exponential backoff with bounded jitter", () => {
+    expect(computeReconnectDelay(1, 2000, 8000, () => 0.5)).toBe(2000);
+    expect(computeReconnectDelay(2, 2000, 8000, () => 0)).toBe(3600);
+    expect(computeReconnectDelay(2, 2000, 8000, () => 1)).toBe(4400);
+  });
+
+  it("never exceeds the configured cap", () => {
+    expect(computeReconnectDelay(8, 2000, 8000, () => 1)).toBe(8000);
+  });
+});


### PR DESCRIPTION
## Summary

- add one adaptive scheduler that prevents overlapping polls, pauses hidden pages, refreshes immediately on resume, and applies bounded jitter
- slow stable data gradually while restoring the configured minimum interval as soon as data changes
- integrate Docker containers, tmux overview/metrics, host status/metrics, Proxmox metrics, desktop remote tunnel status, active connections, session logs, and transfer reconciliation
- keep transfer reconciliation responsive while work exists, then back off from 2 seconds to 30 seconds while idle
- add jitter to the shared connection retry hook to avoid synchronized reconnect bursts
- preserve manual refresh, configured minimum intervals, heartbeats, and last successful data on failures

Tracking issue: Termix-SSH/Support#1151

## Validation

- `npm run lint` (0 errors; 103 existing warnings)
- `npm run type-check`
- `npm run build`
- full test suite: 303 files, 2269 passed, 1 skipped
- adaptive scheduler and retry tests: 6 passed
