### PR TITLE
perf: optimize tmux monitor aggregation

### DIFF
--- a/src/backend/hosts/tmux/monitor-helpers.ts
+++ b/src/backend/hosts/tmux/monitor-helpers.ts
@@ -177,8 +177,8 @@ export function buildPaneMetrics(
     const treePids: number[] = [];
     const queue = [pane.pid];
     const seen = new Set<number>();
-    while (queue.length > 0) {
-      const pid = queue.shift()!;
+    for (let cursor = 0; cursor < queue.length; cursor++) {
+      const pid = queue[cursor];
       if (seen.has(pid)) continue;
       seen.add(pid);
       if (byPid.has(pid)) treePids.push(pid);
@@ -225,9 +225,19 @@ export function attachPanesToWindows(
   windows: Map<string, TmuxWindow[]>,
   panes: RawPane[],
 ): void {
+  const windowsBySessionAndIndex = new Map<string, Map<number, TmuxWindow>>();
+  for (const [sessionName, sessionWindows] of windows) {
+    const byIndex = new Map<number, TmuxWindow>();
+    for (const window of sessionWindows) {
+      if (!byIndex.has(window.index)) byIndex.set(window.index, window);
+    }
+    windowsBySessionAndIndex.set(sessionName, byIndex);
+  }
+
   for (const pane of panes) {
-    const sessionWindows = windows.get(pane.sessionName) || [];
-    const window = sessionWindows.find((w) => w.index === pane.windowIndex);
+    const window = windowsBySessionAndIndex
+      .get(pane.sessionName)
+      ?.get(pane.windowIndex);
     if (window) {
       const { sessionName: _s, windowIndex: _w, ...paneFields } = pane;
       window.panes.push(paneFields);

--- a/src/backend/tests/hosts/tmux/monitor-helpers.test.ts
+++ b/src/backend/tests/hosts/tmux/monitor-helpers.test.ts
@@ -9,6 +9,8 @@ import {
   buildPaneMetrics,
   attachPanesToWindows,
   shellEscape,
+  type ProcessInfo,
+  type TmuxWindow,
 } from "../../../hosts/tmux/monitor-helpers.js";
 
 function join(...fields: (string | number)[]): string {
@@ -194,6 +196,28 @@ describe("buildPaneMetrics", () => {
     const metrics = buildPaneMetrics(pane, cyclic, new Map());
     expect(metrics[0].processCount).toBe(2);
   });
+
+  it("aggregates a wide process tree without dropping children", () => {
+    const childCount = 2_000;
+    const wideTree: ProcessInfo[] = [
+      { pid: 1, ppid: 0, cpu: 0, mem: 0, rss: 1, comm: "bash" },
+      ...Array.from({ length: childCount }, (_, index) => ({
+        pid: index + 2,
+        ppid: 1,
+        cpu: 0.1,
+        mem: 0,
+        rss: 1,
+        comm: `worker-${index}`,
+      })),
+    ];
+    const pane = parsePanes(
+      join("wide", 0, "%1", 0, 1, 1, 80, 24, "bash", "/", "t"),
+    );
+
+    const [metrics] = buildPaneMetrics(pane, wideTree, new Map());
+    expect(metrics.processCount).toBe(childCount + 1);
+    expect(metrics.memRssKb).toBe(childCount + 1);
+  });
 });
 
 describe("attachPanesToWindows", () => {
@@ -213,6 +237,29 @@ describe("attachPanesToWindows", () => {
     expect(windows.get("s1")![0].panes).toHaveLength(1);
     expect(windows.get("s1")![0].panes[0].id).toBe("%1");
     expect(windows.get("s1")![1].panes[0].id).toBe("%2");
+  });
+
+  it("preserves first-match behavior for duplicate window indexes", () => {
+    const first: TmuxWindow = {
+      index: 0,
+      name: "first",
+      active: true,
+      panes: [],
+    };
+    const duplicate: TmuxWindow = {
+      index: 0,
+      name: "duplicate",
+      active: false,
+      panes: [],
+    };
+    const windows = new Map([["s1", [first, duplicate]]]);
+    const panes = parsePanes(
+      join("s1", 0, "%1", 0, 100, 1, 80, 24, "bash", "/", "t"),
+    );
+
+    attachPanesToWindows(windows, panes);
+    expect(first.panes).toHaveLength(1);
+    expect(duplicate.panes).toHaveLength(0);
   });
 });
 


### PR DESCRIPTION
Optimize two tmux monitor hot paths by replacing array shifting with a cursor queue and indexing windows before pane attachment.

The change preserves existing behavior, adds regression coverage for wide process trees and duplicate window indexes, and passes type-check, lint, Prettier, and all 2,548 tests.