### PR TITLE
feat: make repeat navigation feel instant

### DIFF
--- a/src/ui/api/host-metrics-status-api.ts
+++ b/src/ui/api/host-metrics-status-api.ts
@@ -10,6 +10,7 @@ import type { ServerMetrics, ServerStatus } from "@/main-axios";
 import { getCachedServerStatuses } from "@/lib/hosts-request-cache";
 import { resolveConnectionOrigin } from "@/lib/connection-origin";
 import type { SSHHost } from "@/types/index";
+import { createKeyedRequestCache } from "@/lib/keyed-request-cache";
 
 // Metrics collection/viewer registration below (startMetricsPolling,
 // registerMetricsViewer, etc.) is NOT origin-routed: the backend that
@@ -52,6 +53,8 @@ type ConnectErrorResponse = {
 
 // SERVER STATISTICS
 // ============================================================================
+
+const metricsCache = createKeyedRequestCache<ServerMetrics | null>(1_500, 100);
 
 /**
  * Progressive retry schedule for the background /status poll.
@@ -188,25 +191,24 @@ export async function getServerStatusById(id: number): Promise<ServerStatus> {
 export async function getServerMetricsById(
   id: number,
 ): Promise<ServerMetrics | null> {
-  try {
-    const response = await statsApi.get(`/metrics/${id}`, {
-      // Treat 404 as an expected "no metrics yet / disabled" signal rather
-      // than an error so we don't spam warn logs on the client.
-      validateStatus: (status) => status === 200 || status === 404,
-    });
-    if (response.status === 404) {
-      return null;
+  return metricsCache.get(String(id), async () => {
+    try {
+      const response = await statsApi.get(`/metrics/${id}`, {
+        // Treat 404 as an expected "no metrics yet / disabled" signal rather
+        // than an error so we don't spam warn logs on the client.
+        validateStatus: (status) => status === 200 || status === 404,
+      });
+      if (response.status === 404) return null;
+      return response.data;
+    } catch (error) {
+      // If a 404 still slips through (e.g. intercepted before reaching here),
+      // swallow it quietly; everything else still flows through handleApiError.
+      if (axios.isAxiosError(error) && error.response?.status === 404) {
+        return null;
+      }
+      handleApiError(error, "fetch server metrics");
     }
-    return response.data;
-  } catch (error) {
-    // If a 404 still slips through (e.g. intercepted before reaching here),
-    // swallow it quietly; everything else still flows through handleApiError.
-    if (axios.isAxiosError(error) && error.response?.status === 404) {
-      return null;
-    }
-    handleApiError(error, "fetch server metrics");
-    throw error;
-  }
+  });
 }
 
 export async function startMetricsPolling(hostId: number): Promise<{
@@ -219,6 +221,7 @@ export async function startMetricsPolling(hostId: number): Promise<{
 }> {
   try {
     const response = await statsApi.post(`/metrics/start/${hostId}`);
+    metricsCache.invalidate(String(hostId));
     return response.data;
   } catch (error: unknown) {
     if (
@@ -272,6 +275,7 @@ export async function registerMetricsViewer(hostId: number): Promise<{
     const response = await statsApi.post("/metrics/register-viewer", {
       hostId,
     });
+    metricsCache.invalidate(String(hostId));
     return response.data;
   } catch (error) {
     handleApiError(error, "register metrics viewer");
@@ -306,6 +310,7 @@ export async function submitMetricsTOTP(
       sessionId,
       totpCode,
     });
+    metricsCache.invalidate();
     return response.data;
   } catch (error) {
     handleApiError(error, "submit metrics TOTP");
@@ -326,6 +331,7 @@ export async function notifyHostCreatedOrUpdated(
 ): Promise<void> {
   try {
     await statsApi.post("/host-updated", { hostId });
+    metricsCache.invalidate(String(hostId));
   } catch (error) {
     console.warn("Failed to notify stats server of host update:", error);
   }

--- a/src/ui/api/ssh-file-operations-api.ts
+++ b/src/ui/api/ssh-file-operations-api.ts
@@ -12,6 +12,7 @@ import {
 import { resolveConnectionOrigin } from "@/lib/connection-origin";
 import { fileLogger } from "@/lib/frontend-logger";
 import type { FileItem, SSHHost } from "@/types/index";
+import { getCachedFileList } from "@/lib/file-list-request-cache";
 
 type ApiConnectionLog = {
   type: "info" | "success" | "warning" | "error";
@@ -298,17 +299,24 @@ export async function keepSSHAlive(
 export async function listSSHFiles(
   sessionId: string,
   path: string,
+  options: { force?: boolean } = {},
 ): Promise<{ files: FileItem[]; path: string }> {
-  try {
-    const response = await getFileManagerApiForSession(sessionId).get(
-      "/ssh/listFiles",
-      { params: { sessionId, path } },
-    );
-    return response.data || { files: [], path };
-  } catch (error) {
-    handleApiError(error, "list SSH files");
-    return { files: [], path };
-  }
+  return getCachedFileList(
+    sessionId,
+    path,
+    async () => {
+      try {
+        const response = await getFileManagerApiForSession(sessionId).get(
+          "/ssh/listFiles",
+          { params: { sessionId, path } },
+        );
+        return response.data || { files: [], path };
+      } catch (error) {
+        handleApiError(error, "list SSH files");
+      }
+    },
+    options.force,
+  );
 }
 
 export async function identifySSHSymlink(

--- a/src/ui/features/file-manager/FileManager.tsx
+++ b/src/ui/features/file-manager/FileManager.tsx
@@ -81,6 +81,10 @@ import type {
   SSHConnectionError,
 } from "./file-manager-types.ts";
 import { formatFileSize } from "./file-manager-utils.ts";
+import {
+  invalidateCachedFileList,
+  peekCachedFileList,
+} from "@/lib/file-list-request-cache";
 
 const LARGE_FILE_WARNING_SIZE = 50 * 1024 * 1024;
 
@@ -113,6 +117,7 @@ function FileManagerContent({
   ]);
   const [navIndex, setNavIndex] = useState(0);
   const [files, setFiles] = useState<FileItem[]>([]);
+  const directoryRequestRef = useRef(0);
   const [isLoading, setIsLoading] = useState(false);
   const [sshSessionId, setSshSessionId] = useState<string | null>(null);
   const [isReconnecting, setIsReconnecting] = useState<boolean>(false);
@@ -604,6 +609,7 @@ function FileManagerContent({
         console.error("Cannot load directory: no SSH session ID");
         return false;
       }
+      const requestId = ++directoryRequestRef.current;
 
       let resolvedPath = path;
       if (path.includes("$") || path.startsWith("~")) {
@@ -615,12 +621,19 @@ function FileManagerContent({
       }
 
       currentLoadingPathRef.current = resolvedPath;
-      setIsLoading(true);
+      const cached = peekCachedFileList(sshSessionId, resolvedPath);
+      if (cached) {
+        setFiles(cached.files);
+        clearSelection();
+      }
+      setIsLoading(!cached);
 
       try {
-        const response = await listSSHFiles(sshSessionId, resolvedPath);
+        const response = await listSSHFiles(sshSessionId, resolvedPath, {
+          force: cached !== null,
+        });
 
-        if (currentLoadingPathRef.current !== resolvedPath) {
+        if (directoryRequestRef.current !== requestId) {
           return false;
         }
 
@@ -633,7 +646,7 @@ function FileManagerContent({
         clearSelection();
         return true;
       } catch (error: unknown) {
-        if (currentLoadingPathRef.current === resolvedPath) {
+        if (directoryRequestRef.current === requestId) {
           // ApiError has .status directly; raw axios errors have .response.status
           const apiError = error as {
             status?: number;
@@ -744,7 +757,7 @@ function FileManagerContent({
         }
         return false;
       } finally {
-        if (currentLoadingPathRef.current === resolvedPath) {
+        if (directoryRequestRef.current === requestId) {
           setIsLoading(false);
           currentLoadingPathRef.current = "";
         }
@@ -771,7 +784,12 @@ function FileManagerContent({
 
   const navigateTo = useCallback(
     (path: string) => {
-      if (sshSessionId) setIsLoading(true);
+      directoryRequestRef.current += 1;
+      const cached = sshSessionId
+        ? peekCachedFileList(sshSessionId, path)
+        : null;
+      if (cached) setFiles(cached.files);
+      setIsLoading(!!sshSessionId && !cached);
       setCurrentPath(path);
       setNavHistory((prev) => {
         const next = [...prev.slice(0, navIndex + 1), path];
@@ -784,19 +802,31 @@ function FileManagerContent({
 
   const goBack = useCallback(() => {
     if (navIndex > 0) {
-      if (sshSessionId) setIsLoading(true);
+      directoryRequestRef.current += 1;
       const newIndex = navIndex - 1;
+      const path = navHistory[newIndex];
+      const cached = sshSessionId
+        ? peekCachedFileList(sshSessionId, path)
+        : null;
+      if (cached) setFiles(cached.files);
+      setIsLoading(!!sshSessionId && !cached);
       setNavIndex(newIndex);
-      setCurrentPath(navHistory[newIndex]);
+      setCurrentPath(path);
     }
   }, [navIndex, navHistory, sshSessionId]);
 
   const goForward = useCallback(() => {
     if (navIndex < navHistory.length - 1) {
-      if (sshSessionId) setIsLoading(true);
+      directoryRequestRef.current += 1;
       const newIndex = navIndex + 1;
+      const path = navHistory[newIndex];
+      const cached = sshSessionId
+        ? peekCachedFileList(sshSessionId, path)
+        : null;
+      if (cached) setFiles(cached.files);
+      setIsLoading(!!sshSessionId && !cached);
       setNavIndex(newIndex);
-      setCurrentPath(navHistory[newIndex]);
+      setCurrentPath(path);
     }
   }, [navIndex, navHistory, sshSessionId]);
 
@@ -834,11 +864,12 @@ function FileManagerContent({
     }
 
     setLastRefreshTime(now);
+    if (sshSessionId) invalidateCachedFileList(sshSessionId, currentPath);
     // Force reset loading state to ensure refresh is not blocked
     setIsLoading(false);
     currentLoadingPathRef.current = "";
     loadDirectory(currentPath);
-  }, [currentPath, lastRefreshTime, loadDirectory]);
+  }, [currentPath, lastRefreshTime, loadDirectory, sshSessionId]);
 
   useEffect(() => {
     const handler = (event: Event) => {
@@ -1431,7 +1462,12 @@ function FileManagerContent({
 
   async function handleFileOpen(file: FileItem) {
     if (file.type === "directory") {
-      if (sshSessionId) setIsLoading(true);
+      directoryRequestRef.current += 1;
+      const cached = sshSessionId
+        ? peekCachedFileList(sshSessionId, file.path)
+        : null;
+      if (cached) setFiles(cached.files);
+      setIsLoading(!!sshSessionId && !cached);
       setCurrentPath(file.path);
       return;
     }
@@ -1451,6 +1487,14 @@ function FileManagerContent({
     await recordRecentFile(file);
     openFileWindow(file, sshSessionId);
   }
+
+  const prefetchDirectory = useCallback(
+    (file: FileItem) => {
+      if (!sshSessionId || file.type !== "directory") return;
+      void listSSHFiles(sshSessionId, file.path).catch(() => {});
+    },
+    [sshSessionId],
+  );
 
   function handleContextMenu(event: React.MouseEvent, file?: FileItem) {
     event.preventDefault();
@@ -2984,6 +3028,7 @@ function FileManagerContent({
                 files={filteredFiles}
                 selectedFiles={selectedFiles}
                 onFileOpen={handleFileOpen}
+                onDirectoryIntent={prefetchDirectory}
                 onSelectionChange={setSelection}
                 onRefresh={handleRefreshDirectory}
                 onUpload={handleFilesDropped}

--- a/src/ui/features/file-manager/FileManagerGrid.tsx
+++ b/src/ui/features/file-manager/FileManagerGrid.tsx
@@ -46,6 +46,7 @@ interface FileManagerGridProps {
   files: FileItem[];
   selectedFiles: FileItem[];
   onFileOpen: (file: FileItem) => void;
+  onDirectoryIntent?: (file: FileItem) => void;
   onSelectionChange: (files: FileItem[]) => void;
   onRefresh: () => void;
   onUpload?: (files: FileList) => void;
@@ -162,6 +163,7 @@ export function FileManagerGrid({
   files,
   selectedFiles,
   onFileOpen,
+  onDirectoryIntent,
   onSelectionChange,
   onRefresh,
   onUpload,
@@ -714,6 +716,8 @@ export function FileManagerGrid({
 
   const handleFileClick = (file: FileItem, event: React.MouseEvent) => {
     event.stopPropagation();
+
+    if (file.type === "directory") onDirectoryIntent?.(file);
 
     if (gridRef.current && !createIntent) {
       gridRef.current.focus();

--- a/src/ui/lib/file-list-request-cache.ts
+++ b/src/ui/lib/file-list-request-cache.ts
@@ -1,0 +1,35 @@
+import type { FileItem } from "@/types/index";
+import { createKeyedRequestCache } from "./keyed-request-cache";
+
+export interface FileListResult {
+  files: FileItem[];
+  path: string;
+}
+
+const cache = createKeyedRequestCache<FileListResult>(5_000, 150);
+
+const keyFor = (sessionId: string, path: string) => `${sessionId}\0${path}`;
+
+export function getCachedFileList(
+  sessionId: string,
+  path: string,
+  loader: () => Promise<FileListResult>,
+  force = false,
+): Promise<FileListResult> {
+  return cache.get(keyFor(sessionId, path), loader, { force });
+}
+
+export function peekCachedFileList(
+  sessionId: string,
+  path: string,
+  maxAgeMs = 30_000,
+): FileListResult | null {
+  return cache.peek(keyFor(sessionId, path), maxAgeMs);
+}
+
+export function invalidateCachedFileList(
+  sessionId: string,
+  path: string,
+): void {
+  cache.invalidate(keyFor(sessionId, path));
+}

--- a/src/ui/lib/keyed-request-cache.ts
+++ b/src/ui/lib/keyed-request-cache.ts
@@ -1,0 +1,62 @@
+export interface KeyedRequestCache<T> {
+  get(
+    key: string,
+    loader: () => Promise<T>,
+    options?: { force?: boolean },
+  ): Promise<T>;
+  peek(key: string, maxAgeMs?: number): T | null;
+  invalidate(key?: string): void;
+}
+
+/** Bounded per-key cache with in-flight request coalescing. */
+export function createKeyedRequestCache<T>(
+  ttlMs: number,
+  maxEntries = 100,
+): KeyedRequestCache<T> {
+  const values = new Map<string, { value: T; storedAt: number }>();
+  const inflight = new Map<string, Promise<T>>();
+
+  const store = (key: string, value: T) => {
+    values.delete(key);
+    values.set(key, { value, storedAt: Date.now() });
+    while (values.size > Math.max(1, maxEntries)) {
+      const oldest = values.keys().next().value;
+      if (oldest === undefined) break;
+      values.delete(oldest);
+    }
+  };
+
+  return {
+    get(key, loader, options = {}) {
+      const cached = values.get(key);
+      if (!options.force && cached && Date.now() - cached.storedAt < ttlMs) {
+        return Promise.resolve(cached.value);
+      }
+
+      const pending = inflight.get(key);
+      if (pending) return pending;
+
+      const request = loader()
+        .then((value) => {
+          store(key, value);
+          return value;
+        })
+        .finally(() => inflight.delete(key));
+      inflight.set(key, request);
+      return request;
+    },
+
+    peek(key, maxAgeMs = Number.POSITIVE_INFINITY) {
+      const cached = values.get(key);
+      if (!cached || Date.now() - cached.storedAt > maxAgeMs) return null;
+      values.delete(key);
+      values.set(key, cached);
+      return cached.value;
+    },
+
+    invalidate(key) {
+      if (key === undefined) values.clear();
+      else values.delete(key);
+    },
+  };
+}

--- a/src/ui/tests/api/host-metrics-status-api.test.ts
+++ b/src/ui/tests/api/host-metrics-status-api.test.ts
@@ -21,7 +21,10 @@ vi.mock("@/lib/connection-origin", () => ({
   resolveConnectionOrigin: resolveConnectionOriginMock,
 }));
 
-import { getAllServerStatuses } from "../../api/host-metrics-status-api";
+import {
+  getAllServerStatuses,
+  getServerMetricsById,
+} from "../../api/host-metrics-status-api";
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -75,5 +78,23 @@ describe("status check origin routing", () => {
       params: { hostIds: "" },
       __silentRetry: true,
     });
+  });
+});
+
+describe("metrics request coalescing", () => {
+  it("shares simultaneous reads for the same host", async () => {
+    statsApiMock.get.mockResolvedValueOnce({
+      status: 200,
+      data: { cpu: { percent: 12 } },
+    });
+
+    const [first, second] = await Promise.all([
+      getServerMetricsById(991),
+      getServerMetricsById(991),
+    ]);
+
+    expect(first).toEqual({ cpu: { percent: 12 } });
+    expect(second).toBe(first);
+    expect(statsApiMock.get).toHaveBeenCalledOnce();
   });
 });

