### PR TITLE
Fix private CA server connection probe

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -537,7 +537,11 @@ function httpFetch(url, options = {}) {
       method: options.method || "GET",
       headers: options.headers || {},
       timeout: options.timeout || 10000,
-      ...(isHttps ? getTlsVerificationOptions(url) : {}),
+      ...(isHttps
+        ? options.allowInvalidCertificate
+          ? { rejectUnauthorized: false }
+          : getTlsVerificationOptions(url)
+        : {}),
     };
 
     const req = client.request(url, requestOptions, (res) => {
@@ -3134,7 +3138,11 @@ ipcMain.handle("close-external-editor", (_event, editId) => {
   }
 });
 
-ipcMain.handle("test-server-connection", async (event, serverUrl) => {
+async function testServerConnection(
+  _event,
+  serverUrl,
+  allowInvalidCertificate = false,
+) {
   try {
     const normalizedServerUrl = serverUrl.replace(/\/$/, "");
     const healthUrl = `${normalizedServerUrl}/health`;
@@ -3154,6 +3162,7 @@ ipcMain.handle("test-server-connection", async (event, serverUrl) => {
       const response = await httpFetch(healthUrl, {
         method: "GET",
         timeout: 10000,
+        allowInvalidCertificate,
       });
 
       const data = await response.text();
@@ -3207,7 +3216,9 @@ ipcMain.handle("test-server-connection", async (event, serverUrl) => {
   } catch (error) {
     return { success: false, error: error.message };
   }
-});
+}
+
+ipcMain.handle("test-server-connection", testServerConnection);
 
 function createMenu() {
   if (process.platform === "darwin") {

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -40,7 +40,10 @@ export interface ElectronAPI {
 
   getServerConfig: () => Promise<ServerConfig>;
   saveServerConfig: (config: ServerConfig) => Promise<{ success: boolean }>;
-  testServerConnection: (serverUrl: string) => Promise<ConnectionTestResult>;
+  testServerConnection: (
+    serverUrl: string,
+    allowInvalidCertificate?: boolean,
+  ) => Promise<ConnectionTestResult>;
   getC2STunnelConfig: () => Promise<unknown[]>;
   saveC2STunnelConfig: (
     config: unknown[],

--- a/src/ui/settings/RemoteSyncServerPicker.tsx
+++ b/src/ui/settings/RemoteSyncServerPicker.tsx
@@ -98,6 +98,7 @@ export function RemoteSyncServerPicker({
       const testResult = (await window.electronAPI?.invoke?.(
         "test-server-connection",
         normalizedUrl,
+        normalizedUrl.startsWith("https://") && allowInvalidCertificate,
       )) as { success?: boolean; error?: string; warning?: string } | undefined;
 
       if (!testResult?.success) {


### PR DESCRIPTION
Fixes Termix-SSH/Support#1163.

Passes the explicit invalid-certificate preference into the initial remote server health probe, before the remote sync configuration has been persisted. The TLS override remains scoped to that HTTPS probe and does not disable certificate verification globally.

Verification:
- Prettier check
- `node --check electron/main.cjs`
- Vite production build passed; backend TypeScript stage remains blocked by the existing missing `@anthropic-ai/sdk` dependency in the local install.