### PR TITLE
feat: preload likely user actions

### DIFF
--- a/src/ui/api/ssh-file-operations-api.ts
+++ b/src/ui/api/ssh-file-operations-api.ts
@@ -13,6 +13,11 @@ import { resolveConnectionOrigin } from "@/lib/connection-origin";
 import { fileLogger } from "@/lib/frontend-logger";
 import type { FileItem, SSHHost } from "@/types/index";
 import { getCachedFileList } from "@/lib/file-list-request-cache";
+import {
+  getCachedFileContent,
+  invalidateCachedFileContent,
+  type FileContentResult,
+} from "@/lib/file-content-request-cache";
 
 type ApiConnectionLog = {
   type: "info" | "success" | "warning" | "error";
@@ -352,31 +357,41 @@ export async function resolveSSHPath(
 export async function readSSHFile(
   sessionId: string,
   path: string,
-): Promise<{
-  content: string;
-  path: string;
-  encoding?: "base64" | "utf8";
-}> {
-  try {
-    const response = await getFileManagerApiForSession(sessionId).get(
-      "/ssh/readFile",
-      { params: { sessionId, path } },
-    );
-    return response.data;
-  } catch (error: unknown) {
-    const httpError = asHttpError(error);
-    if (httpError.response?.status === 404) {
-      const customError = new Error("File not found");
-      (
-        customError as Error & { response?: unknown; isFileNotFound?: boolean }
-      ).response = httpError.response;
-      (
-        customError as Error & { response?: unknown; isFileNotFound?: boolean }
-      ).isFileNotFound = httpError.response.data?.fileNotFound || true;
-      throw customError;
-    }
-    handleApiError(error, "read SSH file");
-  }
+  options: { force?: boolean } = {},
+): Promise<FileContentResult> {
+  return getCachedFileContent(
+    sessionId,
+    path,
+    async () => {
+      try {
+        const response = await getFileManagerApiForSession(sessionId).get(
+          "/ssh/readFile",
+          { params: { sessionId, path } },
+        );
+        return response.data;
+      } catch (error: unknown) {
+        const httpError = asHttpError(error);
+        if (httpError.response?.status === 404) {
+          const customError = new Error("File not found");
+          (
+            customError as Error & {
+              response?: unknown;
+              isFileNotFound?: boolean;
+            }
+          ).response = httpError.response;
+          (
+            customError as Error & {
+              response?: unknown;
+              isFileNotFound?: boolean;
+            }
+          ).isFileNotFound = httpError.response.data?.fileNotFound || true;
+          throw customError;
+        }
+        handleApiError(error, "read SSH file");
+      }
+    },
+    options.force,
+  );
 }
 
 export async function writeSSHFile(
@@ -397,6 +412,7 @@ export async function writeSSHFile(
       (response.data.message === "File written successfully" ||
         response.status === 200)
     ) {
+      invalidateCachedFileContent(sessionId, path);
       return response.data;
     } else {
       throw new Error("File write operation did not return success status");
@@ -604,6 +620,7 @@ export async function deleteSSHItem(
         },
       },
     );
+    if (!isDirectory) invalidateCachedFileContent(sessionId, path);
     return response.data;
   } catch (error) {
     handleApiError(error, "delete SSH item");
@@ -671,6 +688,10 @@ export async function renameSSHItem(
       "/ssh/renameItem",
       { sessionId, oldPath, newName, hostId, userId },
     );
+    invalidateCachedFileContent(sessionId, oldPath);
+    const separator = oldPath.lastIndexOf("/");
+    const newPath = `${oldPath.slice(0, separator + 1)}${newName}`;
+    invalidateCachedFileContent(sessionId, newPath);
     return response.data;
   } catch (error) {
     handleApiError(error, "rename SSH item");
@@ -699,6 +720,8 @@ export async function moveSSHItem(
         timeout: 60000,
       },
     );
+    invalidateCachedFileContent(sessionId, oldPath);
+    invalidateCachedFileContent(sessionId, newPath);
     return response.data;
   } catch (error) {
     handleApiError(error, "move SSH item");

--- a/src/ui/features/file-manager/FileManager.tsx
+++ b/src/ui/features/file-manager/FileManager.tsx
@@ -75,6 +75,7 @@ import {
 } from "@/main-axios.ts";
 import { getPollingEnvironmentMultiplier } from "@/lib/adaptive-polling";
 import { shouldPrefetchFileContent } from "@/lib/file-content-request-cache";
+import { preloadFilePreview } from "./file-preview-preload";
 import { beginTransferProgressMonitoring } from "./transferProgressMonitor.tsx";
 import { createFormatTransferMetrics } from "./transferMetricsFormat.ts";
 import type {
@@ -1570,6 +1571,7 @@ function FileManagerContent({
         return;
       }
       if (shouldPrefetchFileContent(file, getPollingEnvironmentMultiplier())) {
+        preloadFilePreview(file.name);
         void readSSHFile(sshSessionId, file.path).catch(() => {});
       }
     },

--- a/src/ui/features/file-manager/FileManager.tsx
+++ b/src/ui/features/file-manager/FileManager.tsx
@@ -41,6 +41,7 @@ import { useConnectionRetry } from "@/lib/useConnectionRetry.ts";
 import { copyToClipboard } from "@/lib/clipboard.ts";
 import {
   listSSHFiles,
+  readSSHFile,
   resolveSSHPath,
   uploadSSHFile,
   createSSHFile,
@@ -72,6 +73,8 @@ import {
   type TransferMethodPreference,
   type DiskFilesystem,
 } from "@/main-axios.ts";
+import { getPollingEnvironmentMultiplier } from "@/lib/adaptive-polling";
+import { shouldPrefetchFileContent } from "@/lib/file-content-request-cache";
 import { beginTransferProgressMonitoring } from "./transferProgressMonitor.tsx";
 import { createFormatTransferMetrics } from "./transferMetricsFormat.ts";
 import type {
@@ -1559,10 +1562,16 @@ function FileManagerContent({
     openFileWindow(file, sshSessionId);
   }
 
-  const prefetchDirectory = useCallback(
+  const prefetchFileIntent = useCallback(
     (file: FileItem) => {
-      if (!sshSessionId || file.type !== "directory") return;
-      void listSSHFiles(sshSessionId, file.path).catch(() => {});
+      if (!sshSessionId) return;
+      if (file.type === "directory") {
+        void listSSHFiles(sshSessionId, file.path).catch(() => {});
+        return;
+      }
+      if (shouldPrefetchFileContent(file, getPollingEnvironmentMultiplier())) {
+        void readSSHFile(sshSessionId, file.path).catch(() => {});
+      }
     },
     [sshSessionId],
   );
@@ -3164,7 +3173,7 @@ function FileManagerContent({
                 files={filteredFiles}
                 selectedFiles={selectedFiles}
                 onFileOpen={handleFileOpen}
-                onDirectoryIntent={prefetchDirectory}
+                onFileIntent={prefetchFileIntent}
                 onSelectionChange={setSelection}
                 onRefresh={handleRefreshDirectory}
                 onUpload={handleFilesDropped}

--- a/src/ui/features/file-manager/FileManagerGrid.tsx
+++ b/src/ui/features/file-manager/FileManagerGrid.tsx
@@ -46,7 +46,7 @@ interface FileManagerGridProps {
   files: FileItem[];
   selectedFiles: FileItem[];
   onFileOpen: (file: FileItem) => void;
-  onDirectoryIntent?: (file: FileItem) => void;
+  onFileIntent?: (file: FileItem) => void;
   onSelectionChange: (files: FileItem[]) => void;
   onRefresh: () => void;
   onUpload?: (files: FileList) => void;
@@ -163,7 +163,7 @@ export function FileManagerGrid({
   files,
   selectedFiles,
   onFileOpen,
-  onDirectoryIntent,
+  onFileIntent,
   onSelectionChange,
   onRefresh,
   onUpload,
@@ -717,7 +717,7 @@ export function FileManagerGrid({
   const handleFileClick = (file: FileItem, event: React.MouseEvent) => {
     event.stopPropagation();
 
-    if (file.type === "directory") onDirectoryIntent?.(file);
+    onFileIntent?.(file);
 
     if (gridRef.current && !createIntent) {
       gridRef.current.focus();

--- a/src/ui/features/file-manager/components/FileViewer.tsx
+++ b/src/ui/features/file-manager/components/FileViewer.tsx
@@ -45,32 +45,20 @@ import {
 import { Button } from "@/components/button.tsx";
 import { Kbd, KbdKey } from "@/components/kbd.tsx";
 import type { CodeEditorHandle } from "./CodeEditor.tsx";
+import {
+  loadAudioPreview,
+  loadCodeEditor,
+  loadImagePreview,
+  loadMarkdownRenderer,
+  loadPdfPreview,
+  resolveFilePreviewKind,
+} from "../file-preview-preload";
 
-const CodeEditor = lazy(() =>
-  import("./CodeEditor.tsx").then((module) => ({
-    default: module.CodeEditor,
-  })),
-);
-const ImagePreview = lazy(() =>
-  import("./ImagePreview.tsx").then((module) => ({
-    default: module.ImagePreview,
-  })),
-);
-const MarkdownRenderer = lazy(() =>
-  import("./MarkdownRenderer.tsx").then((module) => ({
-    default: module.MarkdownRenderer,
-  })),
-);
-const PdfPreview = lazy(() =>
-  import("./PdfPreview.tsx").then((module) => ({
-    default: module.PdfPreview,
-  })),
-);
-const AudioPreview = lazy(() =>
-  import("./AudioPreview.tsx").then((module) => ({
-    default: module.AudioPreview,
-  })),
-);
+const CodeEditor = lazy(loadCodeEditor);
+const ImagePreview = lazy(loadImagePreview);
+const MarkdownRenderer = lazy(loadMarkdownRenderer);
+const PdfPreview = lazy(loadPdfPreview);
+const AudioPreview = lazy(loadAudioPreview);
 
 interface FileItem {
   name: string;
@@ -157,84 +145,45 @@ function getFileType(filename: string): {
   icon: React.ReactNode;
   color: string;
 } {
-  const ext = filename.split(".").pop()?.toLowerCase() || "";
+  const kind = resolveFilePreviewKind(filename);
 
-  const imageExts = ["png", "jpg", "jpeg", "gif", "bmp", "svg", "webp"];
-  const videoExts = ["mp4", "avi", "mkv", "mov", "wmv", "flv", "webm"];
-  const audioExts = ["mp3", "wav", "flac", "ogg", "aac", "m4a"];
-  const textExts = ["txt", "readme"];
-  const markdownExts = ["md", "markdown", "mdown", "mkdn", "mdx"];
-  const pdfExts = ["pdf"];
-  const codeExts = [
-    "js",
-    "ts",
-    "jsx",
-    "tsx",
-    "py",
-    "java",
-    "cpp",
-    "c",
-    "cs",
-    "php",
-    "rb",
-    "go",
-    "rs",
-    "html",
-    "css",
-    "scss",
-    "less",
-    "json",
-    "xml",
-    "yaml",
-    "yml",
-    "toml",
-    "ini",
-    "conf",
-    "sh",
-    "bash",
-    "zsh",
-    "sql",
-    "vue",
-    "svelte",
-  ];
-
-  if (imageExts.includes(ext)) {
+  if (kind === "image") {
     return {
       type: "image",
       icon: <ImageIcon className="w-6 h-6" />,
       color: "text-green-500",
     };
-  } else if (videoExts.includes(ext)) {
+  } else if (kind === "video") {
     return {
       type: "video",
       icon: <Film className="w-6 h-6" />,
       color: "text-purple-500",
     };
-  } else if (audioExts.includes(ext)) {
+  } else if (kind === "audio") {
     return {
       type: "audio",
       icon: <Music className="w-6 h-6" />,
       color: "text-pink-500",
     };
-  } else if (markdownExts.includes(ext)) {
+  } else if (kind === "markdown") {
     return {
       type: "markdown",
       icon: <FileText className="w-6 h-6" />,
       color: "text-blue-600",
     };
-  } else if (pdfExts.includes(ext)) {
+  } else if (kind === "pdf") {
     return {
       type: "pdf",
       icon: <FileText className="w-6 h-6" />,
       color: "text-red-600",
     };
-  } else if (textExts.includes(ext)) {
+  } else if (kind === "text") {
     return {
       type: "text",
       icon: <FileText className="w-6 h-6" />,
       color: "text-blue-500",
     };
-  } else if (codeExts.includes(ext)) {
+  } else if (kind === "code") {
     return {
       type: "code",
       icon: getLanguageIcon(filename),

--- a/src/ui/features/file-manager/components/FileWindow.tsx
+++ b/src/ui/features/file-manager/components/FileWindow.tsx
@@ -271,7 +271,9 @@ export function FileWindow({
 
         await ensureSSHConnection();
 
-        const response = await readSSHFile(sshSessionId, file.path);
+        const response = await readSSHFile(sshSessionId, file.path, {
+          force: true,
+        });
         const fileContent = response.content || "";
         setContent(fileContent);
         setPendingContent("");

--- a/src/ui/features/file-manager/file-preview-preload.ts
+++ b/src/ui/features/file-manager/file-preview-preload.ts
@@ -1,0 +1,104 @@
+export type FilePreviewKind =
+  | "image"
+  | "video"
+  | "audio"
+  | "markdown"
+  | "pdf"
+  | "text"
+  | "code"
+  | "unknown";
+
+const extensions = {
+  image: new Set(["png", "jpg", "jpeg", "gif", "bmp", "svg", "webp"]),
+  video: new Set(["mp4", "avi", "mkv", "mov", "wmv", "flv", "webm"]),
+  audio: new Set(["mp3", "wav", "flac", "ogg", "aac", "m4a"]),
+  markdown: new Set(["md", "markdown", "mdown", "mkdn", "mdx"]),
+  pdf: new Set(["pdf"]),
+  text: new Set(["txt", "readme"]),
+  code: new Set([
+    "js",
+    "ts",
+    "jsx",
+    "tsx",
+    "py",
+    "java",
+    "cpp",
+    "c",
+    "cs",
+    "php",
+    "rb",
+    "go",
+    "rs",
+    "html",
+    "css",
+    "scss",
+    "less",
+    "json",
+    "xml",
+    "yaml",
+    "yml",
+    "toml",
+    "ini",
+    "conf",
+    "sh",
+    "bash",
+    "zsh",
+    "sql",
+    "vue",
+    "svelte",
+  ]),
+} satisfies Record<Exclude<FilePreviewKind, "unknown">, Set<string>>;
+
+const extensionlessCodeFiles = new Set([
+  "dockerfile",
+  "makefile",
+  "rakefile",
+  "gemfile",
+]);
+
+export function resolveFilePreviewKind(filename: string): FilePreviewKind {
+  const lowerName = filename.toLowerCase();
+  if (extensionlessCodeFiles.has(lowerName)) return "code";
+
+  const extension = lowerName.split(".").pop() || "";
+  for (const [kind, knownExtensions] of Object.entries(extensions)) {
+    if (knownExtensions.has(extension)) return kind as FilePreviewKind;
+  }
+  return "unknown";
+}
+
+export const loadCodeEditor = () =>
+  import("./components/CodeEditor.tsx").then((module) => ({
+    default: module.CodeEditor,
+  }));
+export const loadImagePreview = () =>
+  import("./components/ImagePreview.tsx").then((module) => ({
+    default: module.ImagePreview,
+  }));
+export const loadMarkdownRenderer = () =>
+  import("./components/MarkdownRenderer.tsx").then((module) => ({
+    default: module.MarkdownRenderer,
+  }));
+export const loadPdfPreview = () =>
+  import("./components/PdfPreview.tsx").then((module) => ({
+    default: module.PdfPreview,
+  }));
+export const loadAudioPreview = () =>
+  import("./components/AudioPreview.tsx").then((module) => ({
+    default: module.AudioPreview,
+  }));
+
+const previewLoaders: Partial<Record<FilePreviewKind, () => Promise<unknown>>> =
+  {
+    image: loadImagePreview,
+    audio: loadAudioPreview,
+    markdown: loadMarkdownRenderer,
+    pdf: loadPdfPreview,
+    text: loadCodeEditor,
+    code: loadCodeEditor,
+    unknown: loadCodeEditor,
+  };
+
+export function preloadFilePreview(filename: string): void {
+  void previewLoaders[resolveFilePreviewKind(filename)]?.().catch(() => {});
+}

--- a/src/ui/features/terminal/Terminal.tsx
+++ b/src/ui/features/terminal/Terminal.tsx
@@ -193,6 +193,7 @@ const TerminalInner = forwardRef<TerminalHandle, SSHTerminalProps>(
       : themeColors.background;
     const fitAddonRef = useRef<FitAddon | null>(null);
     const webSocketRef = useRef<WebSocket | null>(null);
+    const terminalInputDisposableRef = useRef<{ dispose(): void } | null>(null);
     const customKeybindingsRef = useRef<CustomKeybinding[]>([]);
     const cachedSnippetsRef = useRef<{ id: number; content: string }[] | null>(
       null,
@@ -1211,6 +1212,8 @@ const TerminalInner = forwardRef<TerminalHandle, SSHTerminalProps>(
         webSocketRef.current &&
         webSocketRef.current.readyState !== WebSocket.CLOSED
       ) {
+        terminalInputDisposableRef.current?.dispose();
+        terminalInputDisposableRef.current = null;
         webSocketRef.current.close();
       }
 
@@ -1322,7 +1325,9 @@ const TerminalInner = forwardRef<TerminalHandle, SSHTerminalProps>(
             }),
           );
         }
-        terminal.onData((data) => {
+        terminalInputDisposableRef.current?.dispose();
+        terminalInputDisposableRef.current = terminal.onData((data) => {
+          if (ws.readyState !== WebSocket.OPEN) return;
           if (data === "\r" || data === "\n") {
             const currentCmd = getCurrentCommand().trim();
             const termixMatch = currentCmd.match(/^termix\s+(.+)$/);
@@ -2021,6 +2026,9 @@ const TerminalInner = forwardRef<TerminalHandle, SSHTerminalProps>(
           return;
         }
 
+        terminalInputDisposableRef.current?.dispose();
+        terminalInputDisposableRef.current = null;
+
         setIsConnected(false);
         isConnectingRef.current = false;
 
@@ -2602,6 +2610,14 @@ const TerminalInner = forwardRef<TerminalHandle, SSHTerminalProps>(
     }, [xtermRef, terminal]);
 
     const isMountedRef = useRef(false);
+
+    useEffect(
+      () => () => {
+        terminalInputDisposableRef.current?.dispose();
+        terminalInputDisposableRef.current = null;
+      },
+      [],
+    );
 
     useEffect(() => {
       isMountedRef.current = true;

--- a/src/ui/lib/file-content-request-cache.ts
+++ b/src/ui/lib/file-content-request-cache.ts
@@ -1,0 +1,40 @@
+import type { FileItem } from "@/types/index";
+import { createKeyedRequestCache } from "./keyed-request-cache";
+
+export interface FileContentResult {
+  content: string;
+  path: string;
+  encoding?: "base64" | "utf8";
+}
+
+const MAX_PREFETCH_BYTES = 512 * 1024;
+const cache = createKeyedRequestCache<FileContentResult>(30_000, 24);
+const keyFor = (sessionId: string, path: string) => `${sessionId}\0${path}`;
+
+export function getCachedFileContent(
+  sessionId: string,
+  path: string,
+  loader: () => Promise<FileContentResult>,
+  force = false,
+): Promise<FileContentResult> {
+  return cache.get(keyFor(sessionId, path), loader, { force });
+}
+
+export function invalidateCachedFileContent(
+  sessionId: string,
+  path: string,
+): void {
+  cache.invalidate(keyFor(sessionId, path));
+}
+
+export function shouldPrefetchFileContent(
+  file: FileItem,
+  networkMultiplier: number,
+): boolean {
+  return (
+    file.type === "file" &&
+    typeof file.size === "number" &&
+    file.size <= MAX_PREFETCH_BYTES &&
+    networkMultiplier <= 1
+  );
+}

--- a/src/ui/shell/tabUtils.tsx
+++ b/src/ui/shell/tabUtils.tsx
@@ -40,6 +40,7 @@ import { useIsMobile } from "@/hooks/use-mobile";
 import type { Tab, TabType, Host } from "@/types/ui-types";
 import type { SSHHost } from "@/types";
 import { useTabsSafe } from "@/shell/TabContext";
+import { getPollingEnvironmentMultiplier } from "@/lib/adaptive-polling";
 
 // Heavy tab surfaces — keep out of the AppShell critical path.
 const CommandHistoryProvider = lazy(() =>
@@ -47,46 +48,46 @@ const CommandHistoryProvider = lazy(() =>
     (m) => ({ default: m.CommandHistoryProvider }),
   ),
 );
-const TerminalFeature = lazy(() =>
+const loadTerminalFeature = () =>
   import("@/features/terminal/Terminal").then((m) => ({
     default: m.Terminal,
-  })),
-);
+  }));
+const TerminalFeature = lazy(loadTerminalFeature);
 const MobileTerminalKeyboard = lazy(() =>
   import("@/features/terminal/MobileTerminalKeyboard").then((m) => ({
     default: m.MobileTerminalKeyboard,
   })),
 );
-const FileManager = lazy(() =>
+const loadFileManager = () =>
   import("@/features/file-manager/FileManager").then((m) => ({
     default: m.FileManager,
-  })),
-);
-const DockerManager = lazy(() =>
+  }));
+const FileManager = lazy(loadFileManager);
+const loadDockerManager = () =>
   import("@/features/docker/DockerManager").then((m) => ({
     default: m.DockerManager,
-  })),
-);
-const HostMetricsTab = lazy(() =>
+  }));
+const DockerManager = lazy(loadDockerManager);
+const loadHostMetricsTab = () =>
   import("@/features/host-metrics/HostMetricsTab").then((m) => ({
     default: m.HostMetricsTab,
-  })),
-);
-const ProxmoxStatsTab = lazy(() =>
+  }));
+const HostMetricsTab = lazy(loadHostMetricsTab);
+const loadProxmoxStatsTab = () =>
   import("@/features/proxmox-stats/ProxmoxStatsTab").then((m) => ({
     default: m.ProxmoxStatsTab,
-  })),
-);
-const TmuxMonitor = lazy(() =>
+  }));
+const ProxmoxStatsTab = lazy(loadProxmoxStatsTab);
+const loadTmuxMonitor = () =>
   import("@/features/tmux-monitor/TmuxMonitor").then((m) => ({
     default: m.TmuxMonitor,
-  })),
-);
-const GuacamoleApp = lazy(() =>
+  }));
+const TmuxMonitor = lazy(loadTmuxMonitor);
+const loadGuacamoleApp = () =>
   import("@/features/guacamole/GuacamoleApp").then((m) => ({
     default: m.default,
-  })),
-);
+  }));
+const GuacamoleApp = lazy(loadGuacamoleApp);
 const DashboardTab = lazy(() =>
   import("@/dashboard/DashboardTab").then((m) => ({
     default: m.DashboardTab,
@@ -97,11 +98,11 @@ const HomepageCanvas = lazy(() =>
     default: m.HomepageCanvas,
   })),
 );
-const TunnelTab = lazy(() =>
+const loadTunnelTab = () =>
   import("@/features/tunnel/TunnelTab").then((m) => ({
     default: m.TunnelTab,
-  })),
-);
+  }));
+const TunnelTab = lazy(loadTunnelTab);
 const NetworkGraphCard = lazy(() =>
   import("@/dashboard/cards/NetworkGraphCard").then((m) => ({
     default: m.NetworkGraphCard,
@@ -150,6 +151,25 @@ const AiPanel = lazy(() =>
     default: m.AiPanel,
   })),
 );
+
+const tabSurfaceLoaders: Partial<Record<TabType, () => Promise<unknown>>> = {
+  terminal: loadTerminalFeature,
+  files: loadFileManager,
+  docker: loadDockerManager,
+  "host-metrics": loadHostMetricsTab,
+  "proxmox-stats": loadProxmoxStatsTab,
+  tmux_monitor: loadTmuxMonitor,
+  tunnel: loadTunnelTab,
+  rdp: loadGuacamoleApp,
+  vnc: loadGuacamoleApp,
+  telnet: loadGuacamoleApp,
+};
+
+/** Download a likely next tab without starting a connection or mounting UI. */
+export function preloadTabSurface(type: TabType): void {
+  if (getPollingEnvironmentMultiplier() > 1) return;
+  void tabSurfaceLoaders[type]?.().catch(() => {});
+}
 
 function hostToSSHHost(h: Host): SSHHost {
   return {

--- a/src/ui/sidebar/tree/HostItem/HostItem.tsx
+++ b/src/ui/sidebar/tree/HostItem/HostItem.tsx
@@ -68,6 +68,7 @@ import {
   TooltipTrigger,
 } from "@/components/tooltip";
 import { hostMatchesQuery } from "../visible-rows";
+import { preloadTabSurface } from "@/shell/tabUtils";
 
 export function statusCheckEnabled(host: Host): boolean {
   return host.statsConfig?.statusCheckEnabled !== false;
@@ -390,6 +391,8 @@ export function HostItem({
         <button
           key={type}
           title={label}
+          onPointerEnter={() => preloadTabSurface(type)}
+          onFocus={() => preloadTabSurface(type)}
           onClick={(e) => {
             e.stopPropagation();
             onOpenTab(type);
@@ -407,6 +410,8 @@ export function HostItem({
       {host.enableRdp && (
         <button
           title={t("hosts.connectRdp")}
+          onPointerEnter={() => preloadTabSurface("rdp")}
+          onFocus={() => preloadTabSurface("rdp")}
           onClick={(e) => {
             e.stopPropagation();
             onOpenTab("rdp");
@@ -428,6 +433,8 @@ export function HostItem({
       {host.enableVnc && (
         <button
           title={t("hosts.connectVnc")}
+          onPointerEnter={() => preloadTabSurface("vnc")}
+          onFocus={() => preloadTabSurface("vnc")}
           onClick={(e) => {
             e.stopPropagation();
             onOpenTab("vnc");
@@ -440,6 +447,8 @@ export function HostItem({
       {host.enableTelnet && (
         <button
           title={t("hosts.connectTelnet")}
+          onPointerEnter={() => preloadTabSurface("telnet")}
+          onFocus={() => preloadTabSurface("telnet")}
           onClick={(e) => {
             e.stopPropagation();
             onOpenTab("telnet");
@@ -817,6 +826,12 @@ export function HostItem({
         }
       }}
       style={depthStyle}
+      onPointerEnter={() => {
+        if (host.enableSsh) preloadTabSurface("terminal");
+        else if (host.enableRdp) preloadTabSurface("rdp");
+        else if (host.enableVnc) preloadTabSurface("vnc");
+        else if (host.enableTelnet) preloadTabSurface("telnet");
+      }}
       className={`group relative flex items-stretch cursor-pointer select-none transition-colors hover:bg-muted/50 ${
         selected
           ? "bg-accent-brand/[0.07]"

--- a/src/ui/tests/features/file-manager/file-preview-preload.test.ts
+++ b/src/ui/tests/features/file-manager/file-preview-preload.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { resolveFilePreviewKind } from "../../../features/file-manager/file-preview-preload";
+
+describe("resolveFilePreviewKind", () => {
+  it.each([
+    ["photo.webp", "image"],
+    ["movie.webm", "video"],
+    ["voice.m4a", "audio"],
+    ["README.md", "markdown"],
+    ["manual.pdf", "pdf"],
+    ["notes.txt", "text"],
+    ["app.tsx", "code"],
+    ["Dockerfile", "code"],
+    ["LICENSE", "unknown"],
+  ] as const)("classifies %s as %s", (filename, expected) => {
+    expect(resolveFilePreviewKind(filename)).toBe(expected);
+  });
+});

--- a/src/ui/tests/lib/file-content-request-cache.test.ts
+++ b/src/ui/tests/lib/file-content-request-cache.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  getCachedFileContent,
+  invalidateCachedFileContent,
+  shouldPrefetchFileContent,
+} from "../../lib/file-content-request-cache";
+
+describe("file content request cache", () => {
+  it("coalesces reads and reloads after invalidation", async () => {
+    const loader = vi.fn(async () => ({ content: "hello", path: "/note" }));
+
+    await Promise.all([
+      getCachedFileContent("session", "/note", loader),
+      getCachedFileContent("session", "/note", loader),
+    ]);
+    expect(loader).toHaveBeenCalledOnce();
+
+    invalidateCachedFileContent("session", "/note");
+    await getCachedFileContent("session", "/note", loader);
+    expect(loader).toHaveBeenCalledTimes(2);
+  });
+
+  it("only prefetches known small files on an unconstrained network", () => {
+    expect(
+      shouldPrefetchFileContent(
+        { name: "note", path: "/note", type: "file", size: 512 * 1024 },
+        1,
+      ),
+    ).toBe(true);
+    expect(
+      shouldPrefetchFileContent(
+        { name: "large", path: "/large", type: "file", size: 512 * 1024 + 1 },
+        1,
+      ),
+    ).toBe(false);
+    expect(
+      shouldPrefetchFileContent(
+        { name: "unknown", path: "/unknown", type: "file" },
+        1,
+      ),
+    ).toBe(false);
+    expect(
+      shouldPrefetchFileContent(
+        { name: "note", path: "/note", type: "file", size: 100 },
+        1.25,
+      ),
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- prefetch known small files on the first click so double-click previews reuse the in-flight request
- preload the exact CodeMirror, image, Markdown, PDF, or audio viewer alongside likely file content
- preload likely Terminal, File Manager, Docker, metrics, tunnel, tmux, and remote-desktop surfaces from host intent
- skip speculative work on constrained networks and never start authentication or mount the target UI
- replace stale terminal input listeners across WebSocket reconnects so keystrokes are handled exactly once
- bound file-content caching and invalidate it after write, rename, move, and delete operations

## Validation
- `npx eslint src/ui/features/terminal/Terminal.tsx --quiet`
- `npm run type-check`
- `npm test -- --run` (307 files, 2292 passed, 1 skipped)
- `npm run build`