### PR TITLE
Fix Proxmox guest credential usernames

### DIFF
--- a/src/backend/database/routes/proxmox-import-auth.ts
+++ b/src/backend/database/routes/proxmox-import-auth.ts
@@ -32,7 +32,7 @@ export function resolveProxmoxImportAuth(
     return {
       authType: "credential",
       credentialId,
-      overrideCredentialUsername: 1,
+      overrideCredentialUsername: 0,
     };
   }
 

--- a/src/backend/database/routes/proxmox.ts
+++ b/src/backend/database/routes/proxmox.ts
@@ -689,6 +689,12 @@ async function syncProxmoxHost(
           ? existing.connectionType
           : null;
       const connectionType = existingConnectionType ?? guest.connectionType;
+      const usesImportCredential =
+        connectionType === "ssh" && importAuth.authType === "credential";
+      const existingUsesImportCredential =
+        usesImportCredential &&
+        existing?.authType === "credential" &&
+        existing?.credentialId === importAuth.credentialId;
       const port =
         typeof existing?.port === "number"
           ? existing.port
@@ -696,11 +702,13 @@ async function syncProxmoxHost(
             ? 3389
             : 22;
       const username =
-        typeof existing?.username === "string" && existing.username
-          ? existing.username
-          : connectionType === "rdp"
-            ? ""
-            : "root";
+        usesImportCredential && (!existing || existingUsesImportCredential)
+          ? ""
+          : typeof existing?.username === "string" && existing.username
+            ? existing.username
+            : connectionType === "rdp"
+              ? ""
+              : "root";
       const update: Record<string, unknown> = {
         name: guest.name,
         ip: guest.ip || existing?.ip || "0.0.0.0",
@@ -714,6 +722,10 @@ async function syncProxmoxHost(
       };
 
       if (existing) {
+        if (existingUsesImportCredential) {
+          update.credentialId = importAuth.credentialId;
+          update.overrideCredentialUsername = false;
+        }
         await createCurrentHostRepository().updateEncryptedForUser(
           userId,
           existing.id as number,

--- a/src/backend/tests/database/repositories/host-repository.test.ts
+++ b/src/backend/tests/database/repositories/host-repository.test.ts
@@ -1,7 +1,8 @@
 import { sql } from "drizzle-orm";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { TestSqliteDatabase } from "./test-support.js";
 import { HostRepository } from "../../../database/repositories/host-repository.js";
+import { DataCrypto } from "../../../utils/data-crypto.js";
 
 describe("HostRepository.reorderForUser", () => {
   let adapter: TestSqliteDatabase | null = null;
@@ -70,5 +71,102 @@ describe("HostRepository.reorderForUser", () => {
   it("no-ops on an empty positions array", async () => {
     const repo = await createRepository();
     await expect(repo.reorderForUser("user-1", [])).resolves.toBe(0);
+  });
+});
+
+describe("HostRepository Proxmox sync inserts", () => {
+  let adapter: TestSqliteDatabase | null = null;
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await adapter?.close();
+    adapter = null;
+  });
+
+  it("creates a discovered guest using the scheduled-sync payload", async () => {
+    adapter = new TestSqliteDatabase();
+    const context = await adapter.connect();
+    await adapter.exec(`
+      INSERT INTO users (id, username, password_hash)
+      VALUES ('user-1', 'alice', 'hash');
+      INSERT INTO ssh_credentials (id, user_id, name, auth_type, username)
+      VALUES (7, 'user-1', 'guest key', 'key', 'alice');
+    `);
+    const repository = new HostRepository(context);
+    const now = new Date().toISOString();
+    vi.spyOn(DataCrypto, "validateUserAccess").mockReturnValue(
+      Buffer.alloc(32, 1),
+    );
+
+    const created = await repository.createEncryptedForUser("user-1", {
+      userId: "user-1",
+      name: "guest",
+      ip: "10.0.0.8",
+      port: 22,
+      username: "",
+      connectionType: "ssh",
+      folder: "Proxmox",
+      tags: "proxmox,qemu,node-1,vm-100",
+      proxmoxConfig: JSON.stringify({
+        source: {
+          source: "proxmox",
+          sourceHostId: 1,
+          node: "node-1",
+          vmid: 100,
+          type: "qemu",
+        },
+      }),
+      updatedAt: now,
+      createdAt: now,
+      pin: false,
+      authType: "credential",
+      credentialId: 7,
+      overrideCredentialUsername: 0,
+      password: null,
+      key: null,
+      keyPassword: null,
+      keyType: null,
+      enableTerminal: true,
+      enableFileManager: true,
+      enableTunnel: true,
+      enableDocker: false,
+      enableSsh: true,
+      enableRdp: false,
+      rdpUser: null,
+      rdpPassword: null,
+      rdpDomain: null,
+      rdpSecurity: null,
+      rdpIgnoreCert: 0,
+      rdpPort: null,
+      vncUser: null,
+      vncPassword: null,
+      vncPort: null,
+      telnetUser: null,
+      telnetPassword: null,
+      telnetPort: null,
+      defaultPath: "/",
+      tunnelConnections: "[]",
+      jumpHosts: null,
+      quickActions: null,
+      statsConfig: null,
+      dockerConfig: null,
+      terminalConfig: null,
+      forceKeyboardInteractive: "false",
+      useSocks5: 0,
+      socks5Host: null,
+      socks5Port: null,
+      socks5Username: null,
+      socks5Password: null,
+      socks5ProxyChain: null,
+      portKnockSequence: null,
+      showTerminalInSidebar: 0,
+      showFileManagerInSidebar: 0,
+      showTunnelInSidebar: 0,
+      showDockerInSidebar: 0,
+      showServerStatsInSidebar: 0,
+    });
+
+    expect(created.username).toBe("");
+    expect(created.credentialId).toBe(7);
   });
 });

--- a/src/backend/tests/database/routes/proxmox-import-auth.test.ts
+++ b/src/backend/tests/database/routes/proxmox-import-auth.test.ts
@@ -9,7 +9,7 @@ describe("resolveProxmoxImportAuth", () => {
     expect(resolveProxmoxImportAuth("key", 7)).toEqual({
       authType: "credential",
       credentialId: 7,
-      overrideCredentialUsername: 1,
+      overrideCredentialUsername: 0,
     });
   });
 
@@ -17,7 +17,7 @@ describe("resolveProxmoxImportAuth", () => {
     expect(resolveProxmoxImportAuth("password", 7)).toEqual({
       authType: "credential",
       credentialId: 7,
-      overrideCredentialUsername: 1,
+      overrideCredentialUsername: 0,
     });
   });
 
@@ -35,7 +35,7 @@ describe("resolveProxmoxImportAuth", () => {
     expect(resolveProxmoxImportAuth(undefined, 42)).toEqual({
       authType: "credential",
       credentialId: 42,
-      overrideCredentialUsername: 1,
+      overrideCredentialUsername: 0,
     });
     expect(resolveProxmoxImportAuth(undefined, null)).toEqual({
       authType: "none",

--- a/src/ui/components/proxmox/ProxmoxDiscoverDialog.tsx
+++ b/src/ui/components/proxmox/ProxmoxDiscoverDialog.tsx
@@ -154,7 +154,10 @@ export function ProxmoxDiscoverDialog({
         // the real IP. Re-sync keeps the manual value (guest.ip || existing.ip).
         ip: g.ip || "0.0.0.0",
         port: g.connectionType === "rdp" ? 3389 : 22,
-        username: defaultUsername ?? "root",
+        username:
+          importAuth.authType === "credential"
+            ? ""
+            : (defaultUsername ?? "root"),
         folder: importFolder,
         // Inherit the jump-host chain from the scanned Proxmox host so the
         // imported guests are reachable the same way; user can override.

--- a/src/ui/components/proxmox/proxmox-import-auth.ts
+++ b/src/ui/components/proxmox/proxmox-import-auth.ts
@@ -30,7 +30,7 @@ export function resolveProxmoxImportAuth(
     return {
       authType: "credential",
       credentialId,
-      overrideCredentialUsername: true,
+      overrideCredentialUsername: false,
     };
   }
 

--- a/src/ui/tests/components/proxmox/proxmox-import-auth.test.ts
+++ b/src/ui/tests/components/proxmox/proxmox-import-auth.test.ts
@@ -9,7 +9,7 @@ describe("resolveProxmoxImportAuth", () => {
     expect(resolveProxmoxImportAuth("password", 42)).toEqual({
       authType: "credential",
       credentialId: 42,
-      overrideCredentialUsername: true,
+      overrideCredentialUsername: false,
     });
   });
 
@@ -17,7 +17,7 @@ describe("resolveProxmoxImportAuth", () => {
     expect(resolveProxmoxImportAuth("credential", 7)).toEqual({
       authType: "credential",
       credentialId: 7,
-      overrideCredentialUsername: true,
+      overrideCredentialUsername: false,
     });
   });
 
@@ -25,7 +25,7 @@ describe("resolveProxmoxImportAuth", () => {
     expect(resolveProxmoxImportAuth(undefined, 5)).toEqual({
       authType: "credential",
       credentialId: 5,
-      overrideCredentialUsername: true,
+      overrideCredentialUsername: false,
     });
   });
 


### PR DESCRIPTION
## Summary
- let credential-backed Proxmox imports inherit the credential username instead of forcing `root`
- repair existing auto-synced guests that still use the selected import credential
- cover the scheduled-sync SQLite encrypted insert payload with a regression test

## Verification
- `npm test -- --run src/backend/tests/database/repositories/host-repository.test.ts src/backend/tests/database/routes/proxmox-import-auth.test.ts src/ui/tests/components/proxmox/proxmox-import-auth.test.ts`
- `npm run type-check`
- targeted ESLint and Prettier checks

Fixes Termix-SSH/Support#1177