### PR TITLE
feat: make file operations feel immediate

### DIFF
--- a/src/ui/features/file-manager/FileManager.tsx
+++ b/src/ui/features/file-manager/FileManager.tsx
@@ -84,7 +84,15 @@ import { formatFileSize } from "./file-manager-utils.ts";
 import {
   invalidateCachedFileList,
   peekCachedFileList,
+  updateCachedFileList,
 } from "@/lib/file-list-request-cache";
+import {
+  addOptimisticItem,
+  childPath,
+  removePaths,
+  renameOptimisticItem,
+  restoreItems,
+} from "./optimistic-file-list";
 
 const LARGE_FILE_WARNING_SIZE = 50 * 1024 * 1024;
 
@@ -109,6 +117,8 @@ function FileManagerContent({
   const [currentPath, setCurrentPath] = useState(
     initialPath || initialHost?.defaultPath || "/",
   );
+  const currentPathRef = useRef(currentPath);
+  currentPathRef.current = currentPath;
   const lastSuccessfulPathRef = useRef(
     initialPath || initialHost?.defaultPath || "/",
   );
@@ -117,9 +127,13 @@ function FileManagerContent({
   ]);
   const [navIndex, setNavIndex] = useState(0);
   const [files, setFiles] = useState<FileItem[]>([]);
+  const filesRef = useRef(files);
+  filesRef.current = files;
   const directoryRequestRef = useRef(0);
   const [isLoading, setIsLoading] = useState(false);
   const [sshSessionId, setSshSessionId] = useState<string | null>(null);
+  const sshSessionIdRef = useRef(sshSessionId);
+  sshSessionIdRef.current = sshSessionId;
   const [isReconnecting, setIsReconnecting] = useState<boolean>(false);
   const [searchQuery, setSearchQuery] = useState("");
   const [lastRefreshTime, setLastRefreshTime] = useState<number>(0);
@@ -226,6 +240,32 @@ function FileManagerContent({
     useState<PendingSudoOperation | null>(null);
 
   const { selectedFiles, clearSelection, setSelection } = useFileSelection();
+
+  const commitFilesForPath = useCallback(
+    (sessionId: string, path: string, next: FileItem[]) => {
+      updateCachedFileList(sessionId, path, next);
+      if (
+        sshSessionIdRef.current !== sessionId ||
+        currentPathRef.current !== path
+      ) {
+        return;
+      }
+      directoryRequestRef.current += 1;
+      filesRef.current = next;
+      setFiles(next);
+    },
+    [],
+  );
+
+  const filesForPath = useCallback((sessionId: string, path: string) => {
+    if (
+      sshSessionIdRef.current === sessionId &&
+      currentPathRef.current === path
+    ) {
+      return filesRef.current;
+    }
+    return peekCachedFileList(sessionId, path)?.files ?? [];
+  }, []);
 
   const { dragHandlers } = useDragAndDrop({
     onFilesDropped: handleFilesDropped,
@@ -1173,6 +1213,19 @@ function FileManagerContent({
     confirmWithToast(
       fullMessage,
       async () => {
+        const operationPath = currentPath;
+        const operationSession = sshSessionId;
+        const deletedPaths = new Set(files.map((file) => file.path));
+        commitFilesForPath(
+          operationSession,
+          operationPath,
+          removePaths(
+            filesForPath(operationSession, operationPath),
+            deletedPaths,
+          ),
+        );
+        clearSelection();
+        let completed = 0;
         try {
           await ensureSSHConnection();
 
@@ -1184,6 +1237,7 @@ function FileManagerContent({
               currentHost?.id,
               currentHost?.userId?.toString(),
             );
+            completed += 1;
           }
 
           const deletedFiles = files.map((file) => ({
@@ -1206,9 +1260,23 @@ function FileManagerContent({
           toast.success(
             t("fileManager.itemsDeletedSuccessfully", { count: files.length }),
           );
-          handleRefreshDirectory();
-          clearSelection();
+          if (
+            sshSessionIdRef.current === operationSession &&
+            currentPathRef.current === operationPath
+          ) {
+            handleRefreshDirectory();
+          } else {
+            invalidateCachedFileList(operationSession, operationPath);
+          }
         } catch (error: unknown) {
+          commitFilesForPath(
+            operationSession,
+            operationPath,
+            restoreItems(
+              filesForPath(operationSession, operationPath),
+              files.slice(completed),
+            ),
+          );
           const axiosError = error as {
             response?: {
               data?: { needsSudo?: boolean; error?: string };
@@ -1217,7 +1285,10 @@ function FileManagerContent({
             message?: string;
           };
           if (axiosError.response?.data?.needsSudo) {
-            setPendingSudoOperation({ type: "delete", files });
+            setPendingSudoOperation({
+              type: "delete",
+              files: files.slice(completed),
+            });
             setSudoDialogOpen(true);
             return;
           }
@@ -1827,7 +1898,6 @@ function FileManagerContent({
       toast.success(
         t("fileManager.archiveExtractedSuccessfully", { name: file.name }),
       );
-
       handleRefreshDirectory();
     } catch (error: unknown) {
       const errorMessage = getErrorMessage(error, String(error));
@@ -1869,7 +1939,6 @@ function FileManagerContent({
           name: archiveName,
         }),
       );
-
       handleRefreshDirectory();
       clearSelection();
     } catch (error: unknown) {
@@ -2128,10 +2197,25 @@ function FileManagerContent({
   async function handleConfirmCreate(name: string) {
     if (!createIntent || !sshSessionId) return;
 
+    const operationPath = currentPath;
+    const operationSession = sshSessionId;
+    const optimisticPath = childPath(operationPath, name);
+    const previousFiles = filesForPath(operationSession, operationPath);
+    const optimisticFiles = addOptimisticItem(
+      previousFiles,
+      operationPath,
+      name,
+      createIntent.type,
+    );
+    const didAddOptimistically = optimisticFiles !== previousFiles;
+    commitFilesForPath(operationSession, operationPath, optimisticFiles);
+    const createdType = createIntent.type;
+    setCreateIntent(null);
+
     try {
       await ensureSSHConnection();
 
-      if (createIntent.type === "file") {
+      if (createdType === "file") {
         await createSSHFile(
           sshSessionId,
           currentPath,
@@ -2152,9 +2236,25 @@ function FileManagerContent({
         toast.success(t("fileManager.folderCreatedSuccessfully", { name }));
       }
 
-      setCreateIntent(null);
-      handleRefreshDirectory();
+      if (
+        sshSessionIdRef.current === operationSession &&
+        currentPathRef.current === operationPath
+      ) {
+        handleRefreshDirectory();
+      } else {
+        invalidateCachedFileList(operationSession, operationPath);
+      }
     } catch (error: unknown) {
+      if (didAddOptimistically) {
+        commitFilesForPath(
+          operationSession,
+          operationPath,
+          removePaths(
+            filesForPath(operationSession, operationPath),
+            new Set([optimisticPath]),
+          ),
+        );
+      }
       const axiosError = error as {
         response?: { status?: number; data?: { error?: string } };
       };
@@ -2179,6 +2279,25 @@ function FileManagerContent({
   async function handleRenameConfirm(file: FileItem, newName: string) {
     if (!sshSessionId) return;
 
+    const operationPath = currentPath;
+    const operationSession = sshSessionId;
+    const renamedPath = childPath(
+      file.path.slice(0, Math.max(1, file.path.lastIndexOf("/"))),
+      newName,
+    );
+    const operationFiles = filesForPath(operationSession, operationPath);
+    const didRenameOptimistically = !operationFiles.some(
+      (entry) => entry.path === renamedPath && entry.path !== file.path,
+    );
+    if (didRenameOptimistically) {
+      commitFilesForPath(
+        operationSession,
+        operationPath,
+        renameOptimisticItem(operationFiles, file.path, newName),
+      );
+    }
+    setEditingFile(null);
+
     try {
       await ensureSSHConnection();
 
@@ -2193,9 +2312,26 @@ function FileManagerContent({
       toast.success(
         t("fileManager.itemRenamedSuccessfully", { name: newName }),
       );
-      setEditingFile(null);
-      handleRefreshDirectory();
+      if (
+        sshSessionIdRef.current === operationSession &&
+        currentPathRef.current === operationPath
+      ) {
+        handleRefreshDirectory();
+      } else {
+        invalidateCachedFileList(operationSession, operationPath);
+      }
     } catch (error: unknown) {
+      if (didRenameOptimistically) {
+        commitFilesForPath(
+          operationSession,
+          operationPath,
+          renameOptimisticItem(
+            filesForPath(operationSession, operationPath),
+            renamedPath,
+            file.name,
+          ),
+        );
+      }
       const axiosError = error as {
         response?: { status?: number; data?: { error?: string } };
       };

--- a/src/ui/features/file-manager/optimistic-file-list.ts
+++ b/src/ui/features/file-manager/optimistic-file-list.ts
@@ -1,0 +1,53 @@
+import type { FileItem } from "@/types/index";
+
+export function childPath(parent: string, name: string): string {
+  return parent === "/" ? `/${name}` : `${parent.replace(/\/$/, "")}/${name}`;
+}
+
+export function addOptimisticItem(
+  files: FileItem[],
+  parent: string,
+  name: string,
+  type: "file" | "directory",
+  now = Date.now(),
+): FileItem[] {
+  const path = childPath(parent, name);
+  if (files.some((file) => file.path === path)) return files;
+  return [
+    ...files,
+    {
+      name,
+      path,
+      type,
+      size: type === "file" ? 0 : undefined,
+      modified: new Date(now).toISOString(),
+      modifiedTimestamp: now,
+    },
+  ];
+}
+
+export function removePaths(files: FileItem[], paths: Set<string>): FileItem[] {
+  return files.filter((file) => !paths.has(file.path));
+}
+
+export function restoreItems(
+  files: FileItem[],
+  restored: FileItem[],
+): FileItem[] {
+  const existing = new Set(files.map((file) => file.path));
+  return [...files, ...restored.filter((file) => !existing.has(file.path))];
+}
+
+export function renameOptimisticItem(
+  files: FileItem[],
+  originalPath: string,
+  newName: string,
+): FileItem[] {
+  const slash = originalPath.lastIndexOf("/");
+  const parent = slash <= 0 ? "/" : originalPath.slice(0, slash);
+  return files.map((file) =>
+    file.path === originalPath
+      ? { ...file, name: newName, path: childPath(parent, newName) }
+      : file,
+  );
+}

--- a/src/ui/lib/file-list-request-cache.ts
+++ b/src/ui/lib/file-list-request-cache.ts
@@ -33,3 +33,11 @@ export function invalidateCachedFileList(
 ): void {
   cache.invalidate(keyFor(sessionId, path));
 }
+
+export function updateCachedFileList(
+  sessionId: string,
+  path: string,
+  files: FileItem[],
+): void {
+  cache.set(keyFor(sessionId, path), { files, path });
+}

--- a/src/ui/lib/keyed-request-cache.ts
+++ b/src/ui/lib/keyed-request-cache.ts
@@ -5,6 +5,7 @@ export interface KeyedRequestCache<T> {
     options?: { force?: boolean },
   ): Promise<T>;
   peek(key: string, maxAgeMs?: number): T | null;
+  set(key: string, value: T): void;
   invalidate(key?: string): void;
 }
 
@@ -15,6 +16,7 @@ export function createKeyedRequestCache<T>(
 ): KeyedRequestCache<T> {
   const values = new Map<string, { value: T; storedAt: number }>();
   const inflight = new Map<string, Promise<T>>();
+  const versions = new Map<string, number>();
 
   const store = (key: string, value: T) => {
     values.delete(key);
@@ -36,12 +38,15 @@ export function createKeyedRequestCache<T>(
       const pending = inflight.get(key);
       if (pending) return pending;
 
+      const version = versions.get(key) ?? 0;
       const request = loader()
         .then((value) => {
-          store(key, value);
+          if ((versions.get(key) ?? 0) === version) store(key, value);
           return value;
         })
-        .finally(() => inflight.delete(key));
+        .finally(() => {
+          if (inflight.get(key) === request) inflight.delete(key);
+        });
       inflight.set(key, request);
       return request;
     },
@@ -54,9 +59,24 @@ export function createKeyedRequestCache<T>(
       return cached.value;
     },
 
+    set(key, value) {
+      versions.set(key, (versions.get(key) ?? 0) + 1);
+      inflight.delete(key);
+      store(key, value);
+    },
+
     invalidate(key) {
-      if (key === undefined) values.clear();
-      else values.delete(key);
+      if (key === undefined) {
+        for (const activeKey of inflight.keys()) {
+          versions.set(activeKey, (versions.get(activeKey) ?? 0) + 1);
+        }
+        values.clear();
+        inflight.clear();
+      } else {
+        versions.set(key, (versions.get(key) ?? 0) + 1);
+        values.delete(key);
+        inflight.delete(key);
+      }
     },
   };
 }

--- a/src/ui/tests/features/file-manager/optimistic-file-list.test.ts
+++ b/src/ui/tests/features/file-manager/optimistic-file-list.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import type { FileItem } from "@/types/index";
+import {
+  addOptimisticItem,
+  childPath,
+  removePaths,
+  renameOptimisticItem,
+  restoreItems,
+} from "../../../features/file-manager/optimistic-file-list";
+
+const files: FileItem[] = [
+  { name: "alpha.txt", path: "/work/alpha.txt", type: "file", size: 10 },
+  { name: "docs", path: "/work/docs", type: "directory" },
+];
+
+describe("optimistic file list updates", () => {
+  it("builds child paths without duplicate separators", () => {
+    expect(childPath("/", "file.txt")).toBe("/file.txt");
+    expect(childPath("/work/", "file.txt")).toBe("/work/file.txt");
+  });
+
+  it("adds and rolls back a provisional item", () => {
+    const added = addOptimisticItem(files, "/work", "new.txt", "file", 0);
+    expect(added.at(-1)).toMatchObject({
+      name: "new.txt",
+      path: "/work/new.txt",
+      type: "file",
+      size: 0,
+    });
+    expect(removePaths(added, new Set(["/work/new.txt"]))).toEqual(files);
+  });
+
+  it("renames immediately and can reverse the same item", () => {
+    const renamed = renameOptimisticItem(files, "/work/alpha.txt", "beta.txt");
+    expect(renamed[0]).toMatchObject({
+      name: "beta.txt",
+      path: "/work/beta.txt",
+      size: 10,
+    });
+    expect(
+      renameOptimisticItem(renamed, "/work/beta.txt", "alpha.txt"),
+    ).toEqual(files);
+  });
+
+  it("restores only failed deletions without duplicating survivors", () => {
+    const remaining = removePaths(files, new Set(["/work/docs"]));
+    expect(restoreItems(remaining, [files[1], files[0]])).toEqual(files);
+  });
+});

--- a/src/ui/tests/lib/keyed-request-cache.test.ts
+++ b/src/ui/tests/lib/keyed-request-cache.test.ts
@@ -66,4 +66,19 @@ describe("createKeyedRequestCache", () => {
     ).rejects.toThrow("offline");
     expect(cache.peek("key")).toBe("safe");
   });
+
+  it("does not let an invalidated request overwrite newer data", async () => {
+    let resolveOld!: (value: string) => void;
+    const cache = createKeyedRequestCache<string>(10_000);
+    const oldRequest = cache.get(
+      "key",
+      () => new Promise<string>((resolve) => (resolveOld = resolve)),
+    );
+
+    cache.set("key", "optimistic");
+    resolveOld("old");
+    await oldRequest;
+
+    expect(cache.peek("key")).toBe("optimistic");
+  });
 });


### PR DESCRIPTION
## Summary

- apply create, rename, and confirmed delete operations to the visible file list immediately instead of waiting for SSH round trips
- keep the shared directory cache in sync with optimistic state so navigation and background refresh cannot flash old entries back into view
- roll back only the failed portion of multi-item deletes while preserving items already deleted remotely
- scope asynchronous completion and rollback to the originating session and directory, so navigating away during an operation never mutates the new view
- invalidate superseded in-flight cache requests and prevent their late responses from overwriting newer optimistic data
- fall back to server-confirmed behavior for name collisions and preserve sudo escalation

## Validation

- `npm run lint` (0 errors; 103 existing warnings)
- `npm run type-check`
- `npm run build`
- full test suite: 305 files, 2281 passed, 1 skipped
- optimistic list and cache race tests: 9 passed
