### PR TITLE
Fix missing Linux application icon

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -82,7 +82,7 @@
         "arch": ["x64", "arm64", "armv7l"]
       }
     ],
-    "icon": "public/icon.png",
+    "icon": "public/icons",
     "category": "Development",
     "executableName": "termix",
     "maintainer": "Termix <mail@termix.site>",


### PR DESCRIPTION
Fixes Termix-SSH/Support#390

## Summary
- package the existing multi-size Linux icon set instead of only the 1024x1024 source
- install standard hicolor sizes used by KDE, Mint, and other desktop panels

## Verification
- inspected the release-2.7.0 deb: it only contains `/usr/share/icons/hicolor/1024x1024/apps/termix.png`
- validated `electron-builder.json`
- verified all icon filenames match their pixel dimensions (16 through 1024)
- `git diff --check`

A local package rebuild was attempted with the released app as prepackaged input, but the local dependency install is missing `@electron/notarize`; Linux packaging CI should verify the resulting deb contents.