### PR TITLE
feat: learn speculative preload usefulness

### DIFF
--- a/src/ui/features/file-manager/FileManager.tsx
+++ b/src/ui/features/file-manager/FileManager.tsx
@@ -75,10 +75,14 @@ import {
 } from "@/main-axios.ts";
 import {
   getAdaptiveResourceBudget,
+  markAdaptiveResourceUsed,
   runAdaptiveBackgroundTask,
 } from "@/lib/adaptive-resource-budget";
 import { shouldPrefetchFileContent } from "@/lib/file-content-request-cache";
-import { preloadFilePreview } from "./file-preview-preload";
+import {
+  markFilePreviewUsed,
+  preloadFilePreview,
+} from "./file-preview-preload";
 import { beginTransferProgressMonitoring } from "./transferProgressMonitor.tsx";
 import { createFormatTransferMetrics } from "./transferMetricsFormat.ts";
 import type {
@@ -1540,6 +1544,7 @@ function FileManagerContent({
 
   async function handleFileOpen(file: FileItem) {
     if (file.type === "directory") {
+      markAdaptiveResourceUsed("network", "directory-list");
       directoryRequestRef.current += 1;
       const cached = sshSessionId
         ? peekCachedFileList(sshSessionId, file.path)
@@ -1562,6 +1567,13 @@ function FileManagerContent({
 
     if (!(await confirmLargeFileOpen(file))) return;
 
+    markFilePreviewUsed(file.name);
+    markAdaptiveResourceUsed(
+      "network",
+      file.size && file.size > 128 * 1024
+        ? "file-content:medium"
+        : "file-content:small",
+    );
     await recordRecentFile(file);
     openFileWindow(file, sshSessionId);
   }

--- a/src/ui/features/file-manager/file-preview-preload.ts
+++ b/src/ui/features/file-manager/file-preview-preload.ts
@@ -1,4 +1,7 @@
-import { runAdaptiveBackgroundTask } from "@/lib/adaptive-resource-budget";
+import {
+  markAdaptiveResourceUsed,
+  runAdaptiveBackgroundTask,
+} from "@/lib/adaptive-resource-budget";
 
 export type FilePreviewKind =
   | "image"
@@ -105,4 +108,11 @@ export function preloadFilePreview(filename: string): void {
   const kind = resolveFilePreviewKind(filename);
   const loader = previewLoaders[kind];
   if (loader) runAdaptiveBackgroundTask("module", `preview:${kind}`, loader);
+}
+
+export function markFilePreviewUsed(filename: string): void {
+  markAdaptiveResourceUsed(
+    "module",
+    `preview:${resolveFilePreviewKind(filename)}`,
+  );
 }

--- a/src/ui/lib/adaptive-resource-budget.ts
+++ b/src/ui/lib/adaptive-resource-budget.ts
@@ -21,6 +21,8 @@ export interface AdaptiveResourceFeedback {
   cancellations: number;
   fallbacks: number;
   latencyEwmaMs?: number;
+  usefulnessObservations?: number;
+  usefulPreloads?: number;
 }
 
 export interface AdaptiveResourceBudget {
@@ -42,6 +44,15 @@ const scopes: Record<AdaptiveTaskKind, string> = {
   module: "resource-budget:module",
   network: "resource-budget:network",
 };
+const usefulnessScopes: Record<AdaptiveTaskKind, string> = {
+  module: "resource-usefulness:module",
+  network: "resource-usefulness:network",
+};
+const PRELOAD_USE_WINDOW_MS = 10_000;
+const pendingPreloads = new Map<
+  string,
+  { kind: AdaptiveTaskKind; action: string; expiresAt: number }
+>();
 const activeTasks: Record<AdaptiveTaskKind, number> = {
   module: 0,
   network: 0,
@@ -100,7 +111,42 @@ function feedbackIsPoor(feedback?: AdaptiveResourceFeedback): boolean {
   return (
     failureRate > 0.25 ||
     abandoned / feedback.observations > 0.25 ||
-    (feedback.latencyEwmaMs ?? 0) > 2_000
+    (feedback.latencyEwmaMs ?? 0) > 2_000 ||
+    ((feedback.usefulnessObservations ?? 0) >= 4 &&
+      (feedback.usefulPreloads ?? 0) / (feedback.usefulnessObservations ?? 1) <
+        0.25)
+  );
+}
+
+function preloadKey(kind: AdaptiveTaskKind, action: string): string {
+  return `${kind}:${action}`;
+}
+
+function flushExpiredPreloads(now = Date.now()): void {
+  for (const [key, preload] of pendingPreloads) {
+    if (preload.expiresAt > now) continue;
+    recordLocalAdaptiveOutcome(usefulnessScopes[preload.kind], preload.action, {
+      success: false,
+    });
+    pendingPreloads.delete(key);
+  }
+}
+
+/** Marks that foreground navigation consumed a recent speculative preload. */
+export function markAdaptiveResourceUsed(
+  kind: AdaptiveTaskKind,
+  action: string,
+  now = Date.now(),
+): void {
+  flushExpiredPreloads(now);
+  const key = preloadKey(kind, action);
+  if (!pendingPreloads.has(key)) return;
+  pendingPreloads.delete(key);
+  recordLocalAdaptiveOutcome(
+    usefulnessScopes[kind],
+    action,
+    { success: true },
+    now,
   );
 }
 
@@ -148,7 +194,11 @@ function readEnvironment(): AdaptiveResourceEnvironment {
 }
 
 function readFeedback(kind: AdaptiveTaskKind): AdaptiveResourceFeedback {
+  flushExpiredPreloads();
   const stats = Object.values(getLocalAdaptiveStats(scopes[kind]));
+  const usefulness = Object.values(
+    getLocalAdaptiveStats(usefulnessScopes[kind]),
+  );
   const observations = stats.reduce((sum, stat) => sum + stat.observations, 0);
   const latencySamples = stats.filter(
     (stat) => stat.latencyEwmaMs !== undefined && stat.observations > 0,
@@ -162,6 +212,11 @@ function readFeedback(kind: AdaptiveTaskKind): AdaptiveResourceFeedback {
     successes: stats.reduce((sum, stat) => sum + stat.successes, 0),
     cancellations: stats.reduce((sum, stat) => sum + stat.cancellations, 0),
     fallbacks: stats.reduce((sum, stat) => sum + stat.fallbacks, 0),
+    usefulnessObservations: usefulness.reduce(
+      (sum, stat) => sum + stat.observations,
+      0,
+    ),
+    usefulPreloads: usefulness.reduce((sum, stat) => sum + stat.successes, 0),
     ...(latencyWeight > 0
       ? {
           latencyEwmaMs:
@@ -206,6 +261,12 @@ export function runAdaptiveBackgroundTask(
   if (!allowed || activeTasks[kind] >= concurrency) return false;
 
   activeTasks[kind] += 1;
+  const key = preloadKey(kind, action);
+  pendingPreloads.set(key, {
+    kind,
+    action,
+    expiresAt: Date.now() + PRELOAD_USE_WINDOW_MS,
+  });
   const startedAt = performance.now();
   void Promise.resolve()
     .then(task)
@@ -215,11 +276,13 @@ export function runAdaptiveBackgroundTask(
           success: true,
           latencyMs: performance.now() - startedAt,
         }),
-      () =>
+      () => {
+        pendingPreloads.delete(key);
         recordLocalAdaptiveOutcome(scopes[kind], action, {
           success: false,
           latencyMs: performance.now() - startedAt,
-        }),
+        });
+      },
     )
     .finally(() => {
       activeTasks[kind] -= 1;

--- a/src/ui/shell/tabUtils.tsx
+++ b/src/ui/shell/tabUtils.tsx
@@ -40,7 +40,10 @@ import { useIsMobile } from "@/hooks/use-mobile";
 import type { Tab, TabType, Host } from "@/types/ui-types";
 import type { SSHHost } from "@/types";
 import { useTabsSafe } from "@/shell/TabContext";
-import { runAdaptiveBackgroundTask } from "@/lib/adaptive-resource-budget";
+import {
+  markAdaptiveResourceUsed,
+  runAdaptiveBackgroundTask,
+} from "@/lib/adaptive-resource-budget";
 
 // Heavy tab surfaces — keep out of the AppShell critical path.
 const CommandHistoryProvider = lazy(() =>
@@ -169,6 +172,10 @@ const tabSurfaceLoaders: Partial<Record<TabType, () => Promise<unknown>>> = {
 export function preloadTabSurface(type: TabType): void {
   const loader = tabSurfaceLoaders[type];
   if (loader) runAdaptiveBackgroundTask("module", `tab:${type}`, loader);
+}
+
+export function markTabSurfaceUsed(type: TabType): void {
+  markAdaptiveResourceUsed("module", `tab:${type}`);
 }
 
 function hostToSSHHost(h: Host): SSHHost {

--- a/src/ui/sidebar/tree/HostItem/HostItem.tsx
+++ b/src/ui/sidebar/tree/HostItem/HostItem.tsx
@@ -68,7 +68,7 @@ import {
   TooltipTrigger,
 } from "@/components/tooltip";
 import { hostMatchesQuery } from "../visible-rows";
-import { preloadTabSurface } from "@/shell/tabUtils";
+import { markTabSurfaceUsed, preloadTabSurface } from "@/shell/tabUtils";
 import {
   getPreferredHostAction,
   recordHostActionPreference,
@@ -406,6 +406,7 @@ export function HostItem({
           ? "telnet"
           : "terminal";
   const openHostTab = (type: TabType) => {
+    markTabSurfaceUsed(type);
     recordHostActionPreference(host.id, type);
     onOpenTab(type);
   };

--- a/src/ui/tests/lib/adaptive-resource-budget.test.ts
+++ b/src/ui/tests/lib/adaptive-resource-budget.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   computeAdaptiveResourceBudget,
+  markAdaptiveResourceUsed,
   runAdaptiveBackgroundTask,
 } from "../../lib/adaptive-resource-budget";
 import {
@@ -68,6 +69,30 @@ describe("adaptive resource budget", () => {
     ).toMatchObject({ tier: "balanced", reason: "feedback" });
   });
 
+  it("degrades only after enough speculative work goes unused", () => {
+    const environment = { visible: true, deviceMemoryGb: 8 };
+    expect(
+      computeAdaptiveResourceBudget(environment, {
+        observations: 4,
+        successes: 4,
+        cancellations: 0,
+        fallbacks: 0,
+        usefulnessObservations: 3,
+        usefulPreloads: 0,
+      }).tier,
+    ).toBe("eager");
+    expect(
+      computeAdaptiveResourceBudget(environment, {
+        observations: 4,
+        successes: 4,
+        cancellations: 0,
+        fallbacks: 0,
+        usefulnessObservations: 4,
+        usefulPreloads: 0,
+      }),
+    ).toMatchObject({ tier: "balanced", reason: "feedback" });
+  });
+
   it("bounds concurrency and records aggregate task outcomes", async () => {
     let releaseFirst!: () => void;
     let releaseSecond!: () => void;
@@ -104,6 +129,19 @@ describe("adaptive resource budget", () => {
       expect(
         getLocalAdaptiveStats("resource-budget:module")["tab:files"].successes,
       ).toBe(1);
+    });
+  });
+
+  it("records whether foreground navigation used a preload", async () => {
+    expect(
+      runAdaptiveBackgroundTask("module", "tab:files", async () => {}),
+    ).toBe(true);
+    markAdaptiveResourceUsed("module", "tab:files");
+
+    await vi.waitFor(() => {
+      expect(
+        getLocalAdaptiveStats("resource-usefulness:module")["tab:files"],
+      ).toMatchObject({ observations: 1, successes: 1 });
     });
   });
 });

--- a/src/ui/tests/sidebar/tree/HostItem/HostItem.test.tsx
+++ b/src/ui/tests/sidebar/tree/HostItem/HostItem.test.tsx
@@ -3,11 +3,13 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import type { Host } from "@/types/ui-types";
 import { LOCAL_ADAPTIVE_PREFERENCES_KEY } from "@/lib/local-adaptive-preferences";
 
-const { preloadTabSurfaceMock } = vi.hoisted(() => ({
+const { markTabSurfaceUsedMock, preloadTabSurfaceMock } = vi.hoisted(() => ({
+  markTabSurfaceUsedMock: vi.fn(),
   preloadTabSurfaceMock: vi.fn(),
 }));
 
 vi.mock("@/shell/tabUtils", () => ({
+  markTabSurfaceUsed: markTabSurfaceUsedMock,
   preloadTabSurface: preloadTabSurfaceMock,
 }));
 
@@ -86,6 +88,7 @@ function renderHostItem(
 
 afterEach(() => {
   cleanup();
+  markTabSurfaceUsedMock.mockClear();
   preloadTabSurfaceMock.mockClear();
   localStorage.removeItem(LOCAL_ADAPTIVE_PREFERENCES_KEY);
 });


### PR DESCRIPTION
## Summary
- track whether speculative tab, preview, directory, and small-file preloads are actually consumed
- reduce optional work after enough locally observed low-value preloads
- keep feedback local and limited to abstract resource categories

## Validation
- `npm test -- --run` (311 files passed; 2337 passed, 1 skipped)
- `npm run lint` (0 errors; existing warnings only)
- `npm run type-check`
- `npm run build`

Depends on #1241 and should be merged after it.