### PR TITLE
feat: learn local host action preferences

### DIFF
--- a/src/ui/lib/local-adaptive-preferences.ts
+++ b/src/ui/lib/local-adaptive-preferences.ts
@@ -1,0 +1,191 @@
+import type { TabType } from "@/types/ui-types";
+
+export const LOCAL_ADAPTIVE_PREFERENCES_KEY =
+  "termix.local.adaptive-preferences.v1";
+
+const VERSION = 1;
+const HALF_LIFE_MS = 30 * 24 * 60 * 60 * 1000;
+const MAX_SCOPES = 128;
+const MAX_ACTIONS_PER_SCOPE = 12;
+const MIN_EFFECTIVE_WEIGHT = 2.5;
+const MIN_SHARE = 0.6;
+const MIN_MARGIN = 1;
+
+interface ActionStat {
+  weight: number;
+  updatedAt: number;
+}
+
+interface PreferenceScope {
+  actions: Record<string, ActionStat>;
+  updatedAt: number;
+}
+
+interface PreferenceStore {
+  version: typeof VERSION;
+  scopes: Record<string, PreferenceScope>;
+}
+
+function emptyStore(): PreferenceStore {
+  return { version: VERSION, scopes: {} };
+}
+
+function sanitizeStore(value: unknown): PreferenceStore {
+  if (!value || typeof value !== "object") return emptyStore();
+  const candidate = value as Partial<PreferenceStore>;
+  if (
+    candidate.version !== VERSION ||
+    !candidate.scopes ||
+    typeof candidate.scopes !== "object" ||
+    Array.isArray(candidate.scopes)
+  ) {
+    return emptyStore();
+  }
+
+  const scopes: Record<string, PreferenceScope> = {};
+  for (const [scope, rawScope] of Object.entries(candidate.scopes)) {
+    if (!rawScope || typeof rawScope !== "object") continue;
+    const value = rawScope as Partial<PreferenceScope>;
+    if (
+      !Number.isFinite(value.updatedAt) ||
+      !value.actions ||
+      typeof value.actions !== "object" ||
+      Array.isArray(value.actions)
+    ) {
+      continue;
+    }
+    const actions: Record<string, ActionStat> = {};
+    for (const [action, rawStat] of Object.entries(value.actions)) {
+      if (!rawStat || typeof rawStat !== "object") continue;
+      const stat = rawStat as Partial<ActionStat>;
+      if (
+        Number.isFinite(stat.weight) &&
+        Number.isFinite(stat.updatedAt) &&
+        Number(stat.weight) > 0
+      ) {
+        actions[action] = {
+          weight: Number(stat.weight),
+          updatedAt: Number(stat.updatedAt),
+        };
+      }
+    }
+    scopes[scope] = {
+      actions,
+      updatedAt: Number(value.updatedAt),
+    };
+  }
+  return { version: VERSION, scopes };
+}
+
+function readStore(): PreferenceStore {
+  if (typeof localStorage === "undefined") return emptyStore();
+  try {
+    const parsed: unknown = JSON.parse(
+      localStorage.getItem(LOCAL_ADAPTIVE_PREFERENCES_KEY) ?? "null",
+    );
+    return sanitizeStore(parsed);
+  } catch {
+    return emptyStore();
+  }
+}
+
+function writeStore(store: PreferenceStore): void {
+  if (typeof localStorage === "undefined") return;
+  try {
+    localStorage.setItem(LOCAL_ADAPTIVE_PREFERENCES_KEY, JSON.stringify(store));
+  } catch {
+    // Learning is optional; storage limits or privacy modes must not affect UX.
+  }
+}
+
+function decayedWeight(stat: ActionStat, now: number): number {
+  const age = Math.max(0, now - stat.updatedAt);
+  return stat.weight * 2 ** (-age / HALF_LIFE_MS);
+}
+
+function trimStore(store: PreferenceStore): void {
+  const scopes = Object.entries(store.scopes).sort(
+    ([, a], [, b]) => b.updatedAt - a.updatedAt,
+  );
+  store.scopes = Object.fromEntries(scopes.slice(0, MAX_SCOPES));
+}
+
+/** Records an abstract action locally. Callers must not use raw paths or input. */
+export function recordLocalPreference(
+  scope: string,
+  action: string,
+  now = Date.now(),
+): void {
+  if (!scope || !action) return;
+  const store = readStore();
+  const current = store.scopes[scope] ?? { actions: {}, updatedAt: now };
+  const previous = current.actions[action];
+  current.actions[action] = {
+    weight: (previous ? decayedWeight(previous, now) : 0) + 1,
+    updatedAt: now,
+  };
+  current.updatedAt = now;
+
+  const actions = Object.entries(current.actions).sort(
+    ([, a], [, b]) => decayedWeight(b, now) - decayedWeight(a, now),
+  );
+  current.actions = Object.fromEntries(actions.slice(0, MAX_ACTIONS_PER_SCOPE));
+  store.scopes[scope] = current;
+  trimStore(store);
+  writeStore(store);
+}
+
+/** Returns a learned action only after enough consistent local evidence. */
+export function getLocalPreference<T extends string>(
+  scope: string,
+  candidates: readonly T[],
+  fallback: T,
+  now = Date.now(),
+): T {
+  const stats = readStore().scopes[scope]?.actions;
+  if (!stats || candidates.length === 0) return fallback;
+
+  const ranked = candidates
+    .map((action) => ({
+      action,
+      weight: stats[action] ? decayedWeight(stats[action], now) : 0,
+    }))
+    .sort((a, b) => b.weight - a.weight);
+  const total = ranked.reduce((sum, item) => sum + item.weight, 0);
+  const [best, second] = ranked;
+  if (
+    !best ||
+    best.weight < MIN_EFFECTIVE_WEIGHT ||
+    best.weight / total < MIN_SHARE ||
+    best.weight - (second?.weight ?? 0) < MIN_MARGIN
+  ) {
+    return fallback;
+  }
+  return best.action;
+}
+
+export function clearLocalAdaptivePreferences(): void {
+  if (typeof localStorage === "undefined") return;
+  try {
+    localStorage.removeItem(LOCAL_ADAPTIVE_PREFERENCES_KEY);
+  } catch {
+    // Optional local learning must remain safe in restricted storage modes.
+  }
+}
+
+const hostActionScope = (hostId: string) => `host-action:${hostId}`;
+
+export function recordHostActionPreference(
+  hostId: string,
+  action: TabType,
+): void {
+  recordLocalPreference(hostActionScope(hostId), action);
+}
+
+export function getPreferredHostAction(
+  hostId: string,
+  candidates: readonly TabType[],
+  fallback: TabType,
+): TabType {
+  return getLocalPreference(hostActionScope(hostId), candidates, fallback);
+}

