### PR TITLE
fix: sync desktop host changes immediately (#1155)

### DIFF
--- a/src/ui/api/ssh-host-management-api.ts
+++ b/src/ui/api/ssh-host-management-api.ts
@@ -12,6 +12,7 @@ import {
   getCachedSSHHosts,
   invalidateHostsAndStatusCaches,
 } from "@/lib/hosts-request-cache";
+import { requestRemoteSync } from "@/lib/remote-sync-trigger";
 
 // SSH HOST MANAGEMENT
 // ============================================================================
@@ -68,10 +69,12 @@ export async function createSSHHost(hostData: SSHHostData): Promise<SSHHost> {
         headers: { "Content-Type": "multipart/form-data" },
       });
       invalidateHostsAndStatusCaches();
+      void requestRemoteSync();
       return response.data;
     }
     const response = await sshHostApi.post("/db/host", hostData);
     invalidateHostsAndStatusCaches();
+    void requestRemoteSync();
     return response.data;
   } catch (error) {
     throw handleApiError(error, "create SSH host");
@@ -92,10 +95,12 @@ export async function updateSSHHost(
         headers: { "Content-Type": "multipart/form-data" },
       });
       invalidateHostsAndStatusCaches();
+      void requestRemoteSync();
       return response.data;
     }
     const response = await sshHostApi.put(`/db/host/${hostId}`, hostData);
     invalidateHostsAndStatusCaches();
+    void requestRemoteSync();
     return response.data;
   } catch (error) {
     throw handleApiError(error, "update SSH host");
@@ -277,6 +282,7 @@ export async function deleteSSHHost(
   try {
     const response = await sshHostApi.delete(`/db/host/${hostId}`);
     invalidateHostsAndStatusCaches();
+    void requestRemoteSync();
     return response.data;
   } catch (error) {
     handleApiError(error, "delete SSH host");

--- a/src/ui/lib/remote-sync-trigger.ts
+++ b/src/ui/lib/remote-sync-trigger.ts
@@ -1,0 +1,16 @@
+import { isElectron } from "@/lib/electron";
+
+export async function requestRemoteSync(): Promise<void> {
+  if (!isElectron()) return;
+
+  try {
+    const config = (await window.electronAPI?.invoke?.(
+      "get-remote-sync-config",
+    )) as { serverUrl?: string } | null;
+    if (config?.serverUrl) {
+      await window.electronAPI?.invoke?.("remote-sync-now");
+    }
+  } catch {
+    // The periodic sync remains the fallback when IPC or the server is down.
+  }
+}

--- a/src/ui/tests/lib/remote-sync-trigger.test.ts
+++ b/src/ui/tests/lib/remote-sync-trigger.test.ts
@@ -1,0 +1,41 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const isElectron = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/electron", () => ({ isElectron }));
+
+import { requestRemoteSync } from "@/lib/remote-sync-trigger";
+
+describe("requestRemoteSync", () => {
+  const invoke = vi.fn();
+
+  beforeEach(() => {
+    isElectron.mockReset();
+    invoke.mockReset();
+    Object.defineProperty(window, "electronAPI", {
+      configurable: true,
+      value: { invoke },
+    });
+  });
+
+  it("starts a sync when the desktop is connected to a server", async () => {
+    isElectron.mockReturnValue(true);
+    invoke.mockResolvedValueOnce({ serverUrl: "https://termix.example" });
+
+    await requestRemoteSync();
+
+    expect(invoke).toHaveBeenNthCalledWith(1, "get-remote-sync-config");
+    expect(invoke).toHaveBeenNthCalledWith(2, "remote-sync-now");
+  });
+
+  it("does nothing outside Electron or without a configured server", async () => {
+    isElectron.mockReturnValue(false);
+    await requestRemoteSync();
+    expect(invoke).not.toHaveBeenCalled();
+
+    isElectron.mockReturnValue(true);
+    invoke.mockResolvedValueOnce(null);
+    await requestRemoteSync();
+    expect(invoke).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
Fixes Termix-SSH/Support#1155

桌面端创建、更新或删除主机后立即触发远端同步，不再等待最长 90 秒的定时周期。保留定时同步作为故障兜底，并补充连接状态与非 Electron 场景的回归测试。