### PR TITLE
feat: learn direct transfer routes

### DIFF
--- a/src/backend/hosts/file-manager/transfer-engine.ts
+++ b/src/backend/hosts/file-manager/transfer-engine.ts
@@ -35,8 +35,11 @@ import {
   type DirectTransferEndpoint,
 } from "./direct-transfer-routing.js";
 import {
+  getRecentDirectRouteDecision,
   getTransferProfile,
   initializeTransferProfiles,
+  recordDirectRouteBenchmark,
+  recordDirectRouteOutcome,
   recordTransferProfile,
   selectTransferTuning,
 } from "./transfer-tuning.js";
@@ -2643,10 +2646,22 @@ async function benchmarkTransferRoutes(
   sourceSession: SSHSessionLike,
   destSession: SSHSessionLike,
   endpoint: DirectTransferEndpoint,
+  profileKey?: string,
 ): Promise<{ useDirect: boolean; directMs?: number; relayMs?: number }> {
   const key = directRouteKey(sourceSession, endpoint);
   const cached = directRouteCache.get(key);
   if (cached && cached.expiresAt > Date.now()) return cached;
+  const learned = profileKey
+    ? getRecentDirectRouteDecision(profileKey, DIRECT_ROUTE_CACHE_MS)
+    : undefined;
+  if (learned) {
+    const result = {
+      ...learned,
+      expiresAt: Date.now() + DIRECT_ROUTE_CACHE_MS,
+    };
+    directRouteCache.set(key, result);
+    return result;
+  }
 
   updateTransfer(transferId, { phase: "benchmarking" });
   const probe = await execCommand(
@@ -2715,7 +2730,12 @@ async function benchmarkTransferRoutes(
       () => Date.now() >= relayDeadline,
     );
     const relayMs = performance.now() - relayStart;
-    const useDirect = shouldUseDirectTransfer(directMs, relayMs);
+    const profile = profileKey
+      ? recordDirectRouteBenchmark(profileKey, directMs, relayMs)
+      : undefined;
+    const useDirect =
+      shouldUseDirectTransfer(directMs, relayMs) &&
+      (!profile || profile.outcomeSamples < 2 || profile.failureRate < 0.25);
     const result = {
       useDirect,
       directMs,
@@ -2772,6 +2792,7 @@ async function tryAdaptiveDirectTransfer(
     sourceSession,
     destSession,
     endpoint,
+    reconnectMeta.profileKey,
   );
   if (!route.useDirect) return null;
   if (destIsDirectory) {
@@ -2848,6 +2869,14 @@ async function tryAdaptiveDirectTransfer(
     }
 
     const transferMs = performance.now() - transferStart;
+    if (reconnectMeta.profileKey) {
+      recordDirectRouteOutcome(
+        reconnectMeta.profileKey,
+        false,
+        Date.now(),
+        DIRECT_ROUTE_CACHE_MS,
+      );
+    }
     return finalizeTransfer(transferId, {
       status: "success",
       phase: "verifying",
@@ -2876,7 +2905,18 @@ async function tryAdaptiveDirectTransfer(
       transferId,
       error: getErrorMessage(error, "Direct transfer failed"),
     });
-    directRouteCache.delete(directRouteKey(sourceSession, endpoint));
+    if (reconnectMeta.profileKey) {
+      recordDirectRouteOutcome(
+        reconnectMeta.profileKey,
+        true,
+        Date.now(),
+        DIRECT_ROUTE_CACHE_MS,
+      );
+    }
+    directRouteCache.set(directRouteKey(sourceSession, endpoint), {
+      useDirect: false,
+      expiresAt: Date.now() + DIRECT_ROUTE_CACHE_MS,
+    });
     updateTransfer(transferId, {
       method: undefined,
       phase: "transferring",

--- a/src/backend/hosts/file-manager/transfer-tuning.ts
+++ b/src/backend/hosts/file-manager/transfer-tuning.ts
@@ -16,12 +16,24 @@ export interface TransferTuning {
   pipelineConcurrency: number;
 }
 
+export interface DirectRouteProfile {
+  directMs: number;
+  relayMs: number;
+  failureRate: number;
+  benchmarkSamples: number;
+  outcomeSamples: number;
+  benchmarkedAt: number;
+  cooldownUntil?: number;
+  updatedAt: number;
+}
+
 const MB = 1024 * 1024;
 const PROFILE_TTL_MS = 7 * 24 * 60 * 60 * 1000;
 const MAX_PROFILES = 128;
 const STORE_VERSION = 1;
 const STORE_FILENAME = "adaptive-transfer-profiles.json";
 const profiles = new Map<string, TransferPerformanceProfile>();
+const directRoutes = new Map<string, DirectRouteProfile>();
 let loadedPath: string | undefined;
 let loadPromise: Promise<void> | undefined;
 let persistTimer: ReturnType<typeof setTimeout> | undefined;
@@ -30,6 +42,29 @@ let persistPromise = Promise.resolve();
 interface PersistedProfiles {
   version: typeof STORE_VERSION;
   profiles: Record<string, TransferPerformanceProfile>;
+  directRoutes: Record<string, DirectRouteProfile>;
+}
+
+function validDirectRoute(value: unknown): value is DirectRouteProfile {
+  if (!value || typeof value !== "object") return false;
+  const profile = value as Partial<DirectRouteProfile>;
+  return (
+    Number.isFinite(profile.directMs) &&
+    Number(profile.directMs) > 0 &&
+    Number.isFinite(profile.relayMs) &&
+    Number(profile.relayMs) > 0 &&
+    Number.isFinite(profile.failureRate) &&
+    Number(profile.failureRate) >= 0 &&
+    Number(profile.failureRate) <= 1 &&
+    Number.isFinite(profile.benchmarkSamples) &&
+    Number(profile.benchmarkSamples) > 0 &&
+    Number.isFinite(profile.outcomeSamples) &&
+    Number(profile.outcomeSamples) >= 0 &&
+    Number.isFinite(profile.benchmarkedAt) &&
+    (profile.cooldownUntil === undefined ||
+      Number.isFinite(profile.cooldownUntil)) &&
+    Number.isFinite(profile.updatedAt)
+  );
 }
 
 function storePath(): string {
@@ -68,6 +103,15 @@ function trimProfiles(now = Date.now()): void {
     .slice(0, MAX_PROFILES);
   profiles.clear();
   for (const [key, profile] of recent) profiles.set(key, profile);
+
+  for (const [key, profile] of directRoutes) {
+    if (now - profile.updatedAt > PROFILE_TTL_MS) directRoutes.delete(key);
+  }
+  const recentRoutes = [...directRoutes.entries()]
+    .sort(([, a], [, b]) => b.updatedAt - a.updatedAt)
+    .slice(0, MAX_PROFILES);
+  directRoutes.clear();
+  for (const [key, profile] of recentRoutes) directRoutes.set(key, profile);
 }
 
 async function persistProfiles(): Promise<void> {
@@ -77,6 +121,7 @@ async function persistProfiles(): Promise<void> {
   const payload: PersistedProfiles = {
     version: STORE_VERSION,
     profiles: Object.fromEntries(profiles),
+    directRoutes: Object.fromEntries(directRoutes),
   };
   try {
     await fs.mkdir(path.dirname(target), { recursive: true });
@@ -105,6 +150,7 @@ export async function initializeTransferProfiles(): Promise<void> {
   loadedPath = target;
   loadPromise = (async () => {
     profiles.clear();
+    directRoutes.clear();
     try {
       const parsed = JSON.parse(
         await fs.readFile(target, "utf8"),
@@ -113,6 +159,11 @@ export async function initializeTransferProfiles(): Promise<void> {
       for (const [key, profile] of Object.entries(parsed.profiles)) {
         if (/^[a-f0-9]{64}$/.test(key) && validProfile(profile)) {
           profiles.set(key, profile);
+        }
+      }
+      for (const [key, profile] of Object.entries(parsed.directRoutes ?? {})) {
+        if (/^[a-f0-9]{64}$/.test(key) && validDirectRoute(profile)) {
+          directRoutes.set(key, profile);
         }
       }
       trimProfiles();
@@ -240,10 +291,97 @@ export function recordTransferProfile(
   return profile;
 }
 
+export function getDirectRouteProfile(
+  key: string,
+  now = Date.now(),
+): DirectRouteProfile | undefined {
+  const id = profileId(key);
+  const profile = directRoutes.get(id);
+  if (!profile) return undefined;
+  if (now - profile.updatedAt <= PROFILE_TTL_MS) return profile;
+  directRoutes.delete(id);
+  queuePersist();
+  return undefined;
+}
+
+export function recordDirectRouteBenchmark(
+  key: string,
+  directMs: number,
+  relayMs: number,
+  now = Date.now(),
+): DirectRouteProfile {
+  const previous = getDirectRouteProfile(key, now);
+  const weight = previous ? 0.25 : 1;
+  const profile: DirectRouteProfile = {
+    directMs: previous
+      ? previous.directMs * (1 - weight) + directMs * weight
+      : directMs,
+    relayMs: previous
+      ? previous.relayMs * (1 - weight) + relayMs * weight
+      : relayMs,
+    failureRate: previous?.failureRate ?? 0,
+    benchmarkSamples: (previous?.benchmarkSamples ?? 0) + 1,
+    outcomeSamples: previous?.outcomeSamples ?? 0,
+    benchmarkedAt: now,
+    cooldownUntil: previous?.cooldownUntil,
+    updatedAt: now,
+  };
+  directRoutes.set(profileId(key), profile);
+  trimProfiles(now);
+  queuePersist();
+  return profile;
+}
+
+export function recordDirectRouteOutcome(
+  key: string,
+  failed: boolean,
+  now = Date.now(),
+  cooldownMs = 10 * 60 * 1000,
+): DirectRouteProfile | undefined {
+  const previous = getDirectRouteProfile(key, now);
+  if (!previous) return undefined;
+  const failure = failed ? 1 : 0;
+  const weight = previous.outcomeSamples > 0 ? 0.25 : 1;
+  const profile = {
+    ...previous,
+    failureRate: previous.failureRate * (1 - weight) + failure * weight,
+    outcomeSamples: previous.outcomeSamples + 1,
+    cooldownUntil: failed ? now + cooldownMs : undefined,
+    updatedAt: now,
+  };
+  directRoutes.set(profileId(key), profile);
+  queuePersist();
+  return profile;
+}
+
+export function getRecentDirectRouteDecision(
+  key: string,
+  maxAgeMs: number,
+  now = Date.now(),
+): { useDirect: boolean; directMs: number; relayMs: number } | undefined {
+  const profile = getDirectRouteProfile(key, now);
+  if (!profile) return undefined;
+  if ((profile.cooldownUntil ?? 0) > now) {
+    return {
+      useDirect: false,
+      directMs: profile.directMs,
+      relayMs: profile.relayMs,
+    };
+  }
+  if (now - profile.benchmarkedAt > maxAgeMs) return undefined;
+  return {
+    useDirect:
+      profile.failureRate < 0.2 && profile.directMs <= profile.relayMs * 0.8,
+    directMs: profile.directMs,
+    relayMs: profile.relayMs,
+  };
+}
+
 export function clearTransferProfiles(): void {
   if (persistTimer) clearTimeout(persistTimer);
   persistTimer = undefined;
   loadedPath = undefined;
   loadPromise = undefined;
   profiles.clear();
+  directRoutes.clear();
 }

--- a/src/backend/tests/hosts/file-manager/transfer-tuning.test.ts
+++ b/src/backend/tests/hosts/file-manager/transfer-tuning.test.ts
@@ -5,8 +5,11 @@ import path from "node:path";
 import {
   clearTransferProfiles,
   flushTransferProfiles,
+  getRecentDirectRouteDecision,
   getTransferProfile,
   initializeTransferProfiles,
+  recordDirectRouteBenchmark,
+  recordDirectRouteOutcome,
   recordTransferProfile,
   selectTransferTuning,
   updateTransferProfile,
@@ -64,6 +67,21 @@ describe("adaptive transfer tuning", () => {
     expect(getTransferProfile("a->b", 8 * 24 * 60 * 60 * 1000)).toBeUndefined();
   });
 
+  it("reuses recent route benchmarks and cools down failed direct paths", () => {
+    recordDirectRouteBenchmark("a->b", 700, 1000, 100);
+    expect(getRecentDirectRouteDecision("a->b", 1_000, 101)).toEqual({
+      useDirect: true,
+      directMs: 700,
+      relayMs: 1000,
+    });
+
+    recordDirectRouteOutcome("a->b", true, 102, 500);
+    expect(getRecentDirectRouteDecision("a->b", 1_000, 103)?.useDirect).toBe(
+      false,
+    );
+    expect(getRecentDirectRouteDecision("a->b", 1_000, 1_103)).toBeUndefined();
+  });
+
   it("persists only anonymous local profiles across restarts", async () => {
     const previousDataDir = process.env.DATA_DIR;
     const dataDir = await fs.mkdtemp(path.join(tmpdir(), "termix-transfer-"));
@@ -81,6 +99,7 @@ describe("adaptive transfer tuning", () => {
         failed: false,
         now,
       });
+      recordDirectRouteBenchmark(rawKey, 700, 1000, now);
       await flushTransferProfiles();
 
       const stored = await fs.readFile(
@@ -95,6 +114,9 @@ describe("adaptive transfer tuning", () => {
       clearTransferProfiles();
       await initializeTransferProfiles();
       expect(getTransferProfile(rawKey, now + 1)).toMatchObject({ samples: 1 });
+      expect(
+        getRecentDirectRouteDecision(rawKey, 1_000, now + 1),
+      ).toMatchObject({ useDirect: true });
     } finally {
       clearTransferProfiles();
       if (previousDataDir === undefined) delete process.env.DATA_DIR;


### PR DESCRIPTION
## Summary

- learn direct-versus-relay route quality from benchmark EWMA and real direct transfer outcomes
- reuse a recent local benchmark across backend restarts to avoid repeating the 8 MiB probe
- require the current benchmark to show a meaningful direct advantage and let failure history veto risky direct attempts
- cool a failed direct route down for ten minutes and immediately fall back to relay without affecting the foreground transfer
- keep benchmark age separate from outcome age so successful transfers cannot make an old route comparison live forever

## Privacy and safety

Route profiles reuse #1242’s local, bounded, user-isolated SHA-256 profile store. Only aggregate timings, sample counts, failure EWMA, and timestamps are persisted; connection identifiers and transfer contents are not. Existing SSH host-key checks, minimum transfer size, explicit method choices, integrity verification, and relay fallback remain authoritative.

## Validation

- `npm run lint -- --quiet`
- `npm run type-check`
- `npm test -- --run` (310 files, 2332 passed, 1 skipped)
- `npm run build`

Depends on #1242. After #1242 merges, this PR should be rebased to contain only the direct-route learning increment.