### PR TITLE
refactor: split the transfer engine into focused modules

### DIFF
--- a/src/backend/hosts/file-manager/sftp-promisify.ts
+++ b/src/backend/hosts/file-manager/sftp-promisify.ts
@@ -16,7 +16,10 @@ export function promisifySftpStat(
   });
 }
 
-export function promisifySftpUnlink(sftp: SFTPWrapper, path: string): Promise<void> {
+export function promisifySftpUnlink(
+  sftp: SFTPWrapper,
+  path: string,
+): Promise<void> {
   return new Promise((resolve, reject) => {
     sftp.unlink(path, (err) => {
       if (err) reject(err);
@@ -25,7 +28,10 @@ export function promisifySftpUnlink(sftp: SFTPWrapper, path: string): Promise<vo
   });
 }
 
-export function promisifySftpRmdir(sftp: SFTPWrapper, path: string): Promise<void> {
+export function promisifySftpRmdir(
+  sftp: SFTPWrapper,
+  path: string,
+): Promise<void> {
   return new Promise((resolve, reject) => {
     sftp.rmdir(path, (err) => {
       if (err) reject(err);
@@ -89,7 +95,10 @@ export function promisifySftpOpen(
   });
 }
 
-export function promisifySftpClose(sftp: SFTPWrapper, handle: Buffer): Promise<void> {
+export function promisifySftpClose(
+  sftp: SFTPWrapper,
+  handle: Buffer,
+): Promise<void> {
   return new Promise((resolve, reject) => {
     sftp.close(handle, (err) => {
       if (err) reject(err);

--- a/src/backend/hosts/file-manager/sftp-promisify.ts
+++ b/src/backend/hosts/file-manager/sftp-promisify.ts
@@ -1,5 +1,9 @@
 type SFTPWrapper = import("ssh2").SFTPWrapper;
 
+export const SFTP_OPEN_READ = 0x00000001;
+export const SFTP_OPEN_WRITE = 0x00000002 | 0x00000008 | 0x00000010;
+export const SFTP_OPEN_WRITE_RESUME = 0x00000001 | 0x00000002 | 0x00000008;
+
 export function promisifySftpStat(
   sftp: SFTPWrapper,
   path: string,

--- a/src/backend/hosts/file-manager/sftp-promisify.ts
+++ b/src/backend/hosts/file-manager/sftp-promisify.ts
@@ -1,0 +1,107 @@
+type SFTPWrapper = import("ssh2").SFTPWrapper;
+
+export function promisifySftpStat(
+  sftp: SFTPWrapper,
+  path: string,
+): Promise<import("ssh2").Stats> {
+  return new Promise((resolve, reject) => {
+    sftp.stat(path, (err, stats) => {
+      if (err) reject(err);
+      else resolve(stats);
+    });
+  });
+}
+
+export function promisifySftpUnlink(sftp: SFTPWrapper, path: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    sftp.unlink(path, (err) => {
+      if (err) reject(err);
+      else resolve();
+    });
+  });
+}
+
+export function promisifySftpRmdir(sftp: SFTPWrapper, path: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    sftp.rmdir(path, (err) => {
+      if (err) reject(err);
+      else resolve();
+    });
+  });
+}
+
+export function promisifySftpMkdir(
+  sftp: SFTPWrapper,
+  path: string,
+  mode: number,
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    sftp.mkdir(path, { mode }, (err) => {
+      if (err && (err as NodeJS.ErrnoException).code !== "EEXIST") {
+        reject(err);
+      } else {
+        resolve();
+      }
+    });
+  });
+}
+
+export function promisifySftpChmod(
+  sftp: SFTPWrapper,
+  path: string,
+  mode: number,
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    sftp.chmod(path, mode, (err) => {
+      if (err) reject(err);
+      else resolve();
+    });
+  });
+}
+
+export function promisifySftpReaddir(
+  sftp: SFTPWrapper,
+  path: string,
+): Promise<Array<{ filename: string; attrs: import("ssh2").Stats }>> {
+  return new Promise((resolve, reject) => {
+    sftp.readdir(path, (err, list) => {
+      if (err) reject(err);
+      else resolve(list);
+    });
+  });
+}
+
+export function promisifySftpOpen(
+  sftp: SFTPWrapper,
+  path: string,
+  flags: number,
+  mode: number,
+): Promise<Buffer> {
+  return new Promise((resolve, reject) => {
+    sftp.open(path, flags, mode, (err, handle) => {
+      if (err) reject(err);
+      else resolve(handle);
+    });
+  });
+}
+
+export function promisifySftpClose(sftp: SFTPWrapper, handle: Buffer): Promise<void> {
+  return new Promise((resolve, reject) => {
+    sftp.close(handle, (err) => {
+      if (err) reject(err);
+      else resolve();
+    });
+  });
+}
+
+export function promisifySftpFstat(
+  sftp: SFTPWrapper,
+  handle: Buffer,
+): Promise<import("ssh2").Stats> {
+  return new Promise((resolve, reject) => {
+    sftp.fstat(handle, (err, stats) => {
+      if (err) reject(err);
+      else resolve(stats);
+    });
+  });
+}

--- a/src/backend/hosts/file-manager/transfer-engine.ts
+++ b/src/backend/hosts/file-manager/transfer-engine.ts
@@ -61,6 +61,13 @@ import {
   ensureDirectoryTreeSftp,
 } from "./transfer-sftp-dir.js";
 import {
+  DEFAULT_PARALLEL_SEGMENT_COUNT,
+  SFTP_XFER_SEGMENT_SIZE,
+  buildSegmentCopyJobs,
+  clampParallelSegmentCount,
+  type SegmentCopyJob,
+} from "./transfer-segment-copy.js";
+import {
   buildDirectProbeCommand,
   buildDirectRsyncCommand,
   quoteShell,
@@ -301,8 +308,6 @@ const SMALL_FILE_SYNC_THRESHOLD = 10 * 1024 * 1024;
 const SFTP_XFER_CHUNK_SIZE = 256 * 1024;
 /** Pipelined in-flight READ requests per leg (ssh2 fastGet/fastPut default is 64). */
 const SFTP_XFER_CONCURRENCY = 32;
-/** Reset pipelined scheduler every segment to avoid long-run deadlocks at GiB boundaries. */
-const SFTP_XFER_SEGMENT_SIZE = 256 * 1024 * 1024;
 /** Files above this size use segmented copy; smaller files use a single scheduler run. */
 const SFTP_XFER_SEGMENT_THRESHOLD = 32 * 1024 * 1024;
 /** Per-segment attempts before giving up (sequential and parallel). */
@@ -314,8 +319,6 @@ const SFTP_SEQUENTIAL_COPY_MAX_ATTEMPTS = 2;
 const SFTP_PARALLEL_COPY_MAX_ATTEMPTS = 2;
 /** Short backoff before opening fresh dedicated SSH sessions. */
 const TRANSFER_SESSION_RESET_DELAYS_MS = [1000, 2000, 3000];
-const DEFAULT_PARALLEL_SEGMENT_COUNT = 2;
-const MAX_PARALLEL_SEGMENT_COUNT = 8;
 const TRANSFER_HANDLE_CLOSE_TIMEOUT_MS = 2500;
 const HUNG_TRANSFER_MS = 90_000;
 const HUNG_RECONNECTING_MS = 180_000;
@@ -1141,43 +1144,6 @@ interface PipelinedXferOptions {
   segmentIndex?: number;
   reconnect?: TransferReconnectContext;
   onResumeOffset?: (offset: number) => void;
-}
-
-interface SegmentCopyJob {
-  offset: number;
-  length: number;
-  segmentIndex: number;
-}
-
-function clampParallelSegmentCount(value?: number): number {
-  const n = value ?? DEFAULT_PARALLEL_SEGMENT_COUNT;
-  return Math.max(1, Math.min(MAX_PARALLEL_SEGMENT_COUNT, Math.floor(n)));
-}
-
-function buildSegmentCopyJobs(
-  fileSize: number,
-  initialOffset: number,
-  destResumeSize: number,
-): SegmentCopyJob[] {
-  const jobs: SegmentCopyJob[] = [];
-  for (
-    let offset = initialOffset;
-    offset < fileSize;
-    offset += SFTP_XFER_SEGMENT_SIZE
-  ) {
-    const length = Math.min(SFTP_XFER_SEGMENT_SIZE, fileSize - offset);
-    const segmentIndex = Math.floor(offset / SFTP_XFER_SEGMENT_SIZE);
-    if (destResumeSize >= offset + length) {
-      continue;
-    }
-    const start = destResumeSize > offset ? destResumeSize : offset;
-    jobs.push({
-      offset: start,
-      length: offset + length - start,
-      segmentIndex,
-    });
-  }
-  return jobs;
 }
 
 function closeAllTransferSessions(

--- a/src/backend/hosts/file-manager/transfer-engine.ts
+++ b/src/backend/hosts/file-manager/transfer-engine.ts
@@ -51,6 +51,11 @@ import {
   type TransferTimings,
 } from "./transfer-stats.js";
 import {
+  TransferCancelledError,
+  TransferStalledError,
+  isRecoverableTransferError,
+} from "./transfer-errors.js";
+import {
   buildDirectProbeCommand,
   buildDirectRsyncCommand,
   quoteShell,
@@ -208,34 +213,6 @@ interface ActiveXferControl {
 const activeXferControls = new Map<string, ActiveXferControl>();
 const cancelWatchdogs = new Map<string, ReturnType<typeof setTimeout>>();
 
-class TransferCancelledError extends Error {
-  constructor() {
-    super("Transfer cancelled");
-    this.name = "TransferCancelledError";
-  }
-}
-
-class TransferStalledError extends Error {
-  readonly byteOffset?: number;
-  readonly segmentIndex?: number;
-
-  constructor(byteOffset?: number, segmentIndex?: number) {
-    const pos = byteOffset !== undefined ? ` at byte offset ${byteOffset}` : "";
-    const seg = segmentIndex !== undefined ? ` (segment ${segmentIndex})` : "";
-    super(`Transfer stalled — no data moved for 45 seconds${pos}${seg}`);
-    this.name = "TransferStalledError";
-    this.byteOffset = byteOffset;
-    this.segmentIndex = segmentIndex;
-  }
-}
-
-class TransferConnectionLostError extends Error {
-  constructor(message = "Transfer SSH connection lost") {
-    super(message);
-    this.name = "TransferConnectionLostError";
-  }
-}
-
 function throwIfCancelled(transferId: string): void {
   if (cancelRequestedTransfers.has(transferId)) {
     throw new TransferCancelledError();
@@ -366,31 +343,6 @@ function buildTransferReconnectContext(
   meta: TransferReconnectMeta,
 ): TransferReconnectContext {
   return { deps, transferId, ...meta };
-}
-
-function isRecoverableTransferConnectionError(err: unknown): boolean {
-  if (!(err instanceof Error)) return false;
-  const msg = err.message.toLowerCase();
-  return (
-    msg.includes("no response from server") ||
-    msg.includes("connection lost") ||
-    msg.includes("not connected") ||
-    msg.includes("econnreset") ||
-    msg.includes("econnrefused") ||
-    msg.includes("etimedout") ||
-    msg.includes("socket hang up") ||
-    msg.includes("protocol error") ||
-    msg.includes("connection closed") ||
-    msg.includes("channel open failure")
-  );
-}
-
-function isRecoverableTransferError(err: unknown): boolean {
-  return (
-    err instanceof TransferStalledError ||
-    err instanceof TransferConnectionLostError ||
-    isRecoverableTransferConnectionError(err)
-  );
 }
 
 async function probeDestResumeOffset(

--- a/src/backend/hosts/file-manager/transfer-engine.ts
+++ b/src/backend/hosts/file-manager/transfer-engine.ts
@@ -5,7 +5,6 @@ import type { ClientChannel } from "ssh2";
 import { fileLogger } from "../../utils/logger.js";
 import {
   basename,
-  buildPathFromSegments,
   dirname,
   getWorkingDir,
   inferPlatformFromPath,
@@ -13,7 +12,6 @@ import {
   normalizeSftpPath,
   pathsOverlap,
   sftpPathToLocalPath,
-  splitPathSegments,
   type TransferPlatform,
 } from "../transfer-paths.js";
 import {
@@ -29,10 +27,8 @@ import {
   promisifySftpChmod,
   promisifySftpClose,
   promisifySftpFstat,
-  promisifySftpMkdir,
   promisifySftpOpen,
   promisifySftpReaddir,
-  promisifySftpRmdir,
   promisifySftpStat,
   promisifySftpUnlink,
 } from "./sftp-promisify.js";
@@ -60,6 +56,10 @@ import {
   isPermissionError,
   isRootOnlyPath,
 } from "./transfer-host-utils.js";
+import {
+  deletePathSftp,
+  ensureDirectoryTreeSftp,
+} from "./transfer-sftp-dir.js";
 import {
   buildDirectProbeCommand,
   buildDirectRsyncCommand,
@@ -600,61 +600,6 @@ async function detectTransferPlatform(
 
   session.transferPlatform = "unix";
   return "unix";
-}
-
-async function ensureDirectoryTreeSftp(
-  sftp: SFTPWrapper,
-  dirPath: string,
-  created: Set<string> = new Set(),
-): Promise<void> {
-  const normalized = normalizeSftpPath(dirPath);
-  if (!normalized || isRootOnlyPath(normalized)) return;
-
-  const { root, segments } = splitPathSegments(normalized);
-  if (segments.length === 0) return;
-
-  for (let i = 0; i < segments.length; i++) {
-    const current = buildPathFromSegments(root, segments, i + 1);
-    if (created.has(current)) continue;
-
-    try {
-      await promisifySftpMkdir(sftp, current, 0o755);
-    } catch (err) {
-      const code = (err as NodeJS.ErrnoException).code;
-      if (code !== "EEXIST") {
-        try {
-          const stats = await promisifySftpStat(sftp, current);
-          if (!stats.isDirectory()) throw err;
-        } catch {
-          throw err;
-        }
-      }
-    }
-    created.add(current);
-  }
-}
-
-async function deletePathSftp(sftp: SFTPWrapper, path: string): Promise<void> {
-  let stats: import("ssh2").Stats;
-  try {
-    stats = await promisifySftpStat(sftp, path);
-  } catch {
-    return;
-  }
-
-  if (stats.isDirectory()) {
-    const entries = await promisifySftpReaddir(sftp, path);
-    for (const entry of entries) {
-      if (entry.filename === "." || entry.filename === "..") continue;
-      await deletePathSftp(sftp, joinPath(path, entry.filename));
-    }
-    await promisifySftpRmdir(sftp, path);
-    return;
-  }
-
-  if (stats.isFile()) {
-    await promisifySftpUnlink(sftp, path);
-  }
 }
 
 function execCommand(

--- a/src/backend/hosts/file-manager/transfer-engine.ts
+++ b/src/backend/hosts/file-manager/transfer-engine.ts
@@ -1,6 +1,5 @@
 import { getErrorMessage } from "../../utils/error-message.js";
 import { randomUUID } from "crypto";
-import { networkInterfaces } from "os";
 import { performance } from "node:perf_hooks";
 import type { ClientChannel } from "ssh2";
 import { fileLogger } from "../../utils/logger.js";
@@ -55,6 +54,12 @@ import {
   TransferStalledError,
   isRecoverableTransferError,
 } from "./transfer-errors.js";
+import {
+  escapeShell,
+  isLocalSshEndpoint,
+  isPermissionError,
+  isRootOnlyPath,
+} from "./transfer-host-utils.js";
 import {
   buildDirectProbeCommand,
   buildDirectRsyncCommand,
@@ -516,41 +521,6 @@ async function resetDedicatedTransferSessions(
   return { sourceSession, destSession, sourceSftp, destSftp };
 }
 
-let cachedLocalAddresses: Set<string> | null = null;
-
-function normalizeHostAddress(host: string): string {
-  const trimmed = host.trim().toLowerCase();
-  if (trimmed.startsWith("[") && trimmed.endsWith("]")) {
-    return trimmed.slice(1, -1);
-  }
-  return trimmed.split(":")[0] ?? trimmed;
-}
-
-function getLocalAddresses(): Set<string> {
-  if (cachedLocalAddresses) return cachedLocalAddresses;
-
-  const addresses = new Set(["127.0.0.1", "::1", "localhost"]);
-  for (const ifaces of Object.values(networkInterfaces())) {
-    if (!ifaces) continue;
-    for (const iface of ifaces) {
-      if (!iface.internal && iface.family === "IPv4") {
-        addresses.add(iface.address.toLowerCase());
-      }
-    }
-  }
-  cachedLocalAddresses = addresses;
-  return addresses;
-}
-
-export function isLocalSshEndpoint(ip?: string): boolean {
-  if (!ip) return false;
-  const bare = normalizeHostAddress(ip);
-  if (bare === "localhost" || bare === "127.0.0.1" || bare === "::1") {
-    return true;
-  }
-  return getLocalAddresses().has(bare);
-}
-
 function createThrottledProgress(onProgress?: (bytes: number) => void) {
   let pending = 0;
   let lastFlush = 0;
@@ -573,10 +543,6 @@ function createThrottledProgress(onProgress?: (bytes: number) => void) {
     },
     flush,
   };
-}
-
-function escapeShell(s: string): string {
-  return s.replace(/'/g, "'\"'\"'");
 }
 
 async function detectTransferPlatform(
@@ -634,24 +600,6 @@ async function detectTransferPlatform(
 
   session.transferPlatform = "unix";
   return "unix";
-}
-
-function isRootOnlyPath(path: string): boolean {
-  const normalized = normalizeSftpPath(path);
-  return (
-    normalized === "/" ||
-    /^\/[A-Za-z]:$/.test(normalized) ||
-    /^[A-Za-z]:$/.test(normalized)
-  );
-}
-
-function isPermissionError(err: Error): boolean {
-  const msg = err.message.toLowerCase();
-  return (
-    msg.includes("permission denied") ||
-    msg.includes("eacces") ||
-    msg.includes("access denied")
-  );
 }
 
 async function ensureDirectoryTreeSftp(

--- a/src/backend/hosts/file-manager/transfer-engine.ts
+++ b/src/backend/hosts/file-manager/transfer-engine.ts
@@ -38,6 +38,19 @@ import {
   promisifySftpUnlink,
 } from "./sftp-promisify.js";
 import {
+  buildTransferHopTimings,
+  computeTransferMbPerSec,
+  createEmptyXferStats,
+  createHopWallClock,
+  elapsedMs,
+  hopSpanMs,
+  mergeXferStats,
+  noteHopEnd,
+  noteHopStart,
+  type PipelinedXferStats,
+  type TransferTimings,
+} from "./transfer-stats.js";
+import {
   buildDirectProbeCommand,
   buildDirectRsyncCommand,
   quoteShell,
@@ -118,31 +131,11 @@ export type TransferStatus =
   "running" | "success" | "partial" | "error" | "cancelled";
 export type TransferMethod = "stream" | "tar" | "item_sftp" | "direct_rsync";
 
-export type TransferHopId =
-  "source_read" | "dest_sftp_write" | "dest_local_write";
-
-export interface TransferHopMetrics {
-  id: TransferHopId;
-  bytes: number;
-  /** Wall-clock span from first I/O on this hop to last I/O complete. */
-  spanMs: number;
-  mbPerSec: number;
-}
-
-export interface TransferTimings {
-  prepareDestMs?: number;
-  compressMs?: number;
-  transferMs?: number;
-  extractMs?: number;
-  verifyMs?: number;
-  directBenchmarkMs?: number;
-  relayBenchmarkMs?: number;
-  sourceDeleteMs?: number;
-  totalMs?: number;
-  transferBytes?: number;
-  endToEndMbPerSec?: number;
-  hops?: TransferHopMetrics[];
-}
+export type {
+  TransferHopId,
+  TransferHopMetrics,
+  TransferTimings,
+} from "./transfer-stats.js";
 
 export interface TransferProgress {
   transferId: string;
@@ -1097,10 +1090,6 @@ function finalizeTransfer(
   return result;
 }
 
-function elapsedMs(start: number): number {
-  return Date.now() - start;
-}
-
 async function verifyTransferredFile(
   deps: HostTransferDeps,
   transferId: string,
@@ -1148,102 +1137,6 @@ async function verifyTransferredFile(
   });
 }
 
-export function computeTransferMbPerSec(
-  bytes: number,
-  ms: number,
-): number | undefined {
-  if (ms <= 0 || bytes <= 0) return undefined;
-  return ((bytes / ms) * 1000) / (1024 * 1024);
-}
-
-interface HopWallClock {
-  firstAt: number | null;
-  lastAt: number | null;
-}
-
-function createHopWallClock(): HopWallClock {
-  return { firstAt: null, lastAt: null };
-}
-
-function noteHopStart(
-  clock: HopWallClock,
-  t: number = performance.now(),
-): void {
-  if (clock.firstAt === null) clock.firstAt = t;
-}
-
-function noteHopEnd(clock: HopWallClock, t: number = performance.now()): void {
-  clock.lastAt = t;
-}
-
-function hopSpanMs(clock: HopWallClock): number {
-  if (clock.firstAt === null || clock.lastAt === null) return 0;
-  return Math.max(0, clock.lastAt - clock.firstAt);
-}
-
-interface PipelinedXferStats {
-  bytes: number;
-  sourceReadSpanMs: number;
-  destWriteSpanMs: number;
-  destWriteKind: "sftp" | "local";
-}
-
-function createEmptyXferStats(): PipelinedXferStats {
-  return {
-    bytes: 0,
-    sourceReadSpanMs: 0,
-    destWriteSpanMs: 0,
-    destWriteKind: "sftp",
-  };
-}
-
-function mergeXferStats(
-  target: PipelinedXferStats,
-  source: PipelinedXferStats,
-): void {
-  target.bytes += source.bytes;
-  target.sourceReadSpanMs += source.sourceReadSpanMs;
-  target.destWriteSpanMs += source.destWriteSpanMs;
-  target.destWriteKind = source.destWriteKind;
-}
-
-function buildTransferHopTimings(
-  stats: PipelinedXferStats,
-  transferMs: number,
-): Pick<TransferTimings, "transferBytes" | "endToEndMbPerSec" | "hops"> {
-  const hops: TransferHopMetrics[] = [];
-
-  const sourceRate = computeTransferMbPerSec(
-    stats.bytes,
-    stats.sourceReadSpanMs,
-  );
-  if (sourceRate !== undefined) {
-    hops.push({
-      id: "source_read",
-      bytes: stats.bytes,
-      spanMs: stats.sourceReadSpanMs,
-      mbPerSec: sourceRate,
-    });
-  }
-
-  const destHopId: TransferHopId =
-    stats.destWriteKind === "local" ? "dest_local_write" : "dest_sftp_write";
-  const destRate = computeTransferMbPerSec(stats.bytes, stats.destWriteSpanMs);
-  if (destRate !== undefined) {
-    hops.push({
-      id: destHopId,
-      bytes: stats.bytes,
-      spanMs: stats.destWriteSpanMs,
-      mbPerSec: destRate,
-    });
-  }
-
-  return {
-    transferBytes: stats.bytes,
-    endToEndMbPerSec: computeTransferMbPerSec(stats.bytes, transferMs),
-    hops,
-  };
-}
 
 async function deleteSourcePathsAfterSuccess(
   deps: HostTransferDeps,

--- a/src/backend/hosts/file-manager/transfer-engine.ts
+++ b/src/backend/hosts/file-manager/transfer-engine.ts
@@ -65,7 +65,8 @@ import {
   collectFileWorkItems,
   readSftpSample,
   type FileWorkItem,
-} from "./transfer-scan.js";import {
+} from "./transfer-scan.js";
+import {
   deletePathSftp,
   ensureDirectoryTreeSftp,
 } from "./transfer-sftp-dir.js";
@@ -963,7 +964,6 @@ async function verifyTransferredFile(
     },
   });
 }
-
 
 async function deleteSourcePathsAfterSuccess(
   deps: HostTransferDeps,

--- a/src/backend/hosts/file-manager/transfer-engine.ts
+++ b/src/backend/hosts/file-manager/transfer-engine.ts
@@ -27,6 +27,17 @@ import {
 } from "./transfer-routing.js";
 import { verifySftpFileIntegrity } from "./transfer-integrity.js";
 import {
+  promisifySftpChmod,
+  promisifySftpClose,
+  promisifySftpFstat,
+  promisifySftpMkdir,
+  promisifySftpOpen,
+  promisifySftpReaddir,
+  promisifySftpRmdir,
+  promisifySftpStat,
+  promisifySftpUnlink,
+} from "./sftp-promisify.js";
+import {
   buildDirectProbeCommand,
   buildDirectRsyncCommand,
   quoteShell,
@@ -698,36 +709,6 @@ function isPermissionError(err: Error): boolean {
   );
 }
 
-function promisifySftpStat(
-  sftp: SFTPWrapper,
-  path: string,
-): Promise<import("ssh2").Stats> {
-  return new Promise((resolve, reject) => {
-    sftp.stat(path, (err, stats) => {
-      if (err) reject(err);
-      else resolve(stats);
-    });
-  });
-}
-
-function promisifySftpUnlink(sftp: SFTPWrapper, path: string): Promise<void> {
-  return new Promise((resolve, reject) => {
-    sftp.unlink(path, (err) => {
-      if (err) reject(err);
-      else resolve();
-    });
-  });
-}
-
-function promisifySftpRmdir(sftp: SFTPWrapper, path: string): Promise<void> {
-  return new Promise((resolve, reject) => {
-    sftp.rmdir(path, (err) => {
-      if (err) reject(err);
-      else resolve();
-    });
-  });
-}
-
 async function ensureDirectoryTreeSftp(
   sftp: SFTPWrapper,
   dirPath: string,
@@ -781,47 +762,6 @@ async function deletePathSftp(sftp: SFTPWrapper, path: string): Promise<void> {
   if (stats.isFile()) {
     await promisifySftpUnlink(sftp, path);
   }
-}
-
-function promisifySftpMkdir(
-  sftp: SFTPWrapper,
-  path: string,
-  mode: number,
-): Promise<void> {
-  return new Promise((resolve, reject) => {
-    sftp.mkdir(path, { mode }, (err) => {
-      if (err && (err as NodeJS.ErrnoException).code !== "EEXIST") {
-        reject(err);
-      } else {
-        resolve();
-      }
-    });
-  });
-}
-
-function promisifySftpChmod(
-  sftp: SFTPWrapper,
-  path: string,
-  mode: number,
-): Promise<void> {
-  return new Promise((resolve, reject) => {
-    sftp.chmod(path, mode, (err) => {
-      if (err) reject(err);
-      else resolve();
-    });
-  });
-}
-
-function promisifySftpReaddir(
-  sftp: SFTPWrapper,
-  path: string,
-): Promise<Array<{ filename: string; attrs: import("ssh2").Stats }>> {
-  return new Promise((resolve, reject) => {
-    sftp.readdir(path, (err, list) => {
-      if (err) reject(err);
-      else resolve(list);
-    });
-  });
 }
 
 function execCommand(
@@ -1450,41 +1390,6 @@ async function readSftpSample(
   } finally {
     await promisifySftpClose(sftp, handle).catch(() => {});
   }
-}
-
-function promisifySftpOpen(
-  sftp: SFTPWrapper,
-  path: string,
-  flags: number,
-  mode: number,
-): Promise<Buffer> {
-  return new Promise((resolve, reject) => {
-    sftp.open(path, flags, mode, (err, handle) => {
-      if (err) reject(err);
-      else resolve(handle);
-    });
-  });
-}
-
-function promisifySftpClose(sftp: SFTPWrapper, handle: Buffer): Promise<void> {
-  return new Promise((resolve, reject) => {
-    sftp.close(handle, (err) => {
-      if (err) reject(err);
-      else resolve();
-    });
-  });
-}
-
-function promisifySftpFstat(
-  sftp: SFTPWrapper,
-  handle: Buffer,
-): Promise<import("ssh2").Stats> {
-  return new Promise((resolve, reject) => {
-    sftp.fstat(handle, (err, stats) => {
-      if (err) reject(err);
-      else resolve(stats);
-    });
-  });
 }
 
 interface PipelinedXferOptions {

--- a/src/backend/hosts/file-manager/transfer-engine.ts
+++ b/src/backend/hosts/file-manager/transfer-engine.ts
@@ -36,6 +36,7 @@ import {
   computeTransferMbPerSec,
   createEmptyXferStats,
   createHopWallClock,
+  createThrottledProgress,
   elapsedMs,
   hopSpanMs,
   mergeXferStats,
@@ -330,7 +331,6 @@ const TRANSFER_SESSION_RESET_DELAYS_MS = [1000, 2000, 3000];
 const TRANSFER_HANDLE_CLOSE_TIMEOUT_MS = 2500;
 const HUNG_TRANSFER_MS = 90_000;
 const HUNG_RECONNECTING_MS = 180_000;
-const TRANSFER_PROGRESS_INTERVAL_MS = 200;
 
 interface TransferReconnectContext {
   deps: HostTransferDeps;
@@ -525,30 +525,6 @@ async function resetDedicatedTransferSessions(
   }
 
   return { sourceSession, destSession, sourceSftp, destSftp };
-}
-
-function createThrottledProgress(onProgress?: (bytes: number) => void) {
-  let pending = 0;
-  let lastFlush = 0;
-
-  const flush = () => {
-    if (pending > 0) {
-      onProgress?.(pending);
-      pending = 0;
-      lastFlush = Date.now();
-    }
-  };
-
-  return {
-    add(bytes: number) {
-      pending += bytes;
-      const now = Date.now();
-      if (now - lastFlush >= TRANSFER_PROGRESS_INTERVAL_MS) {
-        flush();
-      }
-    },
-    flush,
-  };
 }
 
 async function detectTransferPlatform(

--- a/src/backend/hosts/file-manager/transfer-engine.ts
+++ b/src/backend/hosts/file-manager/transfer-engine.ts
@@ -28,7 +28,6 @@ import {
   promisifySftpClose,
   promisifySftpFstat,
   promisifySftpOpen,
-  promisifySftpReaddir,
   promisifySftpStat,
   promisifySftpUnlink,
 } from "./sftp-promisify.js";
@@ -57,6 +56,15 @@ import {
   isRootOnlyPath,
 } from "./transfer-host-utils.js";
 import {
+  SFTP_OPEN_READ,
+  SFTP_OPEN_WRITE,
+  SFTP_OPEN_WRITE_RESUME,
+} from "./sftp-promisify.js";
+import {
+  collectFileWorkItems,
+  readSftpSample,
+  type FileWorkItem,
+} from "./transfer-scan.js";import {
   deletePathSftp,
   ensureDirectoryTreeSftp,
 } from "./transfer-sftp-dir.js";
@@ -323,11 +331,6 @@ const TRANSFER_HANDLE_CLOSE_TIMEOUT_MS = 2500;
 const HUNG_TRANSFER_MS = 90_000;
 const HUNG_RECONNECTING_MS = 180_000;
 const TRANSFER_PROGRESS_INTERVAL_MS = 200;
-const SFTP_OPEN_READ = 0x00000001;
-/** WRITE | CREATE | TRUNCATE — new file or overwrite from start. */
-const SFTP_OPEN_WRITE = 0x00000002 | 0x00000008 | 0x00000010;
-/** READ | WRITE | CREATE — resume into an existing partial file without truncating. */
-const SFTP_OPEN_WRITE_RESUME = 0x00000001 | 0x00000002 | 0x00000008;
 
 interface TransferReconnectContext {
   deps: HostTransferDeps;
@@ -1015,63 +1018,6 @@ async function ensureDestParentForFile(
   await ensureDestDirectory(deps, destSession, parent);
 }
 
-interface FileWorkItem {
-  sourcePath: string;
-  destPath: string;
-  mode: number;
-  size: number;
-}
-
-async function collectFileWorkItems(
-  sftp: SFTPWrapper,
-  sourcePath: string,
-  destRoot: string,
-  destBaseName?: string,
-): Promise<FileWorkItem[]> {
-  const stats = await promisifySftpStat(sftp, sourcePath);
-  const name = destBaseName ?? basename(sourcePath);
-  const destPath = joinPath(destRoot, name);
-
-  if (stats.isFile()) {
-    return [
-      {
-        sourcePath,
-        destPath,
-        mode: stats.mode & 0o7777,
-        size: stats.size,
-      },
-    ];
-  }
-
-  if (!stats.isDirectory()) {
-    return [];
-  }
-
-  const items: FileWorkItem[] = [];
-  const walk = async (srcDir: string, dstDir: string) => {
-    const entries = await promisifySftpReaddir(sftp, srcDir);
-    for (const entry of entries) {
-      if (entry.filename === "." || entry.filename === "..") continue;
-      const srcChild = joinPath(srcDir, entry.filename);
-      const dstChild = joinPath(dstDir, entry.filename);
-
-      if (entry.attrs.isDirectory()) {
-        await walk(srcChild, dstChild);
-      } else if (entry.attrs.isFile()) {
-        items.push({
-          sourcePath: srcChild,
-          destPath: dstChild,
-          mode: entry.attrs.mode & 0o7777,
-          size: entry.attrs.size,
-        });
-      }
-    }
-  };
-
-  await walk(sourcePath, destPath);
-  return items;
-}
-
 async function scanSourcePathsForRouting(
   sftp: SFTPWrapper,
   sourcePaths: string[],
@@ -1109,28 +1055,6 @@ async function scanSourcePathsForRouting(
       sampledIncompressibleBytes / sampledBytes;
   }
   return summary;
-}
-
-async function readSftpSample(
-  sftp: SFTPWrapper,
-  path: string,
-  fileSize: number,
-): Promise<Buffer> {
-  const sampleSize = Math.min(64 * 1024, fileSize);
-  const position = Math.max(0, Math.floor((fileSize - sampleSize) / 2));
-  const handle = await promisifySftpOpen(sftp, path, SFTP_OPEN_READ, 0o666);
-  try {
-    const buffer = Buffer.alloc(sampleSize);
-    const bytesRead = await new Promise<number>((resolve, reject) => {
-      sftp.read(handle, buffer, 0, sampleSize, position, (err, count) => {
-        if (err) reject(err);
-        else resolve(count);
-      });
-    });
-    return buffer.subarray(0, bytesRead);
-  } finally {
-    await promisifySftpClose(sftp, handle).catch(() => {});
-  }
 }
 
 interface PipelinedXferOptions {

--- a/src/backend/hosts/file-manager/transfer-errors.ts
+++ b/src/backend/hosts/file-manager/transfer-errors.ts
@@ -1,0 +1,52 @@
+export class TransferCancelledError extends Error {
+  constructor() {
+    super("Transfer cancelled");
+    this.name = "TransferCancelledError";
+  }
+}
+
+export class TransferStalledError extends Error {
+  readonly byteOffset?: number;
+  readonly segmentIndex?: number;
+
+  constructor(byteOffset?: number, segmentIndex?: number) {
+    const pos = byteOffset !== undefined ? ` at byte offset ${byteOffset}` : "";
+    const seg = segmentIndex !== undefined ? ` (segment ${segmentIndex})` : "";
+    super(`Transfer stalled — no data moved for 45 seconds${pos}${seg}`);
+    this.name = "TransferStalledError";
+    this.byteOffset = byteOffset;
+    this.segmentIndex = segmentIndex;
+  }
+}
+
+export class TransferConnectionLostError extends Error {
+  constructor(message = "Transfer SSH connection lost") {
+    super(message);
+    this.name = "TransferConnectionLostError";
+  }
+}
+
+export function isRecoverableTransferConnectionError(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  const msg = err.message.toLowerCase();
+  return (
+    msg.includes("no response from server") ||
+    msg.includes("connection lost") ||
+    msg.includes("not connected") ||
+    msg.includes("econnreset") ||
+    msg.includes("econnrefused") ||
+    msg.includes("etimedout") ||
+    msg.includes("socket hang up") ||
+    msg.includes("protocol error") ||
+    msg.includes("connection closed") ||
+    msg.includes("channel open failure")
+  );
+}
+
+export function isRecoverableTransferError(err: unknown): boolean {
+  return (
+    err instanceof TransferStalledError ||
+    err instanceof TransferConnectionLostError ||
+    isRecoverableTransferConnectionError(err)
+  );
+}

--- a/src/backend/hosts/file-manager/transfer-host-utils.ts
+++ b/src/backend/hosts/file-manager/transfer-host-utils.ts
@@ -1,0 +1,59 @@
+import { networkInterfaces } from "os";
+import { normalizeSftpPath } from "../transfer-paths.js";
+
+let cachedLocalAddresses: Set<string> | null = null;
+
+export function normalizeHostAddress(host: string): string {
+  const trimmed = host.trim().toLowerCase();
+  if (trimmed.startsWith("[") && trimmed.endsWith("]")) {
+    return trimmed.slice(1, -1);
+  }
+  return trimmed.split(":")[0] ?? trimmed;
+}
+
+function getLocalAddresses(): Set<string> {
+  if (cachedLocalAddresses) return cachedLocalAddresses;
+
+  const addresses = new Set(["127.0.0.1", "::1", "localhost"]);
+  for (const ifaces of Object.values(networkInterfaces())) {
+    if (!ifaces) continue;
+    for (const iface of ifaces) {
+      if (!iface.internal && iface.family === "IPv4") {
+        addresses.add(iface.address.toLowerCase());
+      }
+    }
+  }
+  cachedLocalAddresses = addresses;
+  return addresses;
+}
+
+export function isLocalSshEndpoint(ip?: string): boolean {
+  if (!ip) return false;
+  const bare = normalizeHostAddress(ip);
+  if (bare === "localhost" || bare === "127.0.0.1" || bare === "::1") {
+    return true;
+  }
+  return getLocalAddresses().has(bare);
+}
+
+export function escapeShell(s: string): string {
+  return s.replace(/'/g, "'\"'\"'");
+}
+
+export function isRootOnlyPath(path: string): boolean {
+  const normalized = normalizeSftpPath(path);
+  return (
+    normalized === "/" ||
+    /^\/[A-Za-z]:$/.test(normalized) ||
+    /^[A-Za-z]:$/.test(normalized)
+  );
+}
+
+export function isPermissionError(err: Error): boolean {
+  const msg = err.message.toLowerCase();
+  return (
+    msg.includes("permission denied") ||
+    msg.includes("eacces") ||
+    msg.includes("access denied")
+  );
+}

--- a/src/backend/hosts/file-manager/transfer-scan.ts
+++ b/src/backend/hosts/file-manager/transfer-scan.ts
@@ -1,0 +1,89 @@
+import { basename, joinPath } from "../transfer-paths.js";
+import {
+  SFTP_OPEN_READ,
+  promisifySftpClose,
+  promisifySftpOpen,
+  promisifySftpReaddir,
+  promisifySftpStat,
+} from "./sftp-promisify.js";
+
+type SFTPWrapper = import("ssh2").SFTPWrapper;
+
+export interface FileWorkItem {
+  sourcePath: string;
+  destPath: string;
+  mode: number;
+  size: number;
+}
+
+export async function collectFileWorkItems(
+  sftp: SFTPWrapper,
+  sourcePath: string,
+  destRoot: string,
+  destBaseName?: string,
+): Promise<FileWorkItem[]> {
+  const stats = await promisifySftpStat(sftp, sourcePath);
+  const name = destBaseName ?? basename(sourcePath);
+  const destPath = joinPath(destRoot, name);
+
+  if (stats.isFile()) {
+    return [
+      {
+        sourcePath,
+        destPath,
+        mode: stats.mode & 0o7777,
+        size: stats.size,
+      },
+    ];
+  }
+
+  if (!stats.isDirectory()) {
+    return [];
+  }
+
+  const items: FileWorkItem[] = [];
+  const walk = async (srcDir: string, dstDir: string) => {
+    const entries = await promisifySftpReaddir(sftp, srcDir);
+    for (const entry of entries) {
+      if (entry.filename === "." || entry.filename === "..") continue;
+      const srcChild = joinPath(srcDir, entry.filename);
+      const dstChild = joinPath(dstDir, entry.filename);
+
+      if (entry.attrs.isDirectory()) {
+        await walk(srcChild, dstChild);
+      } else if (entry.attrs.isFile()) {
+        items.push({
+          sourcePath: srcChild,
+          destPath: dstChild,
+          mode: entry.attrs.mode & 0o7777,
+          size: entry.attrs.size,
+        });
+      }
+    }
+  };
+
+  await walk(sourcePath, destPath);
+  return items;
+}
+
+export async function readSftpSample(
+  sftp: SFTPWrapper,
+  path: string,
+  fileSize: number,
+): Promise<Buffer> {
+  const sampleSize = Math.min(64 * 1024, fileSize);
+  const position = Math.max(0, Math.floor((fileSize - sampleSize) / 2));
+  const handle = await promisifySftpOpen(sftp, path, SFTP_OPEN_READ, 0o666);
+  try {
+    const buffer = Buffer.alloc(sampleSize);
+    const bytesRead = await new Promise<number>((resolve, reject) => {
+      sftp.read(handle, buffer, 0, sampleSize, position, (err, count) => {
+        if (err) reject(err);
+        else resolve(count);
+      });
+    });
+    return buffer.subarray(0, bytesRead);
+  } finally {
+    await promisifySftpClose(sftp, handle).catch(() => {});
+  }
+}

--- a/src/backend/hosts/file-manager/transfer-segment-copy.ts
+++ b/src/backend/hosts/file-manager/transfer-segment-copy.ts
@@ -1,0 +1,40 @@
+export const SFTP_XFER_SEGMENT_SIZE = 256 * 1024 * 1024;
+export const DEFAULT_PARALLEL_SEGMENT_COUNT = 2;
+export const MAX_PARALLEL_SEGMENT_COUNT = 8;
+
+export interface SegmentCopyJob {
+  offset: number;
+  length: number;
+  segmentIndex: number;
+}
+
+export function clampParallelSegmentCount(value?: number): number {
+  const n = value ?? DEFAULT_PARALLEL_SEGMENT_COUNT;
+  return Math.max(1, Math.min(MAX_PARALLEL_SEGMENT_COUNT, Math.floor(n)));
+}
+
+export function buildSegmentCopyJobs(
+  fileSize: number,
+  initialOffset: number,
+  destResumeSize: number,
+): SegmentCopyJob[] {
+  const jobs: SegmentCopyJob[] = [];
+  for (
+    let offset = initialOffset;
+    offset < fileSize;
+    offset += SFTP_XFER_SEGMENT_SIZE
+  ) {
+    const length = Math.min(SFTP_XFER_SEGMENT_SIZE, fileSize - offset);
+    const segmentIndex = Math.floor(offset / SFTP_XFER_SEGMENT_SIZE);
+    if (destResumeSize >= offset + length) {
+      continue;
+    }
+    const start = destResumeSize > offset ? destResumeSize : offset;
+    jobs.push({
+      offset: start,
+      length: offset + length - start,
+      segmentIndex,
+    });
+  }
+  return jobs;
+}

--- a/src/backend/hosts/file-manager/transfer-sftp-dir.ts
+++ b/src/backend/hosts/file-manager/transfer-sftp-dir.ts
@@ -1,0 +1,71 @@
+import {
+  buildPathFromSegments,
+  joinPath,
+  normalizeSftpPath,
+  splitPathSegments,
+} from "../transfer-paths.js";
+import { isRootOnlyPath } from "./transfer-host-utils.js";
+import {
+  promisifySftpMkdir,
+  promisifySftpReaddir,
+  promisifySftpRmdir,
+  promisifySftpStat,
+  promisifySftpUnlink,
+} from "./sftp-promisify.js";
+
+type SFTPWrapper = import("ssh2").SFTPWrapper;
+
+export async function ensureDirectoryTreeSftp(
+  sftp: SFTPWrapper,
+  dirPath: string,
+  created: Set<string> = new Set(),
+): Promise<void> {
+  const normalized = normalizeSftpPath(dirPath);
+  if (!normalized || isRootOnlyPath(normalized)) return;
+
+  const { root, segments } = splitPathSegments(normalized);
+  if (segments.length === 0) return;
+
+  for (let i = 0; i < segments.length; i++) {
+    const current = buildPathFromSegments(root, segments, i + 1);
+    if (created.has(current)) continue;
+
+    try {
+      await promisifySftpMkdir(sftp, current, 0o755);
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code !== "EEXIST") {
+        try {
+          const stats = await promisifySftpStat(sftp, current);
+          if (!stats.isDirectory()) throw err;
+        } catch {
+          throw err;
+        }
+      }
+    }
+    created.add(current);
+  }
+}
+
+export async function deletePathSftp(sftp: SFTPWrapper, path: string): Promise<void> {
+  let stats: import("ssh2").Stats;
+  try {
+    stats = await promisifySftpStat(sftp, path);
+  } catch {
+    return;
+  }
+
+  if (stats.isDirectory()) {
+    const entries = await promisifySftpReaddir(sftp, path);
+    for (const entry of entries) {
+      if (entry.filename === "." || entry.filename === "..") continue;
+      await deletePathSftp(sftp, joinPath(path, entry.filename));
+    }
+    await promisifySftpRmdir(sftp, path);
+    return;
+  }
+
+  if (stats.isFile()) {
+    await promisifySftpUnlink(sftp, path);
+  }
+}

--- a/src/backend/hosts/file-manager/transfer-sftp-dir.ts
+++ b/src/backend/hosts/file-manager/transfer-sftp-dir.ts
@@ -47,7 +47,10 @@ export async function ensureDirectoryTreeSftp(
   }
 }
 
-export async function deletePathSftp(sftp: SFTPWrapper, path: string): Promise<void> {
+export async function deletePathSftp(
+  sftp: SFTPWrapper,
+  path: string,
+): Promise<void> {
   let stats: import("ssh2").Stats;
   try {
     stats = await promisifySftpStat(sftp, path);

--- a/src/backend/hosts/file-manager/transfer-stats.ts
+++ b/src/backend/hosts/file-manager/transfer-stats.ts
@@ -1,0 +1,128 @@
+import { performance } from "node:perf_hooks";
+
+export type TransferHopId =
+  "source_read" | "dest_sftp_write" | "dest_local_write";
+
+export interface TransferHopMetrics {
+  id: TransferHopId;
+  bytes: number;
+  /** Wall-clock span from first I/O on this hop to last I/O complete. */
+  spanMs: number;
+  mbPerSec: number;
+}
+
+export interface TransferTimings {
+  prepareDestMs?: number;
+  compressMs?: number;
+  transferMs?: number;
+  extractMs?: number;
+  verifyMs?: number;
+  directBenchmarkMs?: number;
+  relayBenchmarkMs?: number;
+  sourceDeleteMs?: number;
+  totalMs?: number;
+  transferBytes?: number;
+  endToEndMbPerSec?: number;
+  hops?: TransferHopMetrics[];
+}
+
+export function elapsedMs(start: number): number {
+  return Date.now() - start;
+}
+
+export function computeTransferMbPerSec(
+  bytes: number,
+  ms: number,
+): number | undefined {
+  if (ms <= 0 || bytes <= 0) return undefined;
+  return ((bytes / ms) * 1000) / (1024 * 1024);
+}
+
+export interface HopWallClock {
+  firstAt: number | null;
+  lastAt: number | null;
+}
+
+export function createHopWallClock(): HopWallClock {
+  return { firstAt: null, lastAt: null };
+}
+
+export function noteHopStart(
+  clock: HopWallClock,
+  t: number = performance.now(),
+): void {
+  if (clock.firstAt === null) clock.firstAt = t;
+}
+
+export function noteHopEnd(clock: HopWallClock, t: number = performance.now()): void {
+  clock.lastAt = t;
+}
+
+export function hopSpanMs(clock: HopWallClock): number {
+  if (clock.firstAt === null || clock.lastAt === null) return 0;
+  return Math.max(0, clock.lastAt - clock.firstAt);
+}
+
+export interface PipelinedXferStats {
+  bytes: number;
+  sourceReadSpanMs: number;
+  destWriteSpanMs: number;
+  destWriteKind: "sftp" | "local";
+}
+
+export function createEmptyXferStats(): PipelinedXferStats {
+  return {
+    bytes: 0,
+    sourceReadSpanMs: 0,
+    destWriteSpanMs: 0,
+    destWriteKind: "sftp",
+  };
+}
+
+export function mergeXferStats(
+  target: PipelinedXferStats,
+  source: PipelinedXferStats,
+): void {
+  target.bytes += source.bytes;
+  target.sourceReadSpanMs += source.sourceReadSpanMs;
+  target.destWriteSpanMs += source.destWriteSpanMs;
+  target.destWriteKind = source.destWriteKind;
+}
+
+export function buildTransferHopTimings(
+  stats: PipelinedXferStats,
+  transferMs: number,
+): Pick<TransferTimings, "transferBytes" | "endToEndMbPerSec" | "hops"> {
+  const hops: TransferHopMetrics[] = [];
+
+  const sourceRate = computeTransferMbPerSec(
+    stats.bytes,
+    stats.sourceReadSpanMs,
+  );
+  if (sourceRate !== undefined) {
+    hops.push({
+      id: "source_read",
+      bytes: stats.bytes,
+      spanMs: stats.sourceReadSpanMs,
+      mbPerSec: sourceRate,
+    });
+  }
+
+  const destHopId: TransferHopId =
+    stats.destWriteKind === "local" ? "dest_local_write" : "dest_sftp_write";
+  const destRate = computeTransferMbPerSec(stats.bytes, stats.destWriteSpanMs);
+  if (destRate !== undefined) {
+    hops.push({
+      id: destHopId,
+      bytes: stats.bytes,
+      spanMs: stats.destWriteSpanMs,
+      mbPerSec: destRate,
+    });
+  }
+
+  return {
+    transferBytes: stats.bytes,
+    endToEndMbPerSec: computeTransferMbPerSec(stats.bytes, transferMs),
+    hops,
+  };
+}

--- a/src/backend/hosts/file-manager/transfer-stats.ts
+++ b/src/backend/hosts/file-manager/transfer-stats.ts
@@ -1,5 +1,7 @@
 import { performance } from "node:perf_hooks";
 
+const TRANSFER_PROGRESS_INTERVAL_MS = 200;
+
 export type TransferHopId =
   "source_read" | "dest_sftp_write" | "dest_local_write";
 
@@ -61,6 +63,32 @@ export function noteHopEnd(clock: HopWallClock, t: number = performance.now()): 
 export function hopSpanMs(clock: HopWallClock): number {
   if (clock.firstAt === null || clock.lastAt === null) return 0;
   return Math.max(0, clock.lastAt - clock.firstAt);
+}
+
+export function createThrottledProgress(
+  onProgress?: (bytes: number) => void,
+) {
+  let pending = 0;
+  let lastFlush = 0;
+
+  const flush = () => {
+    if (pending > 0) {
+      onProgress?.(pending);
+      pending = 0;
+      lastFlush = Date.now();
+    }
+  };
+
+  return {
+    add(bytes: number) {
+      pending += bytes;
+      const now = Date.now();
+      if (now - lastFlush >= TRANSFER_PROGRESS_INTERVAL_MS) {
+        flush();
+      }
+    },
+    flush,
+  };
 }
 
 export interface PipelinedXferStats {

--- a/src/backend/hosts/file-manager/transfer-stats.ts
+++ b/src/backend/hosts/file-manager/transfer-stats.ts
@@ -56,7 +56,10 @@ export function noteHopStart(
   if (clock.firstAt === null) clock.firstAt = t;
 }
 
-export function noteHopEnd(clock: HopWallClock, t: number = performance.now()): void {
+export function noteHopEnd(
+  clock: HopWallClock,
+  t: number = performance.now(),
+): void {
   clock.lastAt = t;
 }
 
@@ -65,9 +68,7 @@ export function hopSpanMs(clock: HopWallClock): number {
   return Math.max(0, clock.lastAt - clock.firstAt);
 }
 
-export function createThrottledProgress(
-  onProgress?: (bytes: number) => void,
-) {
+export function createThrottledProgress(onProgress?: (bytes: number) => void) {
   let pending = 0;
   let lastFlush = 0;
 


### PR DESCRIPTION
Refactors transfer-engine.ts (4018 -> 3527 lines) by extracting cohesive, low-coupling code into focused modules, with no behavior change.

## Modules added
- `sftp-promisify.ts` — SFTP callback->promise wrappers + open-flag constants
- `transfer-stats.ts` — timing/throughput/stats + throttled progress
- `transfer-errors.ts` — transfer error classes + recoverable-error checks
- `transfer-host-utils.ts` — host/path helpers (normalize, local-endpoint, escape, root/permission checks)
- `transfer-sftp-dir.ts` — SFTP directory tree create/delete
- `transfer-segment-copy.ts` — segment copy job construction + segment constants
- `transfer-scan.ts` — file work-item collection and sampling

Each extract is a pure move (no logic change), verified independently:
- `tsc -p tsconfig.node.json` passes
- `eslint` passes (dropping now-orphaned imports)
- backend vitest suite: 1646 tests pass

The remaining engine code (copy pipeline, direct transfer, orchestration) stays put — it is tightly coupled to engine-global transfer/session state, so moving it out would add circular imports or require a larger type-layer refactor. That is deliberately left out of scope.