--- a/src/ui/sidebar/UserProfilePanel.tsx
+++ b/src/ui/sidebar/UserProfilePanel.tsx
@@ -84,6 +84,7 @@ import { useTheme } from "@/components/theme-provider";
 import type { FontSizeId, ThemeId } from "@/types/ui-types";
 import { toast } from "sonner";
 import { changeAppLanguage, normalizeLanguageCode } from "@/i18n/i18n";
+import { clearLocalAdaptivePreferences } from "@/lib/local-adaptive-preferences";
 
 type UserProfileSection =
   | "account"
@@ -954,6 +955,7 @@ export function UserProfilePanel({
   }
 
   function resetToDefaults() {
+    clearLocalAdaptivePreferences();
     const DEFAULT_ACCENT = "#f59145";
     setTheme("system");
     setFontSize("md");

--- a/src/ui/sidebar/tree/HostItem/HostItem.tsx
+++ b/src/ui/sidebar/tree/HostItem/HostItem.tsx
@@ -69,6 +69,10 @@ import {
 } from "@/components/tooltip";
 import { hostMatchesQuery } from "../visible-rows";
 import { preloadTabSurface } from "@/shell/tabUtils";
+import {
+  getPreferredHostAction,
+  recordHostActionPreference,
+} from "@/lib/local-adaptive-preferences";
 
 export function statusCheckEnabled(host: Host): boolean {
   return host.statsConfig?.statusCheckEnabled !== false;
@@ -385,9 +389,30 @@ export function HostItem({
   const trayButtonClass =
     "flex items-center justify-center size-6.5 text-muted-foreground/60 hover:text-foreground hover:bg-muted transition-colors";
 
+  const sshActions = getSshActions(host);
+  const availableActions: TabType[] = [
+    ...sshActions.map(({ type }) => type),
+    ...(host.enableRdp ? (["rdp"] as const) : []),
+    ...(host.enableVnc ? (["vnc"] as const) : []),
+    ...(host.enableTelnet ? (["telnet"] as const) : []),
+  ];
+  const defaultAction: TabType = host.enableSsh
+    ? "terminal"
+    : host.enableRdp
+      ? "rdp"
+      : host.enableVnc
+        ? "vnc"
+        : host.enableTelnet
+          ? "telnet"
+          : "terminal";
+  const openHostTab = (type: TabType) => {
+    recordHostActionPreference(host.id, type);
+    onOpenTab(type);
+  };
+
   const connectionButtons = (
     <>
-      {getSshActions(host).map(({ type, icon: Icon, label }) => (
+      {sshActions.map(({ type, icon: Icon, label }) => (
         <button
           key={type}
           title={label}
@@ -395,7 +420,7 @@ export function HostItem({
           onFocus={() => preloadTabSurface(type)}
           onClick={(e) => {
             e.stopPropagation();
-            onOpenTab(type);
+            openHostTab(type);
           }}
           className={trayButtonClass}
         >
@@ -404,7 +429,7 @@ export function HostItem({
       ))}
       {host.enableSsh &&
         (host.enableRdp || host.enableVnc || host.enableTelnet) &&
-        getSshActions(host).length > 0 && (
+        sshActions.length > 0 && (
           <div className="w-px h-3.5 bg-border/60 mx-0.5 shrink-0" />
         )}
       {host.enableRdp && (
@@ -414,7 +439,7 @@ export function HostItem({
           onFocus={() => preloadTabSurface("rdp")}
           onClick={(e) => {
             e.stopPropagation();
-            onOpenTab("rdp");
+            openHostTab("rdp");
           }}
           className={trayButtonClass}
         >
@@ -437,7 +462,7 @@ export function HostItem({
           onFocus={() => preloadTabSurface("vnc")}
           onClick={(e) => {
             e.stopPropagation();
-            onOpenTab("vnc");
+            openHostTab("vnc");
           }}
           className={trayButtonClass}
         >
@@ -451,7 +476,7 @@ export function HostItem({
           onFocus={() => preloadTabSurface("telnet")}
           onClick={(e) => {
             e.stopPropagation();
-            onOpenTab("telnet");
+            openHostTab("telnet");
           }}
           className={trayButtonClass}
         >
@@ -827,10 +852,15 @@ export function HostItem({
       }}
       style={depthStyle}
       onPointerEnter={() => {
-        if (host.enableSsh) preloadTabSurface("terminal");
-        else if (host.enableRdp) preloadTabSurface("rdp");
-        else if (host.enableVnc) preloadTabSurface("vnc");
-        else if (host.enableTelnet) preloadTabSurface("telnet");
+        preloadTabSurface(defaultAction);
+        const preferredAction = getPreferredHostAction(
+          host.id,
+          availableActions,
+          defaultAction,
+        );
+        if (preferredAction !== defaultAction) {
+          preloadTabSurface(preferredAction);
+        }
       }}
       className={`group relative flex items-stretch cursor-pointer select-none transition-colors hover:bg-muted/50 ${
         selected
@@ -845,11 +875,7 @@ export function HostItem({
           return;
         }
         const launchDefault = () => {
-          if (host.enableSsh) onOpenTab("terminal");
-          else if (host.enableRdp) onOpenTab("rdp");
-          else if (host.enableVnc) onOpenTab("vnc");
-          else if (host.enableTelnet) onOpenTab("telnet");
-          else onOpenTab("terminal");
+          openHostTab(defaultAction);
         };
         // On touch devices, open the action tray so the per-protocol buttons are
         // reachable. If the host only exposes a single action, just launch it.

--- a/src/ui/tests/lib/local-adaptive-preferences.test.ts
+++ b/src/ui/tests/lib/local-adaptive-preferences.test.ts
@@ -1,0 +1,85 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  clearLocalAdaptivePreferences,
+  getLocalPreference,
+  LOCAL_ADAPTIVE_PREFERENCES_KEY,
+  recordLocalPreference,
+} from "../../lib/local-adaptive-preferences";
+
+describe("local adaptive preferences", () => {
+  beforeEach(() => localStorage.removeItem(LOCAL_ADAPTIVE_PREFERENCES_KEY));
+
+  it("keeps the fallback until local evidence is strong enough", () => {
+    recordLocalPreference("host-action:1", "files", 1_000);
+    recordLocalPreference("host-action:1", "files", 1_001);
+
+    expect(
+      getLocalPreference(
+        "host-action:1",
+        ["terminal", "files"],
+        "terminal",
+        1_002,
+      ),
+    ).toBe("terminal");
+
+    recordLocalPreference("host-action:1", "files", 1_003);
+    expect(
+      getLocalPreference(
+        "host-action:1",
+        ["terminal", "files"],
+        "terminal",
+        1_004,
+      ),
+    ).toBe("files");
+  });
+
+  it("uses decayed local counts and ignores unavailable actions", () => {
+    const month = 30 * 24 * 60 * 60 * 1000;
+    for (let i = 0; i < 8; i++) {
+      recordLocalPreference("host-action:1", "docker", i);
+    }
+    for (let i = 0; i < 4; i++) {
+      recordLocalPreference("host-action:1", "files", month + i);
+    }
+
+    expect(
+      getLocalPreference(
+        "host-action:1",
+        ["terminal", "files"],
+        "terminal",
+        month + 10,
+      ),
+    ).toBe("files");
+  });
+
+  it("persists only aggregate local action statistics", () => {
+    recordLocalPreference("host-action:42", "terminal", 10);
+
+    const stored = JSON.parse(
+      localStorage.getItem(LOCAL_ADAPTIVE_PREFERENCES_KEY) ?? "{}",
+    );
+    expect(stored).toEqual({
+      version: 1,
+      scopes: {
+        "host-action:42": {
+          actions: { terminal: { weight: 1, updatedAt: 10 } },
+          updatedAt: 10,
+        },
+      },
+    });
+  });
+
+  it("recovers from malformed local data and can be reset", () => {
+    localStorage.setItem(
+      LOCAL_ADAPTIVE_PREFERENCES_KEY,
+      JSON.stringify({ version: 1, scopes: { broken: "raw input" } }),
+    );
+
+    expect(
+      getLocalPreference("broken", ["terminal", "files"], "terminal", 10),
+    ).toBe("terminal");
+    recordLocalPreference("host-action:1", "files", 11);
+    clearLocalAdaptivePreferences();
+    expect(localStorage.getItem(LOCAL_ADAPTIVE_PREFERENCES_KEY)).toBeNull();
+  });
+});

--- a/src/ui/tests/sidebar/tree/HostItem/HostItem.test.tsx
+++ b/src/ui/tests/sidebar/tree/HostItem/HostItem.test.tsx
@@ -1,6 +1,15 @@
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { Host } from "@/types/ui-types";
+import { LOCAL_ADAPTIVE_PREFERENCES_KEY } from "@/lib/local-adaptive-preferences";
+
+const { preloadTabSurfaceMock } = vi.hoisted(() => ({
+  preloadTabSurfaceMock: vi.fn(),
+}));
+
+vi.mock("@/shell/tabUtils", () => ({
+  preloadTabSurface: preloadTabSurfaceMock,
+}));
 
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({ t: (key: string) => key }),
@@ -75,7 +84,11 @@ function renderHostItem(
   );
 }
 
-afterEach(cleanup);
+afterEach(() => {
+  cleanup();
+  preloadTabSurfaceMock.mockClear();
+  localStorage.removeItem(LOCAL_ADAPTIVE_PREFERENCES_KEY);
+});
 
 describe("HostItem density parity", () => {
   it.each(["comfortable", "compact"] as const)(
@@ -151,5 +164,20 @@ describe("HostItem density parity", () => {
       />,
     );
     expect(screen.queryByText("prod")).toBeNull();
+  });
+
+  it("learns repeated local actions and preloads the preferred host tool", () => {
+    renderHostItem("comfortable");
+    const filesButton = screen.getByTitle("Files");
+    fireEvent.click(filesButton);
+    fireEvent.click(filesButton);
+    fireEvent.click(filesButton);
+
+    const hostRow = screen.getByText("web-01").closest(".cursor-pointer");
+    expect(hostRow).toBeTruthy();
+    fireEvent.pointerEnter(hostRow!);
+
+    expect(preloadTabSurfaceMock).toHaveBeenCalledWith("terminal");
+    expect(preloadTabSurfaceMock).toHaveBeenCalledWith("files");
   });
 });


### PR DESCRIPTION
## Summary
- learn per-host tool preferences from explicit local quick-action choices using decayed aggregate counts and a confidence threshold
- use confident preferences only for speculative surface preloading while preserving existing click behavior and defaults
- keep all learning data in a dedicated localStorage key containing only host IDs, abstract action names, weights, and timestamps
- never sync adaptive data through user preferences or remote APIs, recover safely from malformed storage, and clear it with Reset to defaults

## Validation
- `npm run lint -- --quiet`
- `npm run type-check`
- `npm test -- --run` (308 files, 2297 passed, 1 skipped)
- `npm run build`