### PR TITLE
fix: batch of security hardening fixes

### DIFF
--- a/src/backend/database/routes/desktop-auto-session.ts
+++ b/src/backend/database/routes/desktop-auto-session.ts
@@ -2,7 +2,17 @@ import type { Request } from "express";
 import type { UserRecord } from "../repositories/user-repository.js";
 
 export function isLoopbackRequest(req: Request): boolean {
-  const ip = req.ip || req.socket?.remoteAddress || "";
+  // Requests relayed by the bundled nginx always carry X-Real-IP, which
+  // nginx overwrites with the actual client address -- so its presence
+  // means the caller reached the backend through the reverse proxy and is
+  // not a local process, whatever the TCP peer address says (it is nginx
+  // itself on loopback). Everything else is judged by the TCP peer
+  // address, which no client-supplied header can influence: with
+  // `trust proxy = true`, req.ip comes from X-Forwarded-For and would let
+  // any remote caller claim to be loopback.
+  if (req.headers["x-real-ip"]) return false;
+
+  const ip = req.socket?.remoteAddress || "";
   return (
     ip === "127.0.0.1" ||
     ip === "::1" ||

--- a/src/backend/database/routes/homepage-ping-routes.ts
+++ b/src/backend/database/routes/homepage-ping-routes.ts
@@ -1,7 +1,6 @@
 import express, { type Request, type Response } from "express";
-import https from "https";
-import http from "http";
 import { homepageLogger } from "../../utils/logger.js";
+import { safeOutboundFetch } from "../../utils/safe-outbound-fetch.js";
 
 export const homepagePingRouter = express.Router();
 
@@ -16,54 +15,37 @@ const pingCache = new Map<string, PingCacheEntry>();
 const CACHE_SIZE = 200;
 const FETCH_TIMEOUT_MS = 5000;
 
-function pingUrl(
+async function requestStatus(
+  url: string,
+  method: "HEAD" | "GET",
+): Promise<number | null> {
+  const res = await safeOutboundFetch(url, {
+    method,
+    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+  });
+  // Discard the body without buffering it.
+  await res.body?.cancel().catch(() => {});
+  return res.status ?? null;
+}
+
+async function pingUrl(
   url: string,
 ): Promise<{ ok: boolean; statusCode: number | null; latencyMs: number }> {
-  return new Promise((resolve) => {
-    const start = performance.now();
-    const mod = url.startsWith("https") ? https : http;
-
-    const done = (ok: boolean, statusCode: number | null) => {
-      resolve({
-        ok,
-        statusCode,
-        latencyMs: Math.round(performance.now() - start),
-      });
+  const start = performance.now();
+  const elapsed = () => Math.round(performance.now() - start);
+  try {
+    let code = await requestStatus(url, "HEAD");
+    if (code === 405) {
+      code = await requestStatus(url, "GET");
+    }
+    return {
+      ok: code !== null && code < 400,
+      statusCode: code,
+      latencyMs: elapsed(),
     };
-
-    const tryGet = () => {
-      const req = mod.get(url, { timeout: FETCH_TIMEOUT_MS }, (res) => {
-        res.resume();
-        const code = res.statusCode ?? null;
-        done(code !== null && code < 400, code);
-      });
-      req.on("error", () => done(false, null));
-      req.on("timeout", () => {
-        req.destroy();
-        done(false, null);
-      });
-    };
-
-    const req = mod.request(
-      url,
-      { method: "HEAD", timeout: FETCH_TIMEOUT_MS },
-      (res) => {
-        res.resume();
-        const code = res.statusCode ?? null;
-        if (code === 405) {
-          tryGet();
-        } else {
-          done(code !== null && code < 400, code);
-        }
-      },
-    );
-    req.on("error", () => done(false, null));
-    req.on("timeout", () => {
-      req.destroy();
-      done(false, null);
-    });
-    req.end();
-  });
+  } catch {
+    return { ok: false, statusCode: null, latencyMs: elapsed() };
+  }
 }
 
 /**

--- a/src/backend/database/routes/homepage-rss-routes.ts
+++ b/src/backend/database/routes/homepage-rss-routes.ts
@@ -1,7 +1,6 @@
 import express, { type Request, type Response } from "express";
-import https from "https";
-import http from "http";
 import { homepageLogger } from "../../utils/logger.js";
+import { safeOutboundFetch } from "../../utils/safe-outbound-fetch.js";
 
 export const homepageRssRouter = express.Router();
 
@@ -18,19 +17,11 @@ interface RssItem {
 }
 
 function fetchXml(url: string): Promise<string> {
-  return new Promise((resolve, reject) => {
-    const mod = url.startsWith("https") ? https : http;
-    const req = mod.get(url, { timeout: FETCH_TIMEOUT_MS }, (res) => {
-      const chunks: Buffer[] = [];
-      res.on("data", (chunk: Buffer) => chunks.push(chunk));
-      res.on("end", () => resolve(Buffer.concat(chunks).toString("utf-8")));
-      res.on("error", reject);
-    });
-    req.on("error", reject);
-    req.on("timeout", () => {
-      req.destroy();
-      reject(new Error("RSS fetch timeout"));
-    });
+  return safeOutboundFetch(url, {
+    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+  }).then(async (res) => {
+    if (!res.ok) throw new Error(`RSS fetch failed: ${res.status}`);
+    return res.text();
   });
 }
 

--- a/src/backend/database/routes/vault.ts
+++ b/src/backend/database/routes/vault.ts
@@ -92,11 +92,19 @@ router.get("/oidc/callback", async (req: Request, res: Response) => {
   const code = String(req.query.code || "");
   const oidcError = req.query.error ? String(req.query.error) : "";
 
+  const esc = (value: string): string =>
+    value
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;")
+      .replace(/'/g, "&#39;");
+
   const html = (title: string, message: string) =>
-    `<!doctype html><html><head><meta charset="utf-8"><title>${title}</title>
+    `<!doctype html><html><head><meta charset="utf-8"><title>${esc(title)}</title>
 <style>body{font-family:system-ui,sans-serif;background:#0b0b0c;color:#e5e5e5;display:flex;align-items:center;justify-content:center;height:100vh;margin:0}
 .card{max-width:420px;text-align:center;padding:24px;border:1px solid #2a2a2e;border-radius:8px}</style></head>
-<body><div class="card"><h2>${title}</h2><p>${message}</p>
+<body><div class="card"><h2>${esc(title)}</h2><p>${esc(message)}</p>
 <script>setTimeout(function(){window.close()},1500)</script></div></body></html>`;
 
   if (oidcError) {

--- a/src/backend/hosts/tunnel/manager.ts
+++ b/src/backend/hosts/tunnel/manager.ts
@@ -43,6 +43,7 @@ import {
 } from "./utils.js";
 
 import { resolveSshConnectConfigHost } from "../ssh-dns.js";
+import { PermissionManager } from "../../utils/permission-manager.js";
 import { handleSocks5Connect } from "./socks5-relay.js";
 
 export const activeTunnels = new Map<string, Client>();
@@ -65,7 +66,9 @@ export const lastTunnelErrorTypes = new Map<
 export const tunnelConfigs = new Map<string, TunnelConfig>();
 export const activeTunnelProcesses = new Map<string, ChildProcess>();
 export const pendingTunnelOperations = new Map<string, Promise<void>>();
-export const tunnelStatusClients = new Set<Response>();
+// SSE clients mapped to the user they belong to, so snapshots can be
+// filtered to tunnels that user can actually reach.
+export const tunnelStatusClients = new Map<Response, string>();
 
 export const INTERNAL_HOST_API_BASE_URL = "http://localhost:30001/host/db/host";
 export const AUTOSTART_FETCH_RETRIES = 6;
@@ -214,18 +217,63 @@ export function getAllTunnelStatus(): Record<string, TunnelStatus> {
   return tunnelStatus;
 }
 
+// Tunnel names embed host labels and destination endpoints, and error text
+// can leak internal hostnames -- so visibility is scoped to tunnels whose
+// source host the requesting user can access (owner, share grant, admin),
+// mirroring the ownership model of the connect/disconnect routes.
+export async function getTunnelStatusForUser(
+  userId: string,
+): Promise<Record<string, TunnelStatus>> {
+  const permissionManager = PermissionManager.getInstance();
+  const accessibleHostIds = await permissionManager.filterAccessibleHostIds(
+    userId,
+    [...tunnelConfigs.values()]
+      .map((config) => config.sourceHostId)
+      .filter((id) => Number.isInteger(id)),
+  );
+
+  const tunnelStatus: Record<string, TunnelStatus> = {};
+  connectionStatus.forEach((status, name) => {
+    const sourceHostId = tunnelConfigs.get(name)?.sourceHostId;
+    if (sourceHostId !== undefined && accessibleHostIds.has(sourceHostId)) {
+      tunnelStatus[name] = status;
+    }
+  });
+  return tunnelStatus;
+}
+
+export async function canAccessTunnel(
+  userId: string,
+  tunnelName: string,
+): Promise<boolean> {
+  const sourceHostId = tunnelConfigs.get(tunnelName)?.sourceHostId;
+  if (sourceHostId === undefined) return false;
+  const permissionManager = PermissionManager.getInstance();
+  const access = await permissionManager.canAccessHost(
+    userId,
+    sourceHostId,
+    "connect",
+  );
+  return access.hasAccess;
+}
+
 export function sendTunnelStatusSnapshot(res: Response): void {
-  try {
-    res.write(
-      `event: statuses\ndata: ${JSON.stringify(getAllTunnelStatus())}\n\n`,
-    );
-  } catch {
+  const userId = tunnelStatusClients.get(res);
+  if (userId === undefined) {
     tunnelStatusClients.delete(res);
+    return;
   }
+  void getTunnelStatusForUser(userId)
+    .then((statuses) => {
+      res.write(`event: statuses\ndata: ${JSON.stringify(statuses)}\n\n`);
+    })
+    .catch(() => {
+      tunnelStatusClients.delete(res);
+    });
 }
 
 export function broadcastTunnelStatusSnapshot(): void {
-  for (const client of tunnelStatusClients) {
+  for (const client of tunnelStatusClients.keys()) {
     sendTunnelStatusSnapshot(client);
   }
 }

--- a/src/backend/hosts/tunnel/routes.ts
+++ b/src/backend/hosts/tunnel/routes.ts
@@ -36,7 +36,8 @@ import {
   handleDisconnect,
   sendTunnelStatusSnapshot,
   isSingleHostTunnel,
-  getAllTunnelStatus,
+  getTunnelStatusForUser,
+  canAccessTunnel,
   findHostByTunnelEndpoint,
   connectSSHTunnel,
 } from "./manager.js";
@@ -50,12 +51,12 @@ export function registerTunnelRoutes(app: express.Express): void {
   app.get(
     "/ssh/tunnel/status",
     authenticateJWT,
-    (req: AuthenticatedRequest, res: Response) => {
+    async (req: AuthenticatedRequest, res: Response) => {
       if (!req.userId) {
         return res.status(401).json({ error: "Authentication required" });
       }
 
-      res.json(getAllTunnelStatus());
+      res.json(await getTunnelStatusForUser(req.userId));
     },
   );
 
@@ -75,7 +76,7 @@ export function registerTunnelRoutes(app: express.Express): void {
       });
       res.flushHeaders?.();
 
-      tunnelStatusClients.add(res);
+      tunnelStatusClients.set(res, req.userId);
       sendTunnelStatusSnapshot(res);
 
       const heartbeat = setInterval(() => {
@@ -118,7 +119,7 @@ export function registerTunnelRoutes(app: express.Express): void {
   app.get(
     "/ssh/tunnel/status/:tunnelName",
     authenticateJWT,
-    (req: AuthenticatedRequest, res: Response) => {
+    async (req: AuthenticatedRequest, res: Response) => {
       if (!req.userId) {
         return res.status(401).json({ error: "Authentication required" });
       }
@@ -127,6 +128,13 @@ export function registerTunnelRoutes(app: express.Express): void {
       const tunnelName = Array.isArray(tunnelNameParam)
         ? tunnelNameParam[0]
         : tunnelNameParam;
+
+      // 404 rather than 403 for foreign tunnels: the name itself carries
+      // host metadata, so confirming its existence would leak it.
+      if (!(await canAccessTunnel(req.userId, tunnelName))) {
+        return res.status(404).json({ error: "Tunnel not found" });
+      }
+
       const status = connectionStatus.get(tunnelName);
 
       if (!status) {

--- a/src/backend/tests/database/routes/desktop-auto-session.test.ts
+++ b/src/backend/tests/database/routes/desktop-auto-session.test.ts
@@ -24,9 +24,13 @@ describe("isLoopbackRequest", () => {
   it.each(["127.0.0.1", "::1", "::ffff:127.0.0.1"])(
     "accepts %s as loopback",
     (ip) => {
-      expect(isLoopbackRequest({ ip, socket: {} } as unknown as Request)).toBe(
-        true,
-      );
+      expect(
+        isLoopbackRequest({
+          ip,
+          headers: {},
+          socket: { remoteAddress: ip },
+        } as unknown as Request),
+      ).toBe(true);
     },
   );
 
@@ -34,27 +38,40 @@ describe("isLoopbackRequest", () => {
     expect(
       isLoopbackRequest({
         ip: "::ffff:127.0.0.1",
-        socket: {},
+        headers: {},
+        socket: { remoteAddress: "::ffff:127.0.0.1" },
       } as unknown as Request),
     ).toBe(true);
   });
 
-  it("rejects a non-loopback IP", () => {
+  it("rejects a non-loopback TCP peer address", () => {
     expect(
       isLoopbackRequest({
         ip: "192.168.1.50",
-        socket: {},
+        headers: {},
+        socket: { remoteAddress: "192.168.1.50" },
       } as unknown as Request),
     ).toBe(false);
   });
 
-  it("falls back to socket.remoteAddress when req.ip is empty", () => {
+  it("ignores a spoofed X-Forwarded-For value", () => {
     expect(
       isLoopbackRequest({
-        ip: "",
+        ip: "127.0.0.1",
+        headers: { "x-forwarded-for": "127.0.0.1" },
+        socket: { remoteAddress: "203.0.113.10" },
+      } as unknown as Request),
+    ).toBe(false);
+  });
+
+  it("rejects requests that traversed the reverse proxy (X-Real-IP set)", () => {
+    expect(
+      isLoopbackRequest({
+        ip: "127.0.0.1",
+        headers: { "x-real-ip": "203.0.113.10" },
         socket: { remoteAddress: "127.0.0.1" },
       } as unknown as Request),
-    ).toBe(true);
+    ).toBe(false);
   });
 });
 


### PR DESCRIPTION
Four independent fixes, one per commit, all verified against the private advisory reports they close out. Happy to split into separate PRs if that fits the release process better.

## 1. Desktop auto-session loopback check (`desktop-auto-session.ts`)

`isLoopbackRequest` trusted `req.ip`, which with the global `trust proxy = true` is derived from the client-supplied `X-Forwarded-For` header — so any remote caller could claim to be loopback and mint a 30-day admin JWT via `POST /users/internal/auto-session` (dynamically verified against the standard Docker Compose deployment through nginx on port 8080).

The check now:
- rejects any request carrying `X-Real-IP` — the bundled nginx overwrites that header with the real client address on every proxied location, so its presence proves the request came through the reverse proxy rather than from a local process;
- otherwise judges the TCP peer address (`socket.remoteAddress`), which no header can influence.

Desktop (direct loopback connections) keeps working; proxied deployments are now rejected.

## 2. Vault OIDC callback XSS (`vault.ts`)

The `error` query parameter was interpolated into the callback HTML template unescaped, allowing reflected script execution in an authenticated user's browser. Both `title` and `message` are now HTML-entity-encoded inside the template helper, which also covers the `result.error` interpolation path.

## 3. Homepage ping/rss SSRF (`homepage-ping-routes.ts`, `homepage-rss-routes.ts`)

Both routes fetched arbitrary user-supplied URLs with bare `http.get`/`https.get`, with no destination filtering — the same class already fixed for `/homepage/proxy` via `safeOutboundFetch`. Both now go through `safeOutboundFetch`, picking up the private-range blocklist, DNS-resolution-time address checks, credential-in-URL rejection, and `redirect: "error"`. The HEAD-then-GET fallback and timeout behavior of the ping route are preserved.

## 4. Tunnel status cross-user disclosure (`tunnel/routes.ts`, `tunnel/manager.ts`)

The three `/ssh/tunnel/status*` routes returned every user's tunnel names (which embed host label, source port, destination endpoint), connection states, and raw SSH error text to any authenticated caller. They now scope visibility to tunnels whose source host the caller can access (owner / share grant / admin bypass — same model as connect/disconnect), using `filterAccessibleHostIds` to keep the status poll at a fixed query cost. SSE clients are tracked per-user so broadcast snapshots are filtered individually. `/status/:tunnelName` answers 404 rather than 403 for foreign tunnels, since the name itself is the metadata being protected.

## Testing

- `tsc --noEmit` clean
- unit tests updated for the new loopback semantics (spoofed XFF, proxied request, TCP peer address) — full suite green (395 passed, 1 skipped)
- no new lint warnings