### PR TITLE
Fix browser RDP file drops

### DIFF
--- a/src/ui/features/guacamole/GuacamoleApp.tsx
+++ b/src/ui/features/guacamole/GuacamoleApp.tsx
@@ -7,6 +7,7 @@ import React, {
   useImperativeHandle,
 } from "react";
 import type Guacamole from "guacamole-common-js";
+import { toast } from "sonner";
 import {
   GuacamoleDisplay,
   type GuacamoleDisplayHandle,
@@ -179,6 +180,16 @@ const GuacamoleAppInner = React.forwardRef<
     setPendingUploads(files);
     setFileBrowserOpen(true);
   }, []);
+
+  const handleDropUnavailable = useCallback(() => {
+    toast.error(
+      t(
+        allowUpload
+          ? "guacamole.files.driveUnavailable"
+          : "guacamole.files.uploadDisabled",
+      ),
+    );
+  }, [allowUpload, t]);
 
   const resolvedProtocolForConnect = (protocol ??
     hostConfig.connectionType ??
@@ -461,6 +472,7 @@ const GuacamoleAppInner = React.forwardRef<
         }
         onFilesystem={setFilesystem}
         onDropFiles={handleDropFiles}
+        onDropUnavailable={handleDropUnavailable}
       />
       {filesystem && fileBrowserOpen && (
         <GuacamoleFileBrowser

--- a/src/ui/features/guacamole/GuacamoleDisplay.tsx
+++ b/src/ui/features/guacamole/GuacamoleDisplay.tsx
@@ -25,6 +25,10 @@ import {
 } from "./guacamole-clipboard.ts";
 import { getGuacamoleDisplaySize } from "./guacamole-display-size.ts";
 import { bindPointerInput } from "./guacamole-pointer.ts";
+import {
+  getFileDropDisposition,
+  hasDraggedFiles,
+} from "./guacamole-file-drop.ts";
 import { guacStateToStage } from "@/components/connection/connection-status.ts";
 import type { ConnectionStage } from "@/types/connection-log.ts";
 
@@ -66,6 +70,7 @@ interface GuacamoleDisplayProps {
   onError?: (error: string) => void;
   onFilesystem?: (filesystem: Guacamole.Object | null) => void;
   onDropFiles?: (files: File[]) => void;
+  onDropUnavailable?: () => void;
   onStageChange?: (stage: ConnectionStage) => void;
 }
 
@@ -85,6 +90,7 @@ export const GuacamoleDisplay = forwardRef<
     onError,
     onFilesystem,
     onDropFiles,
+    onDropUnavailable,
     onStageChange,
   },
   ref,
@@ -776,8 +782,9 @@ export const GuacamoleDisplay = forwardRef<
 
   const handleDragEnter = useCallback(
     (event: React.DragEvent) => {
-      if (!canDropFiles || !event.dataTransfer.types.includes("Files")) return;
+      if (!hasDraggedFiles(event.dataTransfer.types)) return;
       event.preventDefault();
+      if (!canDropFiles) return;
       dragDepthRef.current += 1;
       setIsDraggingFiles(true);
     },
@@ -791,15 +798,21 @@ export const GuacamoleDisplay = forwardRef<
 
   const handleDrop = useCallback(
     (event: React.DragEvent) => {
-      if (!canDropFiles) return;
+      if (!hasDraggedFiles(event.dataTransfer.types)) return;
       event.preventDefault();
       dragDepthRef.current = 0;
       setIsDraggingFiles(false);
 
       const files = Array.from(event.dataTransfer.files);
-      if (files.length > 0) onDropFiles?.(files);
+      const disposition = getFileDropDisposition(
+        event.dataTransfer.types,
+        files.length,
+        canDropFiles,
+      );
+      if (disposition === "upload") onDropFiles?.(files);
+      if (disposition === "reject") onDropUnavailable?.();
     },
-    [canDropFiles, onDropFiles],
+    [canDropFiles, onDropFiles, onDropUnavailable],
   );
 
   return (
@@ -808,7 +821,9 @@ export const GuacamoleDisplay = forwardRef<
       className="absolute inset-0 overflow-hidden"
       style={{ backgroundColor: "var(--bg-base)" }}
       onDragEnter={handleDragEnter}
-      onDragOver={canDropFiles ? (e) => e.preventDefault() : undefined}
+      onDragOver={(event) => {
+        if (hasDraggedFiles(event.dataTransfer.types)) event.preventDefault();
+      }}
       onDragLeave={canDropFiles ? handleDragLeave : undefined}
       onDrop={handleDrop}
     >

--- a/src/ui/features/guacamole/guacamole-file-drop.ts
+++ b/src/ui/features/guacamole/guacamole-file-drop.ts
@@ -1,0 +1,14 @@
+export type FileDropDisposition = "ignore" | "reject" | "upload";
+
+export function hasDraggedFiles(types: readonly string[]): boolean {
+  return types.includes("Files");
+}
+
+export function getFileDropDisposition(
+  types: readonly string[],
+  fileCount: number,
+  canUpload: boolean,
+): FileDropDisposition {
+  if (!hasDraggedFiles(types) || fileCount === 0) return "ignore";
+  return canUpload ? "upload" : "reject";
+}

--- a/src/ui/locales/en.json
+++ b/src/ui/locales/en.json
@@ -1867,6 +1867,7 @@
       "uploaded": "Uploaded {{name}}",
       "uploadFailed": "Failed to upload {{name}}",
       "uploadDisabled": "Uploads are disabled for this connection",
+      "driveUnavailable": "Enable RDP drive redirection before uploading files",
       "dropToUpload": "Drop files to upload"
     },
     "toolbar": {

--- a/src/ui/tests/features/guacamole/guacamole-file-drop.test.ts
+++ b/src/ui/tests/features/guacamole/guacamole-file-drop.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import {
+  getFileDropDisposition,
+  hasDraggedFiles,
+} from "@/features/guacamole/guacamole-file-drop.ts";
+
+describe("Guacamole file drop", () => {
+  it("recognizes external file drags", () => {
+    expect(hasDraggedFiles(["Files"])).toBe(true);
+    expect(hasDraggedFiles(["text/plain"])).toBe(false);
+  });
+
+  it("rejects files when upload is unavailable instead of ignoring them", () => {
+    expect(getFileDropDisposition(["Files"], 1, false)).toBe("reject");
+    expect(getFileDropDisposition(["Files"], 1, true)).toBe("upload");
+  });
+});


### PR DESCRIPTION
Fixes Termix-SSH/Support#1178

## Summary
- always intercept external file drops over a Guacamole session so the browser cannot navigate away
- upload normally when the redirected RDP drive is ready
- show an actionable message when uploads are disabled or drive redirection is unavailable
- add regression coverage for unavailable and available drop dispositions

## Validation
- `npm test -- --run src/ui/tests/features/guacamole/guacamole-file-drop.test.ts src/ui/tests/features/guacamole/guacamole-filesystem.test.ts`
- targeted ESLint and Prettier checks
- `npm run type-check`