### PR TITLE
fix: build better-sqlite3 from source on ARM64

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -31,7 +31,7 @@ WORKDIR /app
 
 COPY . .
 
-RUN npm rebuild better-sqlite3
+RUN npm rebuild better-sqlite3 --build-from-source
 
 RUN npm run build:backend
 
@@ -67,7 +67,8 @@ COPY scripts/patch-guacamole-lite.cjs ./scripts/
 
 RUN npm ci --omit=dev --ignore-scripts && \
     node scripts/patch-guacamole-lite.cjs && \
-    npm rebuild better-sqlite3 bcryptjs ssh2 && \
+    npm rebuild better-sqlite3 --build-from-source && \
+    npm rebuild bcryptjs ssh2 && \
     npm cache clean --force
 
 # Stage 6: Final optimized image


### PR DESCRIPTION
Fixes Termix-SSH/Support#1172
Fixes Termix-SSH/Support#1164

## Summary
- force `better-sqlite3` to compile against the Docker image's own GLIBC
- keep other dependency rebuilds unchanged

## Verification
- `git diff --check`
- Docker build not run locally because the Docker daemon is unavailable; multi-architecture Docker CI should verify `linux/amd64` and `linux/arm64`