### PR TITLE
Fix online status when metrics collection is disabled

### DIFF
--- a/src/backend/hosts/metrics/index.ts
+++ b/src/backend/hosts/metrics/index.ts
@@ -576,16 +576,32 @@ class PollingManager {
       } else {
         isOnline = await tcpPing(refreshedHost.ip, pingPort, 5000);
       }
+      const config = this.pollingConfigs.get(refreshedHost.id);
+      let authenticated: boolean | undefined;
+      if (
+        isOnline &&
+        supportsMetrics(refreshedHost) &&
+        !config?.statsConfig.metricsEnabled
+      ) {
+        try {
+          await withSshConnection(refreshedHost, async () => undefined);
+          authenticated = true;
+        } catch {
+          authenticated = false;
+        }
+      }
       const statusEntry: StatusEntry = {
-        status: statusAfterReachabilityCheck(
-          isOnline,
-          this.statusStore.get(refreshedHost.id)?.status,
-        ),
+        status:
+          authenticated === undefined
+            ? statusAfterReachabilityCheck(
+                isOnline,
+                this.statusStore.get(refreshedHost.id)?.status,
+              )
+            : statusAfterAuthentication(authenticated),
         lastChecked: new Date().toISOString(),
       };
       this.statusStore.set(refreshedHost.id, statusEntry);
       if (isOnline && this.activeViewers.has(refreshedHost.id)) {
-        const config = this.pollingConfigs.get(refreshedHost.id);
         if (config?.statsConfig.metricsEnabled) {
           this.scheduleInitialMetricsPoll(config.host, config.viewerUserId);
         }


### PR DESCRIPTION
Fixes Termix-SSH/Support#1176

## Summary
- authenticate reachable SSH hosts during status polling when metrics collection is disabled
- preserve `reachable` for hosts that accept TCP connections but fail SSH authentication
- avoid running metric collectors solely to determine host status

## Validation
- `npm test -- --run src/backend/hosts/metrics/host-status.test.ts`
- `npx eslint src/backend/hosts/metrics/index.ts`
- `npm run type-check` *(blocked by the existing missing `@anthropic-ai/sdk` dependency)*