### PR TITLE
fix: prevent sidebar tag rows from overlapping

### DIFF
--- a/src/ui/sidebar/credential-tree/CredentialSidebarTree.tsx
+++ b/src/ui/sidebar/credential-tree/CredentialSidebarTree.tsx
@@ -18,6 +18,7 @@ import type {
   CredentialTrayTrigger,
 } from "@/types/credential-sidebar-preferences";
 import { CredentialItem } from "./CredentialItem/CredentialItem";
+import { getCredentialRowHeight } from "./credential-row-height";
 import { CredentialFolderItem } from "./FolderItem/CredentialFolderItem";
 import {
   isFolder,
@@ -130,8 +131,6 @@ export function CredentialSidebarTree({
     !alwaysShowActions &&
     !actionsOnly &&
     (trayTrigger === "click" || isTouchOnly);
-  const isCompactDensity = density === "compact";
-
   const visibleRows = collectVisibleRows(folders, query, openFolders);
 
   // Fixed, exactly-computed row heights rather than estimate-then-measure,
@@ -146,53 +145,25 @@ export function CredentialSidebarTree({
   // buttons at all, so a password row is shorter than a key row whenever
   // that row is showing (actionsOnly closed, or always mode).
   const FOLDER_ROW_HEIGHT = 31.5;
-  // Base closed height with no persistent extras (hover/click modes,
-  // collapsed) -- identical for both credential types since neither the
-  // connection row nor the management row is rendered. Re-measured live
-  // after fixing the comfortable-density row's top/bottom padding asymmetry
-  // (was pt-2.5 pb-2, now the symmetric py-2, 2px shorter).
-  const BASE_ROW_HEIGHT = isCompactDensity ? 23 : 45;
-  // Fully opened (management row revealed, plus connection row for key
-  // creds) -- differs by type since only key creds have a connection row;
-  // measured identical for click-mode-open and actionsOnly-mode-open.
-  const OPEN_KEY_ROW_HEIGHT = isCompactDensity ? 79.25 : 104.75;
-  const OPEN_PASSWORD_ROW_HEIGHT = isCompactDensity ? 56.5 : 78.5;
-  // actionsOnly closed (connection row shown permanently, management row
-  // still collapsed) -- differs by type since only key creds have a
-  // connection row to show.
-  const ACTIONS_ONLY_KEY_ROW_HEIGHT = isCompactDensity ? 50.25 : 75.75;
-  const ACTIONS_ONLY_PASSWORD_ROW_HEIGHT = isCompactDensity ? 27.5 : 49.5;
-  // always mode (both rows permanently shown) -- measured slightly shorter
-  // than a click-opened row since the chevron toggle button isn't rendered.
-  const ALWAYS_KEY_ROW_HEIGHT = isCompactDensity ? 74.75 : 100.25;
-  const ALWAYS_PASSWORD_ROW_HEIGHT = isCompactDensity ? 52 : 74;
-
   const rowHeight = useCallback(
     (index: number) => {
       const row = visibleRows[index];
       if (!row) return FOLDER_ROW_HEIGHT;
       if (isFolder(row.item)) return FOLDER_ROW_HEIGHT;
       const isKey = row.item.type === "key";
-
-      if (alwaysShowActions) {
-        return isKey ? ALWAYS_KEY_ROW_HEIGHT : ALWAYS_PASSWORD_ROW_HEIGHT;
-      }
-
       const isOpen =
         (openTrayCredentialId === row.item.id ||
           openMenuCredentialId === row.item.id) &&
         (clickTrayActive || actionsOnly);
-
-      if (actionsOnly) {
-        if (isOpen)
-          return isKey ? OPEN_KEY_ROW_HEIGHT : OPEN_PASSWORD_ROW_HEIGHT;
-        return isKey
-          ? ACTIONS_ONLY_KEY_ROW_HEIGHT
-          : ACTIONS_ONLY_PASSWORD_ROW_HEIGHT;
-      }
-
-      if (isOpen) return isKey ? OPEN_KEY_ROW_HEIGHT : OPEN_PASSWORD_ROW_HEIGHT;
-      return BASE_ROW_HEIGHT;
+      return getCredentialRowHeight({
+        density,
+        isKey,
+        alwaysShowActions,
+        actionsOnly,
+        isOpen,
+        showTags,
+        tagCount: row.item.tags?.length ?? 0,
+      });
     },
     [
       visibleRows,
@@ -201,13 +172,8 @@ export function CredentialSidebarTree({
       clickTrayActive,
       alwaysShowActions,
       actionsOnly,
-      BASE_ROW_HEIGHT,
-      OPEN_KEY_ROW_HEIGHT,
-      OPEN_PASSWORD_ROW_HEIGHT,
-      ACTIONS_ONLY_KEY_ROW_HEIGHT,
-      ACTIONS_ONLY_PASSWORD_ROW_HEIGHT,
-      ALWAYS_KEY_ROW_HEIGHT,
-      ALWAYS_PASSWORD_ROW_HEIGHT,
+      density,
+      showTags,
     ],
   );
 
@@ -254,6 +220,7 @@ export function CredentialSidebarTree({
     visibleRows.length,
     density,
     trayTrigger,
+    showTags,
   ]);
 
   function toggleFolder(name: string) {

--- a/src/ui/sidebar/credential-tree/credential-row-height.ts
+++ b/src/ui/sidebar/credential-tree/credential-row-height.ts
@@ -1,0 +1,55 @@
+import type { CredentialDensity } from "@/types/credential-sidebar-preferences";
+
+const HEIGHTS = {
+  comfortable: {
+    base: 45,
+    openKey: 104.75,
+    openPassword: 78.5,
+    actionsOnlyKey: 75.75,
+    actionsOnlyPassword: 49.5,
+    alwaysKey: 100.25,
+    alwaysPassword: 74,
+    tags: 18.5,
+  },
+  compact: {
+    base: 23,
+    openKey: 79.25,
+    openPassword: 56.5,
+    actionsOnlyKey: 50.25,
+    actionsOnlyPassword: 27.5,
+    alwaysKey: 74.75,
+    alwaysPassword: 52,
+    tags: 12.5,
+  },
+} as const;
+
+export function getCredentialRowHeight({
+  density,
+  isKey,
+  alwaysShowActions,
+  actionsOnly,
+  isOpen,
+  showTags,
+  tagCount,
+}: {
+  density: CredentialDensity;
+  isKey: boolean;
+  alwaysShowActions: boolean;
+  actionsOnly: boolean;
+  isOpen: boolean;
+  showTags: boolean;
+  tagCount: number;
+}): number {
+  const heights = HEIGHTS[density];
+  let height: number = heights.base;
+
+  if (alwaysShowActions) {
+    height = isKey ? heights.alwaysKey : heights.alwaysPassword;
+  } else if (isOpen) {
+    height = isKey ? heights.openKey : heights.openPassword;
+  } else if (actionsOnly) {
+    height = isKey ? heights.actionsOnlyKey : heights.actionsOnlyPassword;
+  }
+
+  return height + (showTags && tagCount > 0 ? heights.tags : 0);
+}

--- a/src/ui/tests/sidebar/credential-tree/credential-row-height.test.ts
+++ b/src/ui/tests/sidebar/credential-tree/credential-row-height.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { getCredentialRowHeight } from "@/sidebar/credential-tree/credential-row-height";
+
+const shapes = [
+  { alwaysShowActions: false, actionsOnly: false, isOpen: false },
+  { alwaysShowActions: false, actionsOnly: false, isOpen: true },
+  { alwaysShowActions: false, actionsOnly: true, isOpen: false },
+  { alwaysShowActions: true, actionsOnly: false, isOpen: false },
+];
+
+describe("getCredentialRowHeight", () => {
+  it.each([
+    ["comfortable", 18.5],
+    ["compact", 12.5],
+  ] as const)(
+    "reserves the %s tag row for every row shape",
+    (density, extra) => {
+      for (const shape of shapes) {
+        for (const isKey of [false, true]) {
+          const base = getCredentialRowHeight({
+            density,
+            isKey,
+            ...shape,
+            showTags: false,
+            tagCount: 1,
+          });
+          const tagged = getCredentialRowHeight({
+            density,
+            isKey,
+            ...shape,
+            showTags: true,
+            tagCount: 1,
+          });
+          expect(tagged - base).toBe(extra);
+        }
+      }
+    },
+  );
+
+  it("does not reserve space when tags are hidden or absent", () => {
+    const base = getCredentialRowHeight({
+      density: "comfortable",
+      isKey: true,
+      ...shapes[0],
+      showTags: false,
+      tagCount: 0,
+    });
+    expect(
+      getCredentialRowHeight({
+        density: "comfortable",
+        isKey: true,
+        ...shapes[0],
+        showTags: true,
+        tagCount: 0,
+      }),
+    ).toBe(base);
+  });
+});


### PR DESCRIPTION
Reserve tag-pill space in every virtualized credential row shape, matching the existing host-row fix across comfortable and compact density modes.

The row-height calculation is now isolated and regression-tested for password/key credentials and closed, open, actions-only, and always-visible actions; type-check, lint, build, and 38 related tests pass.