### PR TITLE
feat: persist adaptive transfer profiles

### DIFF
--- a/src/backend/hosts/file-manager/transfer-engine.ts
+++ b/src/backend/hosts/file-manager/transfer-engine.ts
@@ -36,6 +36,7 @@ import {
 } from "./direct-transfer-routing.js";
 import {
   getTransferProfile,
+  initializeTransferProfiles,
   recordTransferProfile,
   selectTransferTuning,
 } from "./transfer-tuning.js";
@@ -2631,8 +2632,9 @@ function directRouteKey(
 function transferProfileKey(
   sourceSession: SSHSessionLike,
   destSession: SSHSessionLike,
+  userId: string,
 ): string {
-  return `${sourceSession.username ?? ""}@${sourceSession.ip ?? "local"}:${sourceSession.port ?? 22}->${destSession.username ?? ""}@${destSession.ip ?? "local"}:${destSession.port ?? 22}`;
+  return `${userId}:${sourceSession.username ?? ""}@${sourceSession.ip ?? "local"}:${sourceSession.port ?? 22}->${destSession.username ?? ""}@${destSession.ip ?? "local"}:${destSession.port ?? 22}`;
 }
 
 async function benchmarkTransferRoutes(
@@ -3333,6 +3335,7 @@ async function runTransfer(
   transferId: string,
   request: TransferRequest,
 ): Promise<void> {
+  await initializeTransferProfiles();
   const {
     sourceSessionId: browseSourceSessionId,
     sourcePaths,
@@ -3371,7 +3374,11 @@ async function runTransfer(
       transferId,
     );
 
-    reconnectMeta.profileKey = transferProfileKey(sourceSession, destSession);
+    reconnectMeta.profileKey = transferProfileKey(
+      sourceSession,
+      destSession,
+      userId,
+    );
 
     sourceSession.lastActive = Date.now();
     destSession.lastActive = Date.now();

--- a/src/backend/hosts/file-manager/transfer-tuning.ts
+++ b/src/backend/hosts/file-manager/transfer-tuning.ts
@@ -1,3 +1,7 @@
+import { createHash } from "node:crypto";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+
 export interface TransferPerformanceProfile {
   throughputBps: number;
   failureRate: number;
@@ -13,8 +17,120 @@ export interface TransferTuning {
 }
 
 const MB = 1024 * 1024;
-const PROFILE_TTL_MS = 24 * 60 * 60 * 1000;
+const PROFILE_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+const MAX_PROFILES = 128;
+const STORE_VERSION = 1;
+const STORE_FILENAME = "adaptive-transfer-profiles.json";
 const profiles = new Map<string, TransferPerformanceProfile>();
+let loadedPath: string | undefined;
+let loadPromise: Promise<void> | undefined;
+let persistTimer: ReturnType<typeof setTimeout> | undefined;
+let persistPromise = Promise.resolve();
+
+interface PersistedProfiles {
+  version: typeof STORE_VERSION;
+  profiles: Record<string, TransferPerformanceProfile>;
+}
+
+function storePath(): string {
+  const dataDir =
+    process.env.DATA_DIR || path.join(process.cwd(), "db", "data");
+  return path.join(dataDir, STORE_FILENAME);
+}
+
+function profileId(key: string): string {
+  return createHash("sha256").update(key).digest("hex");
+}
+
+function validProfile(value: unknown): value is TransferPerformanceProfile {
+  if (!value || typeof value !== "object") return false;
+  const profile = value as Partial<TransferPerformanceProfile>;
+  return (
+    Number.isFinite(profile.throughputBps) &&
+    Number(profile.throughputBps) >= 0 &&
+    Number.isFinite(profile.failureRate) &&
+    Number(profile.failureRate) >= 0 &&
+    Number(profile.failureRate) <= 1 &&
+    Number.isFinite(profile.samples) &&
+    Number(profile.samples) > 0 &&
+    Number.isFinite(profile.preferredLanes) &&
+    Number.isFinite(profile.pipelineConcurrency) &&
+    Number.isFinite(profile.updatedAt)
+  );
+}
+
+function trimProfiles(now = Date.now()): void {
+  for (const [key, profile] of profiles) {
+    if (now - profile.updatedAt > PROFILE_TTL_MS) profiles.delete(key);
+  }
+  const recent = [...profiles.entries()]
+    .sort(([, a], [, b]) => b.updatedAt - a.updatedAt)
+    .slice(0, MAX_PROFILES);
+  profiles.clear();
+  for (const [key, profile] of recent) profiles.set(key, profile);
+}
+
+async function persistProfiles(): Promise<void> {
+  trimProfiles();
+  const target = storePath();
+  const temporary = `${target}.${process.pid}.tmp`;
+  const payload: PersistedProfiles = {
+    version: STORE_VERSION,
+    profiles: Object.fromEntries(profiles),
+  };
+  try {
+    await fs.mkdir(path.dirname(target), { recursive: true });
+    await fs.writeFile(temporary, JSON.stringify(payload), {
+      encoding: "utf8",
+      mode: 0o600,
+    });
+    await fs.rename(temporary, target);
+  } catch {
+    await fs.rm(temporary, { force: true }).catch(() => {});
+  }
+}
+
+function queuePersist(): void {
+  if (persistTimer) clearTimeout(persistTimer);
+  persistTimer = setTimeout(() => {
+    persistTimer = undefined;
+    persistPromise = persistPromise.then(persistProfiles);
+  }, 250);
+  persistTimer.unref?.();
+}
+
+export async function initializeTransferProfiles(): Promise<void> {
+  const target = storePath();
+  if (loadedPath === target) return loadPromise;
+  loadedPath = target;
+  loadPromise = (async () => {
+    profiles.clear();
+    try {
+      const parsed = JSON.parse(
+        await fs.readFile(target, "utf8"),
+      ) as Partial<PersistedProfiles>;
+      if (parsed.version !== STORE_VERSION || !parsed.profiles) return;
+      for (const [key, profile] of Object.entries(parsed.profiles)) {
+        if (/^[a-f0-9]{64}$/.test(key) && validProfile(profile)) {
+          profiles.set(key, profile);
+        }
+      }
+      trimProfiles();
+    } catch {
+      // Missing or malformed local learning data must not affect transfers.
+    }
+  })();
+  return loadPromise;
+}
+
+export async function flushTransferProfiles(): Promise<void> {
+  if (persistTimer) {
+    clearTimeout(persistTimer);
+    persistTimer = undefined;
+  }
+  persistPromise = persistPromise.then(persistProfiles);
+  await persistPromise;
+}
 
 function clamp(value: number, min: number, max: number): number {
   return Math.max(min, Math.min(max, Math.floor(value)));
@@ -104,10 +220,12 @@ export function getTransferProfile(
   key: string,
   now = Date.now(),
 ): TransferPerformanceProfile | undefined {
-  const profile = profiles.get(key);
+  const id = profileId(key);
+  const profile = profiles.get(id);
   if (!profile) return undefined;
   if (now - profile.updatedAt <= PROFILE_TTL_MS) return profile;
-  profiles.delete(key);
+  profiles.delete(id);
+  queuePersist();
   return undefined;
 }
 
@@ -116,10 +234,16 @@ export function recordTransferProfile(
   observation: Parameters<typeof updateTransferProfile>[1],
 ): TransferPerformanceProfile {
   const profile = updateTransferProfile(getTransferProfile(key), observation);
-  profiles.set(key, profile);
+  profiles.set(profileId(key), profile);
+  trimProfiles(observation.now);
+  queuePersist();
   return profile;
 }
 
 export function clearTransferProfiles(): void {
+  if (persistTimer) clearTimeout(persistTimer);
+  persistTimer = undefined;
+  loadedPath = undefined;
+  loadPromise = undefined;
   profiles.clear();
 }

--- a/src/backend/tests/hosts/file-manager/transfer-tuning.test.ts
+++ b/src/backend/tests/hosts/file-manager/transfer-tuning.test.ts
@@ -1,7 +1,12 @@
 import { beforeEach, describe, expect, it } from "vitest";
+import { promises as fs } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import {
   clearTransferProfiles,
+  flushTransferProfiles,
   getTransferProfile,
+  initializeTransferProfiles,
   recordTransferProfile,
   selectTransferTuning,
   updateTransferProfile,
@@ -56,6 +61,45 @@ describe("adaptive transfer tuning", () => {
       now: 100,
     });
     expect(getTransferProfile("a->b", 101)?.samples).toBe(1);
-    expect(getTransferProfile("a->b", 25 * 60 * 60 * 1000)).toBeUndefined();
+    expect(getTransferProfile("a->b", 8 * 24 * 60 * 60 * 1000)).toBeUndefined();
+  });
+
+  it("persists only anonymous local profiles across restarts", async () => {
+    const previousDataDir = process.env.DATA_DIR;
+    const dataDir = await fs.mkdtemp(path.join(tmpdir(), "termix-transfer-"));
+    process.env.DATA_DIR = dataDir;
+    const rawKey = "root@10.0.0.1->deploy@10.0.0.2";
+    const now = Date.now();
+
+    try {
+      await initializeTransferProfiles();
+      recordTransferProfile(rawKey, {
+        bytes: 256 * MB,
+        durationMs: 2000,
+        lanes: 2,
+        pipelineConcurrency: 16,
+        failed: false,
+        now,
+      });
+      await flushTransferProfiles();
+
+      const stored = await fs.readFile(
+        path.join(dataDir, "adaptive-transfer-profiles.json"),
+        "utf8",
+      );
+      expect(stored).not.toContain(rawKey);
+      expect(Object.keys(JSON.parse(stored).profiles)[0]).toMatch(
+        /^[a-f0-9]{64}$/,
+      );
+
+      clearTransferProfiles();
+      await initializeTransferProfiles();
+      expect(getTransferProfile(rawKey, now + 1)).toMatchObject({ samples: 1 });
+    } finally {
+      clearTransferProfiles();
+      if (previousDataDir === undefined) delete process.env.DATA_DIR;
+      else process.env.DATA_DIR = previousDataDir;
+      await fs.rm(dataDir, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
## Summary

- persist learned SFTP throughput, failure rate, lane count, and pipeline concurrency across backend restarts
- load profiles before each transfer policy decision while preserving the existing size-based heuristic as the cold-start fallback
- isolate profiles per user and host pair, hash identifiers before storage, retain at most 128 recent profiles, and expire them after seven days
- write the local profile store atomically with restrictive permissions and tolerate missing, malformed, or unwritable storage without affecting transfers

## Privacy and safety

Profiles stay in `DATA_DIR/adaptive-transfer-profiles.json` and contain only SHA-256 identifiers plus aggregate performance metrics. No hostname, IP, username, path, filename, content, or credential is written to the profile store or sent to an API. Explicit lane overrides and all existing failure fallbacks remain authoritative.

## Validation

- `npm run lint -- --quiet`
- `npm run type-check`
- `npm test -- --run` (310 files, 2331 passed, 1 skipped)
- `npm run build`