### PR TITLE
fix: include host context in automation notifications

### DIFF
--- a/src/backend/automations/engine.ts
+++ b/src/backend/automations/engine.ts
@@ -10,6 +10,7 @@ import {
 } from "../../types/automations.js";
 import { createCurrentAutomationRepository } from "../database/repositories/factory.js";
 import { statsLogger } from "../utils/logger.js";
+import { resolveHostById } from "../hosts/host-resolver.js";
 import { executeStep } from "./actions/index.js";
 import type { StepExecutionContext, StepResult } from "./actions/types.js";
 import { compare } from "./conditions.js";
@@ -175,8 +176,33 @@ export class AutomationEngine {
 
     if (!claimed) this.running.add(automation.id);
 
+    const trigger = { ...(request.triggerContext ?? {}) };
+    trigger.type ??= request.triggerType;
+    let host: TemplateContext["host"];
+    if (request.triggerHostId) {
+      try {
+        const resolved = await resolveHostById(
+          request.triggerHostId,
+          automation.userId,
+        );
+        if (resolved) {
+          host = {
+            id: request.triggerHostId,
+            name: resolved.name || resolved.ip,
+            ip: resolved.ip,
+            username: resolved.username,
+            port: resolved.port,
+          };
+          trigger.hostName ??= host.name;
+        }
+      } catch {
+        // A notification should still run with its numeric host id.
+      }
+    }
+
     const template: TemplateContext = {
-      trigger: request.triggerContext ?? {},
+      host,
+      trigger,
       steps: {},
       vars: {},
       run: {

--- a/src/backend/automations/notify.ts
+++ b/src/backend/automations/notify.ts
@@ -88,6 +88,17 @@ async function sendWebhook(
     headers,
     body: JSON.stringify({
       title: notification.title,
+      hostName:
+        notification.context?.host?.name ??
+        notification.context?.trigger?.hostName,
+      hostId:
+        notification.context?.host?.id ??
+        notification.context?.trigger?.hostId,
+      ruleName: notification.title,
+      ruleId: notification.context?.run?.automationId,
+      triggerType: notification.context?.trigger?.type,
+      value: notification.context?.trigger?.value,
+      threshold: notification.context?.trigger?.threshold,
       message: notification.body,
       severity: notification.severity,
       timestamp: new Date().toISOString(),

--- a/src/backend/automations/notify.ts
+++ b/src/backend/automations/notify.ts
@@ -92,8 +92,7 @@ async function sendWebhook(
         notification.context?.host?.name ??
         notification.context?.trigger?.hostName,
       hostId:
-        notification.context?.host?.id ??
-        notification.context?.trigger?.hostId,
+        notification.context?.host?.id ?? notification.context?.trigger?.hostId,
       ruleName: notification.title,
       ruleId: notification.context?.run?.automationId,
       triggerType: notification.context?.trigger?.type,

--- a/src/backend/tests/automations/engine.test.ts
+++ b/src/backend/tests/automations/engine.test.ts
@@ -47,6 +47,12 @@ const repository = {
   }),
 };
 
+const resolveHostById = vi.fn();
+
+vi.mock("../../hosts/host-resolver.js", () => ({
+  resolveHostById: (...args: unknown[]) => resolveHostById(...args),
+}));
+
 vi.mock("../../database/repositories/factory.js", () => ({
   createCurrentAutomationRepository: () => repository,
 }));
@@ -93,12 +99,41 @@ beforeEach(() => {
   nextRunId = 1;
   nextStepRowId = 1;
   vi.clearAllMocks();
+  resolveHostById.mockResolvedValue(null);
   executeStep.mockResolvedValue({ success: true, output: "ok" });
   // The singleton carries in-flight state between tests.
   (AutomationEngine as unknown as { instance?: unknown }).instance = undefined;
 });
 
 describe("AutomationEngine.run", () => {
+  it("adds the trigger host name to the template context", async () => {
+    defineAutomation([step({ id: "notify", type: "notify" })]);
+    resolveHostById.mockResolvedValue({
+      name: "Proxmox Node",
+      ip: "10.0.0.11",
+      username: "root",
+      port: 22,
+    });
+
+    await AutomationEngine.getInstance().run({
+      automationId: 1,
+      triggerType: "metric_threshold",
+      triggerHostId: 11,
+      triggerContext: { hostId: 11, value: 97 },
+    });
+
+    const context = executeStep.mock.calls[0][1] as {
+      template: {
+        host: { id: number; name: string };
+        trigger: { hostName: string };
+      };
+    };
+    expect(context.template.host).toMatchObject({
+      id: 11,
+      name: "Proxmox Node",
+    });
+    expect(context.template.trigger.hostName).toBe("Proxmox Node");
+  });
   it("runs steps in order and records each one", async () => {
     defineAutomation([
       step({ id: "a", type: "run_command" }),

--- a/src/backend/tests/automations/notify.test.ts
+++ b/src/backend/tests/automations/notify.test.ts
@@ -1,0 +1,45 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const automationFetch = vi.fn();
+
+vi.mock("../../automations/http.js", () => ({
+  automationFetch: (...args: unknown[]) => automationFetch(...args),
+}));
+
+const { sendAutomationNotification } = await import(
+  "../../automations/notify.js"
+);
+
+beforeEach(() => {
+  automationFetch.mockReset();
+  automationFetch.mockResolvedValue({ ok: true });
+});
+
+describe("sendAutomationNotification", () => {
+  it("keeps alert-compatible host and rule fields in webhook payloads", async () => {
+    await sendAutomationNotification(
+      { id: 1, type: "webhook", config: '{"url":"https://example.com"}' },
+      {
+        title: "CPU warning",
+        body: "cpu.percent is at 97",
+        severity: "warning",
+        context: {
+          host: { id: 11, name: "Proxmox Node" },
+          trigger: { value: 97, threshold: 90 },
+          run: { automationId: 42 },
+        },
+      },
+    );
+
+    const options = automationFetch.mock.calls[0][1] as RequestInit;
+    expect(JSON.parse(options.body as string)).toMatchObject({
+      hostName: "Proxmox Node",
+      hostId: 11,
+      ruleName: "CPU warning",
+      ruleId: 42,
+      value: 97,
+      threshold: 90,
+      message: "cpu.percent is at 97",
+    });
+  });
+});

--- a/src/backend/tests/automations/notify.test.ts
+++ b/src/backend/tests/automations/notify.test.ts
@@ -6,9 +6,8 @@ vi.mock("../../automations/http.js", () => ({
   automationFetch: (...args: unknown[]) => automationFetch(...args),
 }));
 
-const { sendAutomationNotification } = await import(
-  "../../automations/notify.js"
-);
+const { sendAutomationNotification } =
+  await import("../../automations/notify.js");
 
 beforeEach(() => {
   automationFetch.mockReset();


### PR DESCRIPTION
Fixes Termix-SSH/Support#1170

## Summary
- resolve the triggering host into `host` and `trigger.hostName` template context
- include alert-compatible host, rule, value, and threshold fields in automation webhooks
- preserve automation-specific title and message fields

## Verification
- `npm test -- --run src/backend/tests/automations/engine.test.ts src/backend/tests/automations/notify.test.ts` (27 passed)
- `npm run type-check`
- `git diff --check`