### PR TITLE
feat: adapt speculative resource usage

### DIFF
--- a/src/ui/features/file-manager/FileManager.tsx
+++ b/src/ui/features/file-manager/FileManager.tsx
@@ -73,7 +73,10 @@ import {
   type TransferMethodPreference,
   type DiskFilesystem,
 } from "@/main-axios.ts";
-import { getPollingEnvironmentMultiplier } from "@/lib/adaptive-polling";
+import {
+  getAdaptiveResourceBudget,
+  runAdaptiveBackgroundTask,
+} from "@/lib/adaptive-resource-budget";
 import { shouldPrefetchFileContent } from "@/lib/file-content-request-cache";
 import { preloadFilePreview } from "./file-preview-preload";
 import { beginTransferProgressMonitoring } from "./transferProgressMonitor.tsx";
@@ -1567,12 +1570,22 @@ function FileManagerContent({
     (file: FileItem) => {
       if (!sshSessionId) return;
       if (file.type === "directory") {
-        void listSSHFiles(sshSessionId, file.path).catch(() => {});
+        runAdaptiveBackgroundTask("network", "directory-list", () =>
+          listSSHFiles(sshSessionId, file.path),
+        );
         return;
       }
-      if (shouldPrefetchFileContent(file, getPollingEnvironmentMultiplier())) {
+      const budget = getAdaptiveResourceBudget("network");
+      if (shouldPrefetchFileContent(file, budget.maxPrefetchBytes)) {
         preloadFilePreview(file.name);
-        void readSSHFile(sshSessionId, file.path).catch(() => {});
+        runAdaptiveBackgroundTask(
+          "network",
+          file.size && file.size > 128 * 1024
+            ? "file-content:medium"
+            : "file-content:small",
+          () => readSSHFile(sshSessionId, file.path),
+          { estimatedBytes: file.size },
+        );
       }
     },
     [sshSessionId],

--- a/src/ui/features/file-manager/file-preview-preload.ts
+++ b/src/ui/features/file-manager/file-preview-preload.ts
@@ -1,3 +1,5 @@
+import { runAdaptiveBackgroundTask } from "@/lib/adaptive-resource-budget";
+
 export type FilePreviewKind =
   | "image"
   | "video"
@@ -100,5 +102,7 @@ const previewLoaders: Partial<Record<FilePreviewKind, () => Promise<unknown>>> =
   };
 
 export function preloadFilePreview(filename: string): void {
-  void previewLoaders[resolveFilePreviewKind(filename)]?.().catch(() => {});
+  const kind = resolveFilePreviewKind(filename);
+  const loader = previewLoaders[kind];
+  if (loader) runAdaptiveBackgroundTask("module", `preview:${kind}`, loader);
 }

--- a/src/ui/lib/adaptive-resource-budget.ts
+++ b/src/ui/lib/adaptive-resource-budget.ts
@@ -1,0 +1,228 @@
+import {
+  getLocalAdaptiveStats,
+  recordLocalAdaptiveOutcome,
+} from "./local-adaptive-engine";
+
+export type AdaptiveTaskKind = "module" | "network";
+export type AdaptiveResourceTier =
+  "paused" | "constrained" | "balanced" | "eager";
+
+export interface AdaptiveResourceEnvironment {
+  visible: boolean;
+  saveData?: boolean;
+  effectiveType?: string;
+  deviceMemoryGb?: number;
+  hardwareConcurrency?: number;
+}
+
+export interface AdaptiveResourceFeedback {
+  observations: number;
+  successes: number;
+  cancellations: number;
+  fallbacks: number;
+  latencyEwmaMs?: number;
+}
+
+export interface AdaptiveResourceBudget {
+  tier: AdaptiveResourceTier;
+  allowModulePreload: boolean;
+  allowNetworkPrefetch: boolean;
+  maxPrefetchBytes: number;
+  maxConcurrentModulePreloads: number;
+  maxConcurrentNetworkPrefetches: number;
+  reason: "hidden" | "environment" | "feedback" | "default";
+}
+
+interface NetworkInformationLike {
+  saveData?: boolean;
+  effectiveType?: string;
+}
+
+const scopes: Record<AdaptiveTaskKind, string> = {
+  module: "resource-budget:module",
+  network: "resource-budget:network",
+};
+const activeTasks: Record<AdaptiveTaskKind, number> = {
+  module: 0,
+  network: 0,
+};
+
+const budgets: Record<AdaptiveResourceTier, AdaptiveResourceBudget> = {
+  paused: {
+    tier: "paused",
+    allowModulePreload: false,
+    allowNetworkPrefetch: false,
+    maxPrefetchBytes: 0,
+    maxConcurrentModulePreloads: 0,
+    maxConcurrentNetworkPrefetches: 0,
+    reason: "hidden",
+  },
+  constrained: {
+    tier: "constrained",
+    allowModulePreload: false,
+    allowNetworkPrefetch: false,
+    maxPrefetchBytes: 0,
+    maxConcurrentModulePreloads: 0,
+    maxConcurrentNetworkPrefetches: 0,
+    reason: "environment",
+  },
+  balanced: {
+    tier: "balanced",
+    allowModulePreload: true,
+    allowNetworkPrefetch: true,
+    maxPrefetchBytes: 128 * 1024,
+    maxConcurrentModulePreloads: 1,
+    maxConcurrentNetworkPrefetches: 1,
+    reason: "environment",
+  },
+  eager: {
+    tier: "eager",
+    allowModulePreload: true,
+    allowNetworkPrefetch: true,
+    maxPrefetchBytes: 512 * 1024,
+    maxConcurrentModulePreloads: 2,
+    maxConcurrentNetworkPrefetches: 2,
+    reason: "default",
+  },
+};
+
+function withReason(
+  tier: AdaptiveResourceTier,
+  reason: AdaptiveResourceBudget["reason"],
+): AdaptiveResourceBudget {
+  return { ...budgets[tier], reason };
+}
+
+function feedbackIsPoor(feedback?: AdaptiveResourceFeedback): boolean {
+  if (!feedback || feedback.observations < 4) return false;
+  const failureRate = 1 - feedback.successes / feedback.observations;
+  const abandoned = feedback.cancellations + feedback.fallbacks;
+  return (
+    failureRate > 0.25 ||
+    abandoned / feedback.observations > 0.25 ||
+    (feedback.latencyEwmaMs ?? 0) > 2_000
+  );
+}
+
+export function computeAdaptiveResourceBudget(
+  environment: AdaptiveResourceEnvironment,
+  feedback?: AdaptiveResourceFeedback,
+): AdaptiveResourceBudget {
+  if (!environment.visible) return withReason("paused", "hidden");
+  if (
+    environment.saveData ||
+    ["slow-2g", "2g", "3g"].includes(environment.effectiveType ?? "")
+  ) {
+    return withReason("constrained", "environment");
+  }
+
+  const limitedDevice =
+    (environment.deviceMemoryGb ?? 8) <= 4 ||
+    (environment.hardwareConcurrency ?? 8) <= 4;
+  const baseline: AdaptiveResourceTier = limitedDevice ? "balanced" : "eager";
+  if (!feedbackIsPoor(feedback)) {
+    return withReason(baseline, limitedDevice ? "environment" : "default");
+  }
+  return withReason(
+    baseline === "eager" ? "balanced" : "constrained",
+    "feedback",
+  );
+}
+
+function readEnvironment(): AdaptiveResourceEnvironment {
+  const navigatorLike =
+    typeof navigator === "undefined"
+      ? undefined
+      : (navigator as Navigator & {
+          connection?: NetworkInformationLike;
+          deviceMemory?: number;
+        });
+  return {
+    visible:
+      typeof document === "undefined" || document.visibilityState !== "hidden",
+    saveData: navigatorLike?.connection?.saveData,
+    effectiveType: navigatorLike?.connection?.effectiveType,
+    deviceMemoryGb: navigatorLike?.deviceMemory,
+    hardwareConcurrency: navigatorLike?.hardwareConcurrency,
+  };
+}
+
+function readFeedback(kind: AdaptiveTaskKind): AdaptiveResourceFeedback {
+  const stats = Object.values(getLocalAdaptiveStats(scopes[kind]));
+  const observations = stats.reduce((sum, stat) => sum + stat.observations, 0);
+  const latencySamples = stats.filter(
+    (stat) => stat.latencyEwmaMs !== undefined && stat.observations > 0,
+  );
+  const latencyWeight = latencySamples.reduce(
+    (sum, stat) => sum + stat.observations,
+    0,
+  );
+  return {
+    observations,
+    successes: stats.reduce((sum, stat) => sum + stat.successes, 0),
+    cancellations: stats.reduce((sum, stat) => sum + stat.cancellations, 0),
+    fallbacks: stats.reduce((sum, stat) => sum + stat.fallbacks, 0),
+    ...(latencyWeight > 0
+      ? {
+          latencyEwmaMs:
+            latencySamples.reduce(
+              (sum, stat) =>
+                sum + (stat.latencyEwmaMs ?? 0) * stat.observations,
+              0,
+            ) / latencyWeight,
+        }
+      : {}),
+  };
+}
+
+export function getAdaptiveResourceBudget(
+  kind: AdaptiveTaskKind,
+): AdaptiveResourceBudget {
+  return computeAdaptiveResourceBudget(readEnvironment(), readFeedback(kind));
+}
+
+interface AdaptiveTaskOptions {
+  estimatedBytes?: number;
+}
+
+/** Starts optional work only when it fits the current local resource budget. */
+export function runAdaptiveBackgroundTask(
+  kind: AdaptiveTaskKind,
+  action: string,
+  task: () => Promise<unknown>,
+  options: AdaptiveTaskOptions = {},
+): boolean {
+  const budget = getAdaptiveResourceBudget(kind);
+  const allowed =
+    kind === "module"
+      ? budget.allowModulePreload
+      : budget.allowNetworkPrefetch &&
+        (options.estimatedBytes === undefined ||
+          options.estimatedBytes <= budget.maxPrefetchBytes);
+  const concurrency =
+    kind === "module"
+      ? budget.maxConcurrentModulePreloads
+      : budget.maxConcurrentNetworkPrefetches;
+  if (!allowed || activeTasks[kind] >= concurrency) return false;
+
+  activeTasks[kind] += 1;
+  const startedAt = performance.now();
+  void Promise.resolve()
+    .then(task)
+    .then(
+      () =>
+        recordLocalAdaptiveOutcome(scopes[kind], action, {
+          success: true,
+          latencyMs: performance.now() - startedAt,
+        }),
+      () =>
+        recordLocalAdaptiveOutcome(scopes[kind], action, {
+          success: false,
+          latencyMs: performance.now() - startedAt,
+        }),
+    )
+    .finally(() => {
+      activeTasks[kind] -= 1;
+    });
+  return true;
+}

--- a/src/ui/lib/file-content-request-cache.ts
+++ b/src/ui/lib/file-content-request-cache.ts
@@ -7,7 +7,6 @@ export interface FileContentResult {
   encoding?: "base64" | "utf8";
 }
 
-const MAX_PREFETCH_BYTES = 512 * 1024;
 const cache = createKeyedRequestCache<FileContentResult>(30_000, 24);
 const keyFor = (sessionId: string, path: string) => `${sessionId}\0${path}`;
 
@@ -29,12 +28,11 @@ export function invalidateCachedFileContent(
 
 export function shouldPrefetchFileContent(
   file: FileItem,
-  networkMultiplier: number,
+  maxPrefetchBytes: number,
 ): boolean {
   return (
     file.type === "file" &&
     typeof file.size === "number" &&
-    file.size <= MAX_PREFETCH_BYTES &&
-    networkMultiplier <= 1
+    file.size <= maxPrefetchBytes
   );
 }

--- a/src/ui/lib/local-adaptive-engine.ts
+++ b/src/ui/lib/local-adaptive-engine.ts
@@ -147,7 +147,11 @@ function trimStore(store: AdaptiveStore, now: number): void {
   for (const scope of Object.values(store.scopes)) {
     scope.actions = Object.fromEntries(
       Object.entries(scope.actions)
-        .sort(([, a], [, b]) => decayedWeight(b, now) - decayedWeight(a, now))
+        .sort(
+          ([, a], [, b]) =>
+            decayedWeight(b, now) - decayedWeight(a, now) ||
+            b.updatedAt - a.updatedAt,
+        )
         .slice(0, MAX_ACTIONS_PER_SCOPE),
     );
   }

--- a/src/ui/shell/tabUtils.tsx
+++ b/src/ui/shell/tabUtils.tsx
@@ -40,7 +40,7 @@ import { useIsMobile } from "@/hooks/use-mobile";
 import type { Tab, TabType, Host } from "@/types/ui-types";
 import type { SSHHost } from "@/types";
 import { useTabsSafe } from "@/shell/TabContext";
-import { getPollingEnvironmentMultiplier } from "@/lib/adaptive-polling";
+import { runAdaptiveBackgroundTask } from "@/lib/adaptive-resource-budget";
 
 // Heavy tab surfaces — keep out of the AppShell critical path.
 const CommandHistoryProvider = lazy(() =>
@@ -167,8 +167,8 @@ const tabSurfaceLoaders: Partial<Record<TabType, () => Promise<unknown>>> = {
 
 /** Download a likely next tab without starting a connection or mounting UI. */
 export function preloadTabSurface(type: TabType): void {
-  if (getPollingEnvironmentMultiplier() > 1) return;
-  void tabSurfaceLoaders[type]?.().catch(() => {});
+  const loader = tabSurfaceLoaders[type];
+  if (loader) runAdaptiveBackgroundTask("module", `tab:${type}`, loader);
 }
 
 function hostToSSHHost(h: Host): SSHHost {

--- a/src/ui/tests/lib/adaptive-resource-budget.test.ts
+++ b/src/ui/tests/lib/adaptive-resource-budget.test.ts
@@ -1,0 +1,109 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  computeAdaptiveResourceBudget,
+  runAdaptiveBackgroundTask,
+} from "../../lib/adaptive-resource-budget";
+import {
+  clearLocalAdaptiveEngine,
+  getLocalAdaptiveStats,
+} from "../../lib/local-adaptive-engine";
+
+describe("adaptive resource budget", () => {
+  beforeEach(clearLocalAdaptiveEngine);
+
+  it("uses hard environmental constraints before optional work", () => {
+    expect(computeAdaptiveResourceBudget({ visible: false }).tier).toBe(
+      "paused",
+    );
+    expect(
+      computeAdaptiveResourceBudget({ visible: true, saveData: true }).tier,
+    ).toBe("constrained");
+    expect(
+      computeAdaptiveResourceBudget({ visible: true, effectiveType: "3g" })
+        .allowNetworkPrefetch,
+    ).toBe(false);
+  });
+
+  it("scales eager work down on limited devices", () => {
+    const eager = computeAdaptiveResourceBudget({
+      visible: true,
+      deviceMemoryGb: 8,
+      hardwareConcurrency: 8,
+    });
+    expect(eager).toMatchObject({
+      tier: "eager",
+      maxPrefetchBytes: 512 * 1024,
+      maxConcurrentNetworkPrefetches: 2,
+    });
+
+    const balanced = computeAdaptiveResourceBudget({
+      visible: true,
+      deviceMemoryGb: 4,
+      hardwareConcurrency: 8,
+    });
+    expect(balanced).toMatchObject({
+      tier: "balanced",
+      maxPrefetchBytes: 128 * 1024,
+      maxConcurrentNetworkPrefetches: 1,
+    });
+  });
+
+  it("requires enough poor local feedback before degrading", () => {
+    const environment = { visible: true, deviceMemoryGb: 8 };
+    expect(
+      computeAdaptiveResourceBudget(environment, {
+        observations: 3,
+        successes: 0,
+        cancellations: 0,
+        fallbacks: 0,
+      }).tier,
+    ).toBe("eager");
+    expect(
+      computeAdaptiveResourceBudget(environment, {
+        observations: 4,
+        successes: 2,
+        cancellations: 0,
+        fallbacks: 0,
+      }),
+    ).toMatchObject({ tier: "balanced", reason: "feedback" });
+  });
+
+  it("bounds concurrency and records aggregate task outcomes", async () => {
+    let releaseFirst!: () => void;
+    let releaseSecond!: () => void;
+    const first = new Promise<void>((resolve) => (releaseFirst = resolve));
+    const second = new Promise<void>((resolve) => (releaseSecond = resolve));
+
+    expect(
+      runAdaptiveBackgroundTask("module", "tab:terminal", () => first),
+    ).toBe(true);
+    expect(runAdaptiveBackgroundTask("module", "tab:files", () => second)).toBe(
+      true,
+    );
+    expect(
+      runAdaptiveBackgroundTask("module", "tab:docker", async () => {}),
+    ).toBe(false);
+    expect(
+      runAdaptiveBackgroundTask(
+        "network",
+        "file-content:large",
+        async () => {},
+        {
+          estimatedBytes: 512 * 1024 + 1,
+        },
+      ),
+    ).toBe(false);
+
+    releaseFirst();
+    releaseSecond();
+    await vi.waitFor(() => {
+      expect(
+        getLocalAdaptiveStats("resource-budget:module")["tab:terminal"]
+          .successes,
+      ).toBe(1);
+      expect(
+        getLocalAdaptiveStats("resource-budget:module")["tab:files"].successes,
+      ).toBe(1);
+    });
+  });
+});

--- a/src/ui/tests/lib/file-content-request-cache.test.ts
+++ b/src/ui/tests/lib/file-content-request-cache.test.ts
@@ -24,25 +24,25 @@ describe("file content request cache", () => {
     expect(
       shouldPrefetchFileContent(
         { name: "note", path: "/note", type: "file", size: 512 * 1024 },
-        1,
+        512 * 1024,
       ),
     ).toBe(true);
     expect(
       shouldPrefetchFileContent(
         { name: "large", path: "/large", type: "file", size: 512 * 1024 + 1 },
-        1,
+        512 * 1024,
       ),
     ).toBe(false);
     expect(
       shouldPrefetchFileContent(
         { name: "unknown", path: "/unknown", type: "file" },
-        1,
+        512 * 1024,
       ),
     ).toBe(false);
     expect(
       shouldPrefetchFileContent(
         { name: "note", path: "/note", type: "file", size: 100 },
-        1.25,
+        0,
       ),
     ).toBe(false);
   });

--- a/src/ui/tests/lib/local-adaptive-engine.test.ts
+++ b/src/ui/tests/lib/local-adaptive-engine.test.ts
@@ -102,4 +102,20 @@ describe("local adaptive engine", () => {
       }),
     ).toMatchObject({ action: "terminal", confidence: 0, reason: "fallback" });
   });
+
+  it("keeps recent outcome-only actions when a scope reaches its limit", () => {
+    for (let i = 0; i < 13; i++) {
+      recordLocalAdaptiveOutcome(
+        "resource-budget:module",
+        `module:${i}`,
+        { success: true },
+        i,
+      );
+    }
+
+    const stats = getLocalAdaptiveStats("resource-budget:module");
+    expect(Object.keys(stats)).toHaveLength(12);
+    expect(stats["module:0"]).toBeUndefined();
+    expect(stats["module:12"]).toBeDefined();
+  });
 });


### PR DESCRIPTION
## Summary

- add a shared adaptive resource budget for optional module preloads and network prefetches
- combine visibility, Save Data, network class, device capacity, local success rate, and EWMA latency into paused, constrained, balanced, or eager budgets
- apply bounded concurrency and byte limits to tab, preview, directory, and small-file intent prefetches without changing explicit user actions
- keep feedback local as abstract action outcomes and retain recent outcome-only actions correctly at the storage limit

## Safety

All governed work is speculative and optional. Hidden pages, constrained networks, poor local feedback, storage failures, or exhausted concurrency simply skip background work; user clicks continue through the existing foreground paths. No hostname, IP, path, filename, content, or credential is recorded.

## Validation

- `npm run lint -- --quiet`
- `npm run type-check`
- `npm test -- --run` (311 files, 2335 passed, 1 skipped)
- `npm run build`