### PR TITLE
fix: allow HTTPS to share the configured port

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -68,6 +68,11 @@ fi
 mkdir -p /tmp/nginx
 envsubst '${PORT} ${SSL_PORT} ${SSL_CERT_PATH} ${SSL_KEY_PATH}' < $NGINX_CONF_SOURCE > /tmp/nginx/nginx.conf
 
+if [ "$ENABLE_SSL" = "true" ] && [ "$PORT" = "$SSL_PORT" ]; then
+    echo "HTTP and HTTPS use port $SSL_PORT; disabling the HTTP redirect listener"
+    sed -i '/# BEGIN HTTP_REDIRECT_SERVER/,/# END HTTP_REDIRECT_SERVER/d' /tmp/nginx/nginx.conf
+fi
+
 mkdir -p /app/data /app/uploads /app/data/.opk /app/data/acme-webroot/.well-known/acme-challenge
 chmod 755 /app/data /app/uploads /app/data/.opk 2>/dev/null || true
 

--- a/docker/nginx-https.conf
+++ b/docker/nginx-https.conf
@@ -69,12 +69,14 @@ http {
     ssl_session_cache shared:SSL:10m;
     ssl_session_timeout 10m;
 
+    # BEGIN HTTP_REDIRECT_SERVER
     server {
         listen ${PORT};
         server_name _;
 
         return 301 https://$host:${SSL_PORT}$request_uri;
     }
+    # END HTTP_REDIRECT_SERVER
 
     server {
         listen ${SSL_PORT} ssl;


### PR DESCRIPTION
When `PORT` and `SSL_PORT` are identical, remove the separate HTTP redirect server so nginx has exactly one listener on that address and it owns the configured certificate. This restores persisted `.env` SSL setups that expose only port 8443.

Fixes Termix-SSH/Support#1182