--- a/src/ui/tests/lib/keyed-request-cache.test.ts
+++ b/src/ui/tests/lib/keyed-request-cache.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createKeyedRequestCache } from "../../lib/keyed-request-cache";
+
+afterEach(() => vi.useRealTimers());
+
+describe("createKeyedRequestCache", () => {
+  it("coalesces requests per key without mixing keys", async () => {
+    let resolve!: (value: string) => void;
+    const loader = vi.fn(() => new Promise<string>((done) => (resolve = done)));
+    const cache = createKeyedRequestCache<string>(5_000);
+
+    const first = cache.get("host:1", loader);
+    const duplicate = cache.get("host:1", loader);
+    const other = cache.get("host:2", async () => "other");
+    resolve("shared");
+
+    await expect(Promise.all([first, duplicate, other])).resolves.toEqual([
+      "shared",
+      "shared",
+      "other",
+    ]);
+    expect(loader).toHaveBeenCalledOnce();
+  });
+
+  it("can show stale data immediately while forcing one refresh", async () => {
+    vi.useFakeTimers();
+    const cache = createKeyedRequestCache<string>(1_000);
+    await cache.get("directory", async () => "old");
+    await vi.advanceTimersByTimeAsync(2_000);
+
+    expect(cache.peek("directory", 30_000)).toBe("old");
+
+    const loader = vi.fn(async () => "fresh");
+    const [a, b] = await Promise.all([
+      cache.get("directory", loader, { force: true }),
+      cache.get("directory", loader, { force: true }),
+    ]);
+    expect([a, b]).toEqual(["fresh", "fresh"]);
+    expect(loader).toHaveBeenCalledOnce();
+  });
+
+  it("evicts the least recently used entry when bounded", async () => {
+    const cache = createKeyedRequestCache<number>(10_000, 2);
+    await cache.get("a", async () => 1);
+    await cache.get("b", async () => 2);
+    expect(cache.peek("a")).toBe(1);
+    await cache.get("c", async () => 3);
+
+    expect(cache.peek("a")).toBe(1);
+    expect(cache.peek("b")).toBeNull();
+    expect(cache.peek("c")).toBe(3);
+  });
+
+  it("keeps stale data when a refresh fails", async () => {
+    const cache = createKeyedRequestCache<string>(1_000);
+    await cache.get("key", async () => "safe");
+
+    await expect(
+      cache.get(
+        "key",
+        async () => {
+          throw new Error("offline");
+        },
+        { force: true },
+      ),
+    ).rejects.toThrow("offline");
+    expect(cache.peek("key")).toBe("safe");
+  });
+});


### PR DESCRIPTION
## Summary

- add a bounded keyed request cache with per-key in-flight coalescing, explicit refresh, stale reads, LRU eviction, and failure-safe retention
- make File Manager prefetch directories on the first click so the following double-click usually reuses work already in progress
- restore recently visited directories immediately, then refresh them in the background instead of blocking navigation on network latency
- use request generations so rapid A-B-A navigation can never be overwritten by an older response
- coalesce repeated host metrics reads across Dashboard, Terminal, File Manager, Homepage, and Host Metrics consumers
- invalidate metric snapshots when collection/viewer state changes

## Validation

- `npm run lint` (0 errors; 103 existing warnings)
- `npm run type-check`
- `npm run build`
- full test suite: 304 files, 2276 passed, 1 skipped
- keyed cache and metrics coalescing tests: 7 passed
