### PR TITLE
fix: prompt for encrypted SFTP key passphrases

### DIFF
--- a/src/backend/hosts/file-manager/index.ts
+++ b/src/backend/hosts/file-manager/index.ts
@@ -9,7 +9,7 @@ import { createCorsMiddleware } from "../../utils/cors-config.js";
 import { createCompressionMiddleware } from "../../utils/compression-config.js";
 import cookieParser from "cookie-parser";
 import axios from "axios";
-import { Client as SSHClient } from "ssh2";
+import ssh2Pkg, { Client as SSHClient } from "ssh2";
 import { SSH_ALGORITHMS } from "../../utils/ssh-algorithms.js";
 import { createCurrentHostResolutionRepository } from "../../database/repositories/factory.js";
 import { fileLogger } from "../../utils/logger.js";
@@ -43,7 +43,10 @@ import {
 import { registerFileContentRoutes } from "./content-routes.js";
 import { createConnectionLog } from "../connection-log.js";
 import { createJumpHostChain } from "../jump-host-chain.js";
-import { preparePrivateKeyForSSH2 } from "../../utils/ssh-key-utils.js";
+import {
+  isPrivateKeyPassphraseError,
+  preparePrivateKeyForSSH2,
+} from "../../utils/ssh-key-utils.js";
 import {
   ChannelOpenSerializer,
   execChannel,
@@ -840,7 +843,7 @@ app.post("/ssh/file_manager/ssh/connect", async (req, res) => {
         resolvedCredentials = {
           password: resolvedHost.password,
           sshKey: resolvedHost.key,
-          keyPassword: resolvedHost.keyPassword,
+          keyPassword: keyPassword || resolvedHost.keyPassword,
           authType: resolvedHost.authType,
           sudoPassword: resolvedHost.sudoPassword as string | undefined,
           certPublicKey: (resolvedHost as { certPublicKey?: string })
@@ -909,7 +912,7 @@ app.post("/ssh/file_manager/ssh/connect", async (req, res) => {
         resolvedCredentials = {
           password: resolvedHost.password,
           sshKey: resolvedHost.key,
-          keyPassword: resolvedHost.keyPassword,
+          keyPassword: keyPassword || resolvedHost.keyPassword,
           authType: resolvedHost.authType,
           sudoPassword: resolvedHost.sudoPassword as string | undefined,
           certPublicKey: (resolvedHost as { certPublicKey?: string })
@@ -1049,6 +1052,12 @@ app.post("/ssh/file_manager/ssh/connect", async (req, res) => {
         resolvedCredentials.keyPassword,
       );
 
+      const parsedKey = ssh2Pkg.utils.parseKey(
+        config.privateKey as Buffer,
+        resolvedCredentials.keyPassword,
+      );
+      if (parsedKey instanceof Error) throw parsedKey;
+
       if (resolvedCredentials.keyPassword)
         config.passphrase = resolvedCredentials.keyPassword;
 
@@ -1071,6 +1080,10 @@ app.post("/ssh/file_manager/ssh/connect", async (req, res) => {
         ),
       );
     } catch (keyError) {
+      if (isPrivateKeyPassphraseError(keyError)) {
+        return res.json({ status: "passphrase_required", connectionLogs });
+      }
+
       fileLogger.error("SSH key format error for file manager", {
         operation: "file_connect",
         sessionId,

--- a/src/backend/tests/utils/ssh-key-utils.test.ts
+++ b/src/backend/tests/utils/ssh-key-utils.test.ts
@@ -102,13 +102,15 @@ describe("isPrivateKeyPassphraseError", () => {
   it("recognizes missing and incorrect passphrase errors", () => {
     expect(
       isPrivateKeyPassphraseError(
-        new Error("Encrypted OpenSSH private key detected, but no passphrase given"),
+        new Error(
+          "Encrypted OpenSSH private key detected, but no passphrase given",
+        ),
       ),
     ).toBe(true);
     expect(isPrivateKeyPassphraseError(new Error("Bad passphrase"))).toBe(true);
-    expect(isPrivateKeyPassphraseError(new Error("Unsupported key format"))).toBe(
-      false,
-    );
+    expect(
+      isPrivateKeyPassphraseError(new Error("Unsupported key format")),
+    ).toBe(false);
   });
 });
 

--- a/src/backend/tests/utils/ssh-key-utils.test.ts
+++ b/src/backend/tests/utils/ssh-key-utils.test.ts
@@ -4,6 +4,7 @@ import {
   parseSSHKey,
   parsePublicKey,
   preparePrivateKeyForSSH2,
+  isPrivateKeyPassphraseError,
   getFriendlyKeyTypeName,
   validateKeyPair,
 } from "../../utils/ssh-key-utils.js";
@@ -94,6 +95,20 @@ describe("parseSSHKey", () => {
     );
     expect(info.success).toBe(false);
     expect(info.error).toMatch(/Unsupported PuTTY PPK v3/);
+  });
+});
+
+describe("isPrivateKeyPassphraseError", () => {
+  it("recognizes missing and incorrect passphrase errors", () => {
+    expect(
+      isPrivateKeyPassphraseError(
+        new Error("Encrypted OpenSSH private key detected, but no passphrase given"),
+      ),
+    ).toBe(true);
+    expect(isPrivateKeyPassphraseError(new Error("Bad passphrase"))).toBe(true);
+    expect(isPrivateKeyPassphraseError(new Error("Unsupported key format"))).toBe(
+      false,
+    );
   });
 });
 

--- a/src/backend/utils/ssh-key-utils.ts
+++ b/src/backend/utils/ssh-key-utils.ts
@@ -256,6 +256,10 @@ export function preparePrivateKeyForSSH2(
   return Buffer.from(cleanKey, "utf8");
 }
 
+export function isPrivateKeyPassphraseError(error: unknown): boolean {
+  return /passphrase/i.test(getErrorMessage(error, ""));
+}
+
 export function parseSSHKey(
   privateKeyData: string,
   passphrase?: string,


### PR DESCRIPTION
Fixes Termix-SSH/Support#1162

## Summary
- detect encrypted SFTP keys before opening the SSH connection
- return the existing `passphrase_required` response instead of treating the key as invalid
- preserve a passphrase supplied by the dialog when stored credentials are resolved
- cover missing, incorrect, and unrelated key errors

## Verification
- `npm test -- --run src/backend/tests/utils/ssh-key-utils.test.ts` (17 passed)
- `npm run type-check`
- `git diff --check`