### PR TITLE
feat: make adaptive polling cost and network aware

### DIFF
--- a/src/ui/features/docker/components/ContainerStats.tsx
+++ b/src/ui/features/docker/components/ContainerStats.tsx
@@ -14,6 +14,7 @@ import { getContainerStats } from "@/main-axios.ts";
 import { useTranslation } from "react-i18next";
 import { SectionCard } from "@/components/section-card";
 import { DockerBadge } from "./ContainerCard.tsx";
+import { useAdaptivePolling } from "@/hooks/use-adaptive-polling.ts";
 
 interface ContainerStatsProps {
   sessionId: string;
@@ -32,14 +33,26 @@ export function ContainerStats({
   const [stats, setStats] = React.useState<DockerStats | null>(null);
   const [isLoading, setIsLoading] = React.useState(false);
   const [error, setError] = React.useState<string | null>(null);
+  const statsRef = React.useRef(stats);
+  statsRef.current = stats;
 
   const fetchStats = React.useCallback(async () => {
-    if (containerState !== "running") return;
+    if (containerState !== "running") return false;
     setIsLoading(true);
     setError(null);
     try {
       const data = await getContainerStats(sessionId, containerId);
+      const previous = statsRef.current;
+      const changed =
+        !previous ||
+        Math.abs(parseFloat(data.cpu) - parseFloat(previous.cpu)) >= 1.5 ||
+        Math.abs(
+          parseFloat(data.memoryPercent) - parseFloat(previous.memoryPercent),
+        ) >= 1 ||
+        data.pids !== previous.pids;
+      statsRef.current = data;
       setStats(data);
+      return changed;
     } catch (err) {
       setError(getErrorMessage(err, t("docker.failedToFetchStats")));
     } finally {
@@ -47,14 +60,16 @@ export function ContainerStats({
     }
   }, [sessionId, containerId, containerState, t]);
 
-  React.useEffect(() => {
-    fetchStats();
-    const interval = setInterval(() => {
-      if (document.visibilityState === "hidden") return;
-      void fetchStats();
-    }, 2000);
-    return () => clearInterval(interval);
-  }, [fetchStats]);
+  useAdaptivePolling(
+    fetchStats,
+    {
+      minIntervalMs: 2_000,
+      maxIntervalMs: 12_000,
+      stablePollsPerStep: 2,
+      maxRequestDutyCycle: 0.2,
+    },
+    containerState === "running",
+  );
 
   if (containerState !== "running") {
     return (

--- a/src/ui/features/docker/components/LogViewer.tsx
+++ b/src/ui/features/docker/components/LogViewer.tsx
@@ -8,6 +8,7 @@ import { toast } from "sonner";
 import { useTranslation } from "react-i18next";
 import type { DockerLogOptions } from "@/types";
 import { getContainerLogs, downloadContainerLogs } from "@/main-axios.ts";
+import { useAdaptivePolling } from "@/hooks/use-adaptive-polling.ts";
 
 interface LogViewerProps {
   sessionId: string;
@@ -66,6 +67,8 @@ export function LogViewer({
   const [autoRefresh, setAutoRefresh] = React.useState(false);
   const [logSearch, setLogSearch] = React.useState("");
   const logsEndRef = React.useRef<HTMLDivElement>(null);
+  const rawLogsRef = React.useRef(rawLogs);
+  rawLogsRef.current = rawLogs;
 
   const fetchLogs = React.useCallback(async () => {
     setIsLoading(true);
@@ -75,7 +78,15 @@ export function LogViewer({
         timestamps: showTimestamps,
       };
       const data = await getContainerLogs(sessionId, containerId, options);
-      setRawLogs(data.logs.split("\n").filter(Boolean));
+      const next = data.logs.split("\n").filter(Boolean);
+      const changed =
+        next.length !== rawLogsRef.current.length ||
+        next.some((line, index) => line !== rawLogsRef.current[index]);
+      if (changed) {
+        rawLogsRef.current = next;
+        setRawLogs(next);
+      }
+      return changed;
     } catch (error) {
       toast.error(`Failed to fetch logs: ${getErrorMessage(error)}`);
     } finally {
@@ -87,14 +98,17 @@ export function LogViewer({
     fetchLogs();
   }, [fetchLogs]);
 
-  React.useEffect(() => {
-    if (!autoRefresh) return;
-    const interval = setInterval(() => {
-      if (document.visibilityState === "hidden") return;
-      void fetchLogs();
-    }, 3000);
-    return () => clearInterval(interval);
-  }, [autoRefresh, fetchLogs]);
+  useAdaptivePolling(
+    fetchLogs,
+    {
+      minIntervalMs: 3_000,
+      maxIntervalMs: 18_000,
+      stablePollsPerStep: 2,
+      maxRequestDutyCycle: 0.2,
+    },
+    autoRefresh,
+    { runImmediately: false },
+  );
 
   React.useEffect(() => {
     if (autoRefresh && logsEndRef.current) {

--- a/src/ui/features/host-metrics/cards/managers/LogViewerCard.tsx
+++ b/src/ui/features/host-metrics/cards/managers/LogViewerCard.tsx
@@ -1,9 +1,10 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { ScrollText } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { managerGet, managerGetSub } from "@/main-axios";
 import { extractError } from "./useManagerData";
 import { ManagerCardShell } from "./ManagerCardShell";
+import { useAdaptivePolling } from "@/hooks/use-adaptive-polling";
 
 interface LogFiles {
   common: string[];
@@ -26,6 +27,8 @@ export function LogViewerCard({ hostId }: { hostId: number | null }) {
   const [error, setError] = useState<string | null>(null);
   const [files, setFiles] = useState<string[]>([]);
   const bodyRef = useRef<HTMLPreElement | null>(null);
+  const contentRef = useRef(content);
+  contentRef.current = content;
 
   // Load the host's actual log files once.
   useEffect(() => {
@@ -42,44 +45,56 @@ export function LogViewerCard({ hostId }: { hostId: number | null }) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [hostId]);
 
-  const fetchLog = async () => {
-    if (hostId == null) return;
+  const fetchLog = useCallback(async () => {
+    if (hostId == null) return false;
     const params: Record<string, string | number> = { lines };
     if (mode === "unit") {
-      if (!unit.trim()) return;
+      if (!unit.trim()) return false;
       params.unit = unit.trim();
     } else {
       const p = customPath.trim() || path;
-      if (!p) return;
+      if (!p) return false;
       params.path = p;
     }
     setLoading(true);
     setError(null);
     try {
       const res = await managerGet<{ content: string }>(hostId, "logs", params);
-      setContent(res.content || "");
-      requestAnimationFrame(() => {
-        if (bodyRef.current)
-          bodyRef.current.scrollTop = bodyRef.current.scrollHeight;
-      });
+      const next = res.content || "";
+      const changed = next !== contentRef.current;
+      if (changed) {
+        contentRef.current = next;
+        setContent(next);
+        requestAnimationFrame(() => {
+          if (bodyRef.current)
+            bodyRef.current.scrollTop = bodyRef.current.scrollHeight;
+        });
+      }
+      return changed;
     } catch (e) {
       setError(extractError(e).message);
     } finally {
       setLoading(false);
     }
-  };
+  }, [customPath, hostId, lines, mode, path, unit]);
 
   useEffect(() => {
-    fetchLog();
+    void fetchLog();
+    // Custom paths are applied on blur/manual refresh, not on every keystroke.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [mode, path, unit, lines]);
+  }, [hostId, mode, path, unit, lines]);
 
-  useEffect(() => {
-    if (!follow) return;
-    const id = setInterval(fetchLog, 3000);
-    return () => clearInterval(id);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [follow, mode, path, unit, lines, customPath]);
+  useAdaptivePolling(
+    fetchLog,
+    {
+      minIntervalMs: 3_000,
+      maxIntervalMs: 18_000,
+      stablePollsPerStep: 2,
+      maxRequestDutyCycle: 0.2,
+    },
+    follow,
+    { runImmediately: false },
+  );
 
   const shown = useMemo(() => {
     if (!grep) return content;

--- a/src/ui/features/terminal/TerminalToolbar.tsx
+++ b/src/ui/features/terminal/TerminalToolbar.tsx
@@ -21,6 +21,10 @@ import {
   stopMetricsPolling,
 } from "@/api/host-metrics-status-api";
 import type { Host, TabType } from "@/types/ui-types";
+import {
+  getPollingEnvironmentMultiplier,
+  runAdaptivePolling,
+} from "@/lib/adaptive-polling";
 
 type ToolbarDensity = "icon" | "labeled" | "expanded";
 
@@ -204,20 +208,36 @@ export const TerminalToolbar: React.FC<TerminalToolbarProps> = ({
     }
 
     let cancelled = false;
-    let intervalId: number | undefined;
+    let stopPolling: (() => void) | undefined;
     let viewerSessionId: string | undefined;
+    let previousMetrics: typeof metrics = null;
 
     const poll = async () => {
       try {
         const data = await getServerMetricsById(hostId);
         if (cancelled || !data) return;
-        setMetrics({
+        const next = {
           cpu: data.cpu?.percent ?? null,
           memory: data.memory?.percent ?? null,
           disk: data.disk?.percent ?? null,
-        });
+        };
+        const changed =
+          !previousMetrics ||
+          (["cpu", "memory", "disk"] as const).some((key) => {
+            const previous = previousMetrics?.[key];
+            const current = next[key];
+            return (
+              previous == null ||
+              current == null ||
+              Math.abs(current - previous) >= 2
+            );
+          });
+        previousMetrics = next;
+        setMetrics(next);
+        return changed;
       } catch {
         // keep prior value on transient errors
+        return false;
       }
     };
 
@@ -230,8 +250,16 @@ export const TerminalToolbar: React.FC<TerminalToolbarProps> = ({
           return;
         }
         viewerSessionId = result.viewerSessionId;
-        await poll();
-        intervalId = window.setInterval(poll, 5000);
+        stopPolling = runAdaptivePolling(
+          poll,
+          {
+            minIntervalMs: 5_000,
+            maxIntervalMs: 20_000,
+            stablePollsPerStep: 2,
+            maxRequestDutyCycle: 0.2,
+          },
+          { intervalMultiplier: getPollingEnvironmentMultiplier },
+        );
       } catch {
         if (!cancelled) setStatsAvailable(false);
       }
@@ -241,7 +269,7 @@ export const TerminalToolbar: React.FC<TerminalToolbarProps> = ({
 
     return () => {
       cancelled = true;
-      if (intervalId) window.clearInterval(intervalId);
+      stopPolling?.();
       void stopMetricsPolling(hostId, viewerSessionId).catch(() => {});
     };
   }, [showStats, hostId, collapsed]);

--- a/src/ui/hooks/use-adaptive-polling.ts
+++ b/src/ui/hooks/use-adaptive-polling.ts
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from "react";
 import {
+  getPollingEnvironmentMultiplier,
   runAdaptivePolling,
   type AdaptivePollResult,
   type AdaptivePollingPolicy,
@@ -18,8 +19,13 @@ export function useAdaptivePolling(
   const errorRef = useRef(options.onError);
   pollRef.current = poll;
   errorRef.current = options.onError;
-  const { minIntervalMs, maxIntervalMs, stablePollsPerStep, jitterRatio } =
-    policy;
+  const {
+    minIntervalMs,
+    maxIntervalMs,
+    stablePollsPerStep,
+    jitterRatio,
+    maxRequestDutyCycle,
+  } = policy;
   const runImmediately = options.runImmediately;
 
   useEffect(
@@ -31,11 +37,13 @@ export function useAdaptivePolling(
           maxIntervalMs,
           stablePollsPerStep,
           jitterRatio,
+          maxRequestDutyCycle,
         },
         {
           enabled: () => enabled,
           runImmediately,
           onError: (error) => errorRef.current?.(error),
+          intervalMultiplier: getPollingEnvironmentMultiplier,
         },
       ),
     [
@@ -45,6 +53,7 @@ export function useAdaptivePolling(
       minIntervalMs,
       runImmediately,
       stablePollsPerStep,
+      maxRequestDutyCycle,
     ],
   );
 }

--- a/src/ui/lib/adaptive-polling.ts
+++ b/src/ui/lib/adaptive-polling.ts
@@ -3,11 +3,14 @@ export interface AdaptivePollingPolicy {
   maxIntervalMs: number;
   stablePollsPerStep?: number;
   jitterRatio?: number;
+  /** Prevent expensive requests from consuming more than this share of time. */
+  maxRequestDutyCycle?: number;
 }
 
 export interface AdaptivePollingState {
   stablePolls: number;
   consecutiveFailures: number;
+  lastPollDurationMs?: number;
 }
 
 export type AdaptivePollResult = boolean | void;
@@ -23,7 +26,13 @@ export function computeAdaptivePollDelay(
     state.stablePolls / Math.max(1, policy.stablePollsPerStep ?? 3),
   );
   const exponent = state.consecutiveFailures || stableStep;
-  const base = Math.min(max, min * 2 ** Math.min(exponent, 10));
+  let base = Math.min(max, min * 2 ** Math.min(exponent, 10));
+  const dutyCycle = policy.maxRequestDutyCycle;
+  if (dutyCycle && dutyCycle > 0 && dutyCycle < 1) {
+    const duration = Math.max(0, state.lastPollDurationMs ?? 0);
+    base = Math.max(base, duration * ((1 - dutyCycle) / dutyCycle));
+  }
+  base = Math.min(max, base);
   const jitterRatio = Math.max(0, Math.min(0.5, policy.jitterRatio ?? 0.1));
   const jitter = base * jitterRatio * (random() * 2 - 1);
   return Math.max(min, Math.min(max, Math.round(base + jitter)));
@@ -37,6 +46,7 @@ export function runAdaptivePolling(
     visible?: () => boolean;
     runImmediately?: boolean;
     random?: () => number;
+    intervalMultiplier?: () => number;
     onError?: (error: unknown) => void;
   } = {},
 ): () => void {
@@ -64,13 +74,20 @@ export function runAdaptivePolling(
     if (stopped || !enabled() || !visible()) return;
     timer = setTimeout(
       () => void tick(),
-      computeAdaptivePollDelay(policy, state, options.random),
+      Math.min(
+        policy.maxIntervalMs,
+        Math.round(
+          computeAdaptivePollDelay(policy, state, options.random) *
+            Math.max(1, options.intervalMultiplier?.() ?? 1),
+        ),
+      ),
     );
   };
 
   const tick = async () => {
     if (stopped || inFlight || !enabled() || !visible()) return;
     inFlight = true;
+    const startedAt = Date.now();
     try {
       const changed = await poll();
       state.consecutiveFailures = 0;
@@ -80,6 +97,7 @@ export function runAdaptivePolling(
       state.consecutiveFailures += 1;
       options.onError?.(error);
     } finally {
+      state.lastPollDurationMs = Date.now() - startedAt;
       inFlight = false;
       schedule();
     }
@@ -108,4 +126,24 @@ export function runAdaptivePolling(
       document.removeEventListener("visibilitychange", onVisibility);
     }
   };
+}
+
+interface NetworkInformationLike {
+  saveData?: boolean;
+  effectiveType?: string;
+}
+
+export function getPollingEnvironmentMultiplier(
+  connection?: NetworkInformationLike,
+): number {
+  const current =
+    connection ??
+    (typeof navigator === "undefined"
+      ? undefined
+      : (navigator as Navigator & { connection?: NetworkInformationLike })
+          .connection);
+  if (current?.saveData || current?.effectiveType === "slow-2g") return 2;
+  if (current?.effectiveType === "2g") return 1.75;
+  if (current?.effectiveType === "3g") return 1.25;
+  return 1;
 }

--- a/src/ui/tests/lib/adaptive-polling.test.ts
+++ b/src/ui/tests/lib/adaptive-polling.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   computeAdaptivePollDelay,
+  getPollingEnvironmentMultiplier,
   runAdaptivePolling,
 } from "../../lib/adaptive-polling.ts";
 
@@ -37,6 +38,30 @@ describe("adaptive polling", () => {
     const state = { stablePolls: 0, consecutiveFailures: 2 };
     expect(computeAdaptivePollDelay(policy, state, () => 0)).toBe(3600);
     expect(computeAdaptivePollDelay(policy, state, () => 1)).toBe(4400);
+  });
+
+  it("limits request duty cycle when polling is expensive", () => {
+    expect(
+      computeAdaptivePollDelay(
+        {
+          minIntervalMs: 1000,
+          maxIntervalMs: 30000,
+          maxRequestDutyCycle: 0.2,
+          jitterRatio: 0,
+        },
+        {
+          stablePolls: 0,
+          consecutiveFailures: 0,
+          lastPollDurationMs: 2000,
+        },
+      ),
+    ).toBe(8000);
+  });
+
+  it("slows non-critical polling on constrained connections", () => {
+    expect(getPollingEnvironmentMultiplier({ saveData: true })).toBe(2);
+    expect(getPollingEnvironmentMultiplier({ effectiveType: "2g" })).toBe(1.75);
+    expect(getPollingEnvironmentMultiplier({ effectiveType: "4g" })).toBe(1);
   });
 
   it("never overlaps requests", async () => {


### PR DESCRIPTION
## Summary

- make adaptive polling account for request cost with an opt-in duty-cycle ceiling, preventing slow endpoints from consuming a disproportionate share of time
- respect browser `Save-Data` and constrained network hints for non-critical background polling
- classify meaningful Docker and terminal metric changes instead of treating noisy samples as constant activity
- adapt Docker log refresh and host log follow between their existing fast interval and a bounded idle interval
- preserve immediate first loads, manual refresh, visibility pause/resume, and minimum intervals while activity is present

## Validation

- `npm run lint` (0 errors; 103 existing warnings)
- `npm run type-check`
- `npm run build`
- full test suite: 303 files, 2271 passed, 1 skipped
- adaptive scheduler tests: 6 passed
