### PR TITLE
fix: support forwarding from the memory SSH agent

### DIFF
--- a/src/backend/hosts/terminal-auth-helpers.ts
+++ b/src/backend/hosts/terminal-auth-helpers.ts
@@ -1,13 +1,14 @@
 import dgram from "dgram";
 import net from "net";
 import ssh2Pkg, {
+  type GetStreamCallback,
   type IdentityCallback,
   type ParsedKey,
   type SignCallback,
   type SigningRequestOptions,
 } from "ssh2";
 
-const { BaseAgent } = ssh2Pkg;
+const { AgentProtocol, BaseAgent } = ssh2Pkg;
 const DEFAULT_PORT_KNOCK_TIMEOUT_MS = 1000;
 
 type Sleep = (ms: number) => Promise<void>;
@@ -32,6 +33,23 @@ export class MemoryAgent extends BaseAgent {
 
   getIdentities(cb: IdentityCallback<ParsedKey>): void {
     cb(null, [this.key]);
+  }
+
+  getStream(cb: GetStreamCallback): void {
+    const protocol = new AgentProtocol(false);
+
+    protocol.on("identities", (request) => {
+      protocol.getIdentitiesReply(request, [this.key]);
+    });
+
+    protocol.on("sign", (request, publicKey, data, options) => {
+      this.sign(publicKey, data, options, (error, signature) => {
+        if (error || !signature) return protocol.failureReply(request);
+        protocol.signReply(request, signature);
+      });
+    });
+
+    cb(null, protocol);
   }
 
   sign(

--- a/src/backend/tests/hosts/terminal-agent-auth.test.ts
+++ b/src/backend/tests/hosts/terminal-agent-auth.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { generateKeyPairSync } from "crypto";
+import ssh2Pkg, { type ParsedKey } from "ssh2";
 
 const mockAccess = vi.fn();
 
@@ -6,7 +8,53 @@ vi.mock("fs/promises", () => ({
   access: mockAccess,
 }));
 
-import { resolveAgentSocket } from "../../hosts/terminal-auth-helpers.js";
+import {
+  MemoryAgent,
+  resolveAgentSocket,
+} from "../../hosts/terminal-auth-helpers.js";
+
+describe("MemoryAgent", () => {
+  it("serves identities and signatures over the agent protocol", async () => {
+    const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+    const parsed = ssh2Pkg.utils.parseKey(
+      privateKey.export({ type: "pkcs1", format: "pem" }),
+    );
+    expect(parsed).not.toBeInstanceOf(Error);
+
+    const agent = new MemoryAgent(parsed as ParsedKey);
+    const stream = await new Promise<NodeJS.ReadWriteStream>((resolve, reject) => {
+      agent.getStream((error, result) => {
+        if (error || !result) reject(error ?? new Error("Missing agent stream"));
+        else resolve(result);
+      });
+    });
+    const client = new ssh2Pkg.AgentProtocol(true);
+    client.pipe(stream).pipe(client);
+
+    const identities = await new Promise<ParsedKey[]>((resolve, reject) => {
+      client.getIdentities((error, keys) => {
+        if (error || !keys) reject(error ?? new Error("Missing identities"));
+        else resolve(keys);
+      });
+    });
+    expect(identities).toHaveLength(1);
+    expect(identities[0].getPublicSSH()).toEqual(
+      (parsed as ParsedKey).getPublicSSH(),
+    );
+
+    const data = Buffer.from("forwarded-agent-test");
+    const signature = await new Promise<Buffer>((resolve, reject) => {
+      client.sign(identities[0], data, (error, result) => {
+        if (error || !result) reject(error ?? new Error("Missing signature"));
+        else resolve(result);
+      });
+    });
+    expect((parsed as ParsedKey).verify(data, signature)).toBe(true);
+
+    client.destroy();
+    stream.destroy();
+  });
+});
 
 describe("resolveAgentSocket", () => {
   const originalEnv = process.env.SSH_AUTH_SOCK;

--- a/src/backend/tests/hosts/terminal-agent-auth.test.ts
+++ b/src/backend/tests/hosts/terminal-agent-auth.test.ts
@@ -22,12 +22,15 @@ describe("MemoryAgent", () => {
     expect(parsed).not.toBeInstanceOf(Error);
 
     const agent = new MemoryAgent(parsed as ParsedKey);
-    const stream = await new Promise<NodeJS.ReadWriteStream>((resolve, reject) => {
-      agent.getStream((error, result) => {
-        if (error || !result) reject(error ?? new Error("Missing agent stream"));
-        else resolve(result);
-      });
-    });
+    const stream = await new Promise<NodeJS.ReadWriteStream>(
+      (resolve, reject) => {
+        agent.getStream((error, result) => {
+          if (error || !result)
+            reject(error ?? new Error("Missing agent stream"));
+          else resolve(result);
+        });
+      },
+    );
     const client = new ssh2Pkg.AgentProtocol(true);
     client.pipe(stream).pipe(client);
 


### PR DESCRIPTION
Fixes Termix-SSH/Support#1166

## Summary
- expose the built-in memory agent through an OpenSSH agent protocol stream
- serve identity and signing requests from the stored Termix key
- add a protocol-level forwarding regression test

## Verification
- `npm test -- --run src/backend/tests/hosts/terminal-agent-auth.test.ts` (8 passed)
- `npm run type-check`
- `git diff --check`