### PR TITLE
Fix duplicate Docker HTTPS listener

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -35,6 +35,7 @@ export ENABLE_SSL=${ENABLE_SSL:-false}
 export SSL_PORT=${SSL_PORT:-8443}
 export SSL_CERT_PATH=${SSL_CERT_PATH:-/app/data/ssl/termix.crt}
 export SSL_KEY_PATH=${SSL_KEY_PATH:-/app/data/ssl/termix.key}
+export TERMIX_SSL_TERMINATED_BY_NGINX=true
 
 echo "Configuring web UI to run on port: $PORT"
 

--- a/src/backend/database/database.ts
+++ b/src/backend/database/database.ts
@@ -2052,7 +2052,12 @@ if (sslConfig.enabled) {
     ssl_port: sslConfig.port,
     backend_http_port: HTTP_PORT,
   });
+}
 
+if (
+  sslConfig.enabled &&
+  process.env.TERMIX_SSL_TERMINATED_BY_NGINX !== "true"
+) {
   try {
     const httpsServer = https.createServer(
       {


### PR DESCRIPTION
Fixes Termix-SSH/Support#1175

## Summary
- mark Docker TLS as terminated by the bundled nginx process
- keep SSL certificate setup and nginx HTTPS behavior unchanged
- prevent the Node backend from binding the same `SSL_PORT` inside Docker
- preserve direct backend HTTPS for non-Docker deployments

## Verification
- `sh -n docker/entrypoint.sh`
- ESLint on `src/backend/database/database.ts`
- Prettier check
- `git diff --check`