### PR TITLE
fix: show and manage remote shared hosts (#1154, #1156)

### DIFF
--- a/src/ui/api/rbac-api.ts
+++ b/src/ui/api/rbac-api.ts
@@ -6,10 +6,25 @@ import {
   type UserRole,
 } from "@/main-axios";
 import type { AuthOverrideProtocol } from "@/types/auth-protocols";
+import {
+  getConnectedRemoteApi,
+  resolveRemoteHostId,
+} from "@/lib/remote-server-api";
+
+async function getSharingTarget(hostId: number, syncId?: string | null) {
+  const api = await getConnectedRemoteApi();
+  if (!api || !syncId) return { api: rbacApi, hostId };
+  const remoteHostId = await resolveRemoteHostId(syncId);
+  if (remoteHostId === null) {
+    throw new Error("The synced host does not exist on the remote server");
+  }
+  return { api, hostId: remoteHostId };
+}
 
 export async function getRoles(): Promise<{ roles: Role[] }> {
   try {
-    const response = await rbacApi.get("/rbac/roles");
+    const api = (await getConnectedRemoteApi()) ?? rbacApi;
+    const response = await api.get("/rbac/roles");
     return response.data;
   } catch (error) {
     throw handleApiError(error, "fetch roles");
@@ -109,6 +124,7 @@ export async function shareHost(
     permissionLevel: SharePermissionLevel;
     durationHours?: number;
   },
+  syncId?: string | null,
 ): Promise<{
   success: boolean;
   expiresAt: string | null;
@@ -120,8 +136,9 @@ export async function shareHost(
   }>;
 }> {
   try {
-    const response = await rbacApi.post(
-      `/rbac/host/${hostId}/share`,
+    const target = await getSharingTarget(hostId, syncId);
+    const response = await target.api.post(
+      `/rbac/host/${target.hostId}/share`,
       shareData,
     );
     return response.data;
@@ -145,7 +162,8 @@ export async function shareFolder(
   hostResults: Array<{ hostId: number; shared: boolean; reason?: string }>;
 }> {
   try {
-    const response = await rbacApi.post("/rbac/folder/share", {
+    const api = (await getConnectedRemoteApi()) ?? rbacApi;
+    const response = await api.post("/rbac/folder/share", {
       folder,
       ...shareData,
     });
@@ -162,10 +180,12 @@ export async function updateHostAccess(
     permissionLevel?: SharePermissionLevel;
     durationHours?: number | null;
   },
+  syncId?: string | null,
 ): Promise<{ success: boolean; expiresAt: string | null }> {
   try {
-    const response = await rbacApi.patch(
-      `/rbac/host/${hostId}/access/${accessId}`,
+    const target = await getSharingTarget(hostId, syncId);
+    const response = await target.api.patch(
+      `/rbac/host/${target.hostId}/access/${accessId}`,
       update,
     );
     return response.data;
@@ -176,9 +196,11 @@ export async function updateHostAccess(
 
 export async function getHostAccess(
   hostId: number,
+  syncId?: string | null,
 ): Promise<{ accessList: AccessRecord[]; isOwner?: boolean }> {
   try {
-    const response = await rbacApi.get(`/rbac/host/${hostId}/access`);
+    const target = await getSharingTarget(hostId, syncId);
+    const response = await target.api.get(`/rbac/host/${target.hostId}/access`);
     return response.data;
   } catch (error) {
     throw handleApiError(error, "fetch host access");
@@ -217,7 +239,8 @@ export async function getSharedHosts(): Promise<{
   }>;
 }> {
   try {
-    const response = await rbacApi.get("/rbac/shared-hosts");
+    const api = (await getConnectedRemoteApi()) ?? rbacApi;
+    const response = await api.get("/rbac/shared-hosts");
     return response.data;
   } catch (error) {
     throw handleApiError(error, "fetch shared hosts");
@@ -227,10 +250,12 @@ export async function getSharedHosts(): Promise<{
 export async function revokeHostAccess(
   hostId: number,
   accessId: number,
+  syncId?: string | null,
 ): Promise<{ success: boolean }> {
   try {
-    const response = await rbacApi.delete(
-      `/rbac/host/${hostId}/access/${accessId}`,
+    const target = await getSharingTarget(hostId, syncId);
+    const response = await target.api.delete(
+      `/rbac/host/${target.hostId}/access/${accessId}`,
     );
     return response.data;
   } catch (error) {

--- a/src/ui/api/ssh-host-management-api.ts
+++ b/src/ui/api/ssh-host-management-api.ts
@@ -13,6 +13,10 @@ import {
   invalidateHostsAndStatusCaches,
 } from "@/lib/hosts-request-cache";
 import { requestRemoteSync } from "@/lib/remote-sync-trigger";
+import {
+  getConnectedRemoteApi,
+  markRemoteSharedHosts,
+} from "@/lib/remote-server-api";
 
 // SSH HOST MANAGEMENT
 // ============================================================================
@@ -24,7 +28,22 @@ export type GetSSHHostsOptions = {
 
 async function loadSSHHostsFromApi(): Promise<SSHHost[]> {
   const hostsResponse = await sshHostApi.get("/db/host");
-  return Array.isArray(hostsResponse.data) ? hostsResponse.data : [];
+  const localHosts = Array.isArray(hostsResponse.data)
+    ? hostsResponse.data
+    : [];
+  const remoteApi = await getConnectedRemoteApi();
+  if (!remoteApi) return localHosts;
+
+  try {
+    const remoteResponse = await remoteApi.get("/host/db/host");
+    const remoteSharedHosts = Array.isArray(remoteResponse.data)
+      ? markRemoteSharedHosts(remoteResponse.data)
+      : [];
+    return [...localHosts, ...remoteSharedHosts];
+  } catch {
+    // Keep the last locally synced host set usable while the server is offline.
+    return localHosts;
+  }
 }
 
 export async function getSSHHosts(

--- a/src/ui/api/user-management-api.ts
+++ b/src/ui/api/user-management-api.ts
@@ -1,4 +1,5 @@
 import { authApi, handleApiError, type UserInfo } from "@/main-axios";
+import { getConnectedRemoteApi } from "@/lib/remote-server-api";
 
 // USER MANAGEMENT
 // ============================================================================
@@ -15,7 +16,8 @@ export async function getUserList(
   options: UserListOptions = {},
 ): Promise<{ users: UserInfo[]; total?: number }> {
   try {
-    const response = await authApi.get("/users/list", {
+    const api = (await getConnectedRemoteApi()) ?? authApi;
+    const response = await api.get("/users/list", {
       params: {
         ...(options.search ? { search: options.search } : {}),
         ...(options.limit ? { limit: options.limit } : {}),

--- a/src/ui/lib/remote-server-api.ts
+++ b/src/ui/lib/remote-server-api.ts
@@ -1,0 +1,41 @@
+import type { AxiosInstance } from "axios";
+import { getRemoteStatsApi } from "@/main-axios";
+import { isElectron } from "@/lib/electron";
+import type { SSHHost } from "@/types/index";
+
+export function markRemoteSharedHosts(hosts: SSHHost[]): SSHHost[] {
+  return hosts
+    .filter((host) => host.isShared)
+    .map((host) => ({
+      ...host,
+      // Local SQLite ids are positive. Negative ids keep remote-only shared
+      // rows distinct while syncId remains the delegated backend identity.
+      id: -Math.abs(host.id),
+      connectionOrigin: "remote" as const,
+    }));
+}
+
+export async function getConnectedRemoteApi(): Promise<AxiosInstance | null> {
+  if (!isElectron()) return null;
+  try {
+    const config = (await window.electronAPI?.invoke?.(
+      "get-remote-sync-config",
+    )) as { serverUrl?: string } | null;
+    return config?.serverUrl ? getRemoteStatsApi() : null;
+  } catch {
+    return null;
+  }
+}
+
+export async function resolveRemoteHostId(
+  syncId: string | null | undefined,
+): Promise<number | null> {
+  if (!syncId) return null;
+  const api = await getConnectedRemoteApi();
+  if (!api) return null;
+  const response = await api.get("/sync/hosts");
+  const host = (response.data?.rows ?? []).find(
+    (row: { syncId?: string }) => row.syncId === syncId,
+  );
+  return typeof host?.id === "number" ? host.id : null;
+}

--- a/src/ui/sidebar/HostShareModal.tsx
+++ b/src/ui/sidebar/HostShareModal.tsx
@@ -98,7 +98,9 @@ export function HostShareModal({
     setSharingLoaded(true);
     Promise.all([
       host
-        ? getHostAccess(Number(host.id)).catch(() => ({ accessList: [] }))
+        ? getHostAccess(Number(host.id), host.syncId).catch(() => ({
+            accessList: [],
+          }))
         : Promise.resolve({ accessList: [] }),
       getUserList().catch(() => ({ users: [] })),
       getRoles().catch(() => ({ roles: [] })),
@@ -171,7 +173,7 @@ export function HostShareModal({
 
   async function refreshAccessList() {
     if (!host) return;
-    const res = await getHostAccess(Number(host.id));
+    const res = await getHostAccess(Number(host.id), host.syncId);
     setAccessList(res.accessList ?? []);
   }
 
@@ -206,11 +208,15 @@ export function HostShareModal({
           }),
         );
       } else if (host) {
-        await shareHost(Number(host.id), {
-          targets,
-          permissionLevel,
-          ...(durationHours ? { durationHours } : {}),
-        });
+        await shareHost(
+          Number(host.id),
+          {
+            targets,
+            permissionLevel,
+            ...(durationHours ? { durationHours } : {}),
+          },
+          host.syncId,
+        );
         await refreshAccessList();
         setSelectedUserIds(new Set());
         setSelectedRoleIds(new Set());
@@ -233,9 +239,14 @@ export function HostShareModal({
   ) {
     if (!host || record.permissionLevel === level) return;
     try {
-      await updateHostAccess(Number(host.id), record.id, {
-        permissionLevel: level,
-      });
+      await updateHostAccess(
+        Number(host.id),
+        record.id,
+        {
+          permissionLevel: level,
+        },
+        host.syncId,
+      );
       setAccessList((prev) =>
         prev.map((entry) =>
           entry.id === record.id ? { ...entry, permissionLevel: level } : entry,
@@ -560,7 +571,11 @@ export function HostShareModal({
                         className="h-6 text-[10px] px-2 text-destructive hover:bg-destructive/10"
                         onClick={async () => {
                           try {
-                            await revokeHostAccess(Number(host!.id), record.id);
+                            await revokeHostAccess(
+                              Number(host!.id),
+                              record.id,
+                              host!.syncId,
+                            );
                             setAccessList((prev) =>
                               prev.filter((entry) => entry.id !== record.id),
                             );

--- a/src/ui/tests/lib/remote-server-api.test.ts
+++ b/src/ui/tests/lib/remote-server-api.test.ts
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { SSHHost } from "@/types/index";
+
+const isElectron = vi.hoisted(() => vi.fn());
+const remoteApi = vi.hoisted(() => ({ get: vi.fn() }));
+
+vi.mock("@/lib/electron", () => ({ isElectron }));
+vi.mock("@/main-axios", () => ({ getRemoteStatsApi: () => remoteApi }));
+
+import {
+  getConnectedRemoteApi,
+  markRemoteSharedHosts,
+  resolveRemoteHostId,
+} from "@/lib/remote-server-api";
+
+describe("remote server API", () => {
+  const invoke = vi.fn();
+
+  beforeEach(() => {
+    isElectron.mockReset();
+    remoteApi.get.mockReset();
+    invoke.mockReset();
+    Object.defineProperty(window, "electronAPI", {
+      configurable: true,
+      value: { invoke },
+    });
+  });
+
+  it("is available only for a configured Electron sync server", async () => {
+    isElectron.mockReturnValue(false);
+    await expect(getConnectedRemoteApi()).resolves.toBeNull();
+
+    isElectron.mockReturnValue(true);
+    invoke.mockResolvedValueOnce({ serverUrl: "https://termix.example" });
+    await expect(getConnectedRemoteApi()).resolves.toBe(remoteApi);
+  });
+
+  it("maps a local host to the remote numeric id by syncId", async () => {
+    isElectron.mockReturnValue(true);
+    invoke.mockResolvedValue({ serverUrl: "https://termix.example" });
+    remoteApi.get.mockResolvedValue({
+      data: { rows: [{ id: 41, syncId: "host-a" }] },
+    });
+
+    await expect(resolveRemoteHostId("host-a")).resolves.toBe(41);
+    await expect(resolveRemoteHostId("missing")).resolves.toBeNull();
+    expect(remoteApi.get).toHaveBeenCalledWith("/sync/hosts");
+  });
+
+  it("keeps only shared remote hosts and gives them collision-free ids", () => {
+    const rows = markRemoteSharedHosts([
+      { id: 4, isShared: false },
+      { id: 9, isShared: true, syncId: "shared-host" },
+    ] as SSHHost[]);
+
+    expect(rows).toEqual([
+      expect.objectContaining({
+        id: -9,
+        syncId: "shared-host",
+        connectionOrigin: "remote",
+      }),
+    ]);
+  });
+});


### PR DESCRIPTION
Fixes Termix-SSH/Support#1154
Fixes Termix-SSH/Support#1156

桌面端连接同步服务器后合并展示远端共享主机，并从远端加载用户、角色及共享权限数据。所有主机权限操作通过 syncId 解析远端 ID，避免本地与远端自增 ID 不一致导致误操作。