### PR TITLE
Add WSL option to Windows local terminal

### DIFF
--- a/electron/local-shell.cjs
+++ b/electron/local-shell.cjs
@@ -1,0 +1,21 @@
+function resolveLocalShell(platform, requestedShell, env = process.env) {
+  if (platform === "win32") {
+    if (requestedShell === "wsl") {
+      return { file: "wsl.exe", args: [] };
+    }
+    return {
+      file: env.TERMIX_LOCAL_SHELL || "powershell.exe",
+      args: ["-NoLogo"],
+    };
+  }
+
+  return {
+    file:
+      env.TERMIX_LOCAL_SHELL ||
+      env.SHELL ||
+      (platform === "darwin" ? "/bin/zsh" : "/bin/bash"),
+    args: ["-l"],
+  };
+}
+
+module.exports = { resolveLocalShell };

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -30,24 +30,9 @@ const { launchNativeRdp } = require("./native-rdp.cjs");
 const { isCloseActiveTabInput } = require("./keyboard-shortcuts.cjs");
 const { quitApp } = require("./app-quit.cjs");
 const { selectLinuxPasswordStore } = require("./linux-password-store.cjs");
+const { resolveLocalShell } = require("./local-shell.cjs");
 
 const localTerminalSessions = new Map();
-
-function localShell() {
-  if (process.platform === "win32") {
-    return {
-      file: process.env.TERMIX_LOCAL_SHELL || "powershell.exe",
-      args: ["-NoLogo"],
-    };
-  }
-  return {
-    file:
-      process.env.TERMIX_LOCAL_SHELL ||
-      process.env.SHELL ||
-      (process.platform === "darwin" ? "/bin/zsh" : "/bin/bash"),
-    args: ["-l"],
-  };
-}
 
 function ownedLocalTerminal(event, sessionId) {
   if (typeof sessionId !== "string" || !/^[a-f0-9-]{36}$/.test(sessionId)) {
@@ -2932,7 +2917,7 @@ ipcMain.handle("local-terminal-start", (event, dimensions = {}) => {
   const cols = Math.min(500, Math.max(2, Number(dimensions.cols) || 80));
   const rows = Math.min(300, Math.max(1, Number(dimensions.rows) || 24));
   const sessionId = crypto.randomUUID();
-  const shellConfig = localShell();
+  const shellConfig = resolveLocalShell(process.platform, dimensions.shell);
   const child = pty.spawn(shellConfig.file, shellConfig.args, {
     name: "xterm-256color",
     cols,

--- a/src/backend/tests/electron/local-shell.test.ts
+++ b/src/backend/tests/electron/local-shell.test.ts
@@ -1,0 +1,35 @@
+import { createRequire } from "node:module";
+import { describe, expect, it } from "vitest";
+
+const require = createRequire(import.meta.url);
+const { resolveLocalShell } =
+  require("../../../../electron/local-shell.cjs") as {
+    resolveLocalShell: (
+      platform: NodeJS.Platform,
+      requestedShell?: string,
+      env?: NodeJS.ProcessEnv,
+    ) => { file: string; args: string[] };
+  };
+
+describe("resolveLocalShell", () => {
+  it("starts the default WSL distribution without PowerShell arguments", () => {
+    expect(resolveLocalShell("win32", "wsl", {})).toEqual({
+      file: "wsl.exe",
+      args: [],
+    });
+  });
+
+  it("keeps PowerShell as the default Windows shell", () => {
+    expect(resolveLocalShell("win32", "default", {})).toEqual({
+      file: "powershell.exe",
+      args: ["-NoLogo"],
+    });
+  });
+
+  it("preserves the configured shell on non-Windows platforms", () => {
+    expect(resolveLocalShell("linux", "wsl", { SHELL: "/bin/fish" })).toEqual({
+      file: "/bin/fish",
+      args: ["-l"],
+    });
+  });
+});

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -174,6 +174,7 @@ export interface ElectronAPI {
   startLocalTerminal(dimensions: {
     cols: number;
     rows: number;
+    shell?: "default" | "wsl";
   }): Promise<{ sessionId: string; shell: string }>;
   readyLocalTerminal(sessionId: string): Promise<boolean>;
   writeLocalTerminal(sessionId: string, data: string): Promise<boolean>;

--- a/src/ui/features/local-terminal/LocalTerminal.tsx
+++ b/src/ui/features/local-terminal/LocalTerminal.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { FitAddon } from "@xterm/addon-fit";
 import { useXTerm } from "react-xtermjs";
 import { useTheme } from "@/components/theme-provider";
@@ -17,6 +17,14 @@ export function LocalTerminal({
   const { instance: terminal, ref: xtermRef } = useXTerm();
   const fitAddonRef = useRef<FitAddon | null>(null);
   const sessionIdRef = useRef<string | null>(null);
+  const [isWindows, setIsWindows] = useState(false);
+  const [shell, setShell] = useState<"default" | "wsl">("default");
+
+  useEffect(() => {
+    window.electronAPI?.getPlatform().then((platform) => {
+      setIsWindows(platform === "win32");
+    });
+  }, []);
 
   const fit = useCallback(() => {
     const fitAddon = fitAddonRef.current;
@@ -60,7 +68,7 @@ export function LocalTerminal({
     });
 
     window.electronAPI
-      .startLocalTerminal({ cols: terminal.cols, rows: terminal.rows })
+      .startLocalTerminal({ cols: terminal.cols, rows: terminal.rows, shell })
       .then(({ sessionId }) => {
         if (disposed) {
           window.electronAPI.closeLocalTerminal(sessionId);
@@ -100,11 +108,30 @@ export function LocalTerminal({
       fitAddonRef.current = null;
       fitAddon.dispose();
     };
-  }, [fit, instanceId, terminal, xtermRef]);
+  }, [fit, instanceId, shell, terminal, xtermRef]);
 
   useEffect(() => {
     if (isVisible) requestAnimationFrame(fit);
   }, [fit, isVisible]);
 
-  return <div ref={xtermRef} className="h-full w-full bg-background p-2" />;
+  return (
+    <div className="flex h-full w-full flex-col bg-background">
+      {isWindows && (
+        <div className="flex justify-end border-b border-border px-2 py-1">
+          <select
+            aria-label="Local terminal shell"
+            className="rounded border border-border bg-background px-2 py-1 text-xs text-foreground"
+            value={shell}
+            onChange={(event) =>
+              setShell(event.target.value === "wsl" ? "wsl" : "default")
+            }
+          >
+            <option value="default">PowerShell</option>
+            <option value="wsl">WSL</option>
+          </select>
+        </div>
+      )}
+      <div ref={xtermRef} className="min-h-0 flex-1 p-2" />
+    </div>
+  );
 }


### PR DESCRIPTION
## Summary
- add a PowerShell / WSL selector to local terminal tabs on Windows
- start `wsl.exe` with the user's default distribution and no PowerShell-only arguments
- keep the existing default shell behavior unchanged on Windows, macOS, and Linux

## Verification
- `npm test -- --run src/backend/tests/electron/local-shell.test.ts src/backend/tests/electron/backend-paths.test.ts src/ui/tests/lib/electron.test.ts`
- `npm run type-check`
- `npm run build`
- targeted ESLint and Prettier checks

Fixes Termix-SSH/Support#1179