### PR TITLE
fix: resolve synced jump hosts on the server

### DIFF
--- a/src/backend/hosts/terminal/host-identity.ts
+++ b/src/backend/hosts/terminal/host-identity.ts
@@ -55,6 +55,15 @@ export const HOST_NOT_ON_THIS_SERVER_MESSAGE =
   "This host does not exist on the sync server, so the connection was refused. " +
   'Run a sync so the server knows about it, or set the connection origin to "This device" for this host.';
 
+export function resolveServerJumpHosts(
+  clientJumpHosts: Array<{ hostId: number }> | undefined,
+  serverJumpHosts: Array<{ hostId: number }> | undefined,
+  hostSyncId?: string | null,
+): Array<{ hostId: number }> | undefined {
+  if (hostSyncId) return serverJumpHosts ?? [];
+  return clientJumpHosts?.length ? clientJumpHosts : serverJumpHosts;
+}
+
 /**
  * Thrown where a mismatch is reported by rejecting rather than by messaging
  * the socket. Callers whose host-resolution is wrapped in a "failed to resolve

--- a/src/backend/hosts/terminal/index.ts
+++ b/src/backend/hosts/terminal/index.ts
@@ -54,6 +54,7 @@ import {
   hostAddressMismatch,
   HOST_ADDRESS_MISMATCH_MESSAGE,
   HOST_NOT_ON_THIS_SERVER_MESSAGE,
+  resolveServerJumpHosts,
 } from "./host-identity.js";
 
 interface ConnectToHostData {
@@ -1542,16 +1543,17 @@ wss.on("connection", async (ws: WebSocket, req) => {
         }
 
         if (resolvedHostData) {
-          if (
-            (!hostConfig.jumpHosts || hostConfig.jumpHosts.length === 0) &&
-            resolvedHostData.jumpHosts &&
-            resolvedHostData.jumpHosts.length > 0
-          ) {
-            hostConfig.jumpHosts = resolvedHostData.jumpHosts;
+          const resolvedJumpHosts = resolveServerJumpHosts(
+            hostConfig.jumpHosts,
+            resolvedHostData.jumpHosts,
+            hostSyncId,
+          );
+          if (resolvedJumpHosts !== hostConfig.jumpHosts) {
+            hostConfig.jumpHosts = resolvedJumpHosts;
             sendLog(
               "jump",
               "info",
-              `Loaded ${resolvedHostData.jumpHosts.length} jump host(s) from server-side host data`,
+              `Loaded ${resolvedJumpHosts?.length ?? 0} jump host(s) from server-side host data`,
             );
           }
 

--- a/src/backend/tests/hosts/terminal/host-identity.test.ts
+++ b/src/backend/tests/hosts/terminal/host-identity.test.ts
@@ -6,6 +6,7 @@ import {
   HostAddressMismatchError,
   HostNotOnThisServerError,
   normalizeHostAddress,
+  resolveServerJumpHosts,
 } from "../../../hosts/terminal/host-identity.js";
 
 /**
@@ -56,6 +57,20 @@ describe("hostAddressMismatch", () => {
     // An id alone must not be enough to pick a machine.
     expect(hostAddressMismatch(undefined, "10.0.0.9")).toBe(true);
     expect(hostAddressMismatch("", "10.0.0.9")).toBe(true);
+  });
+});
+
+describe("resolveServerJumpHosts", () => {
+  it("uses server-side ids for a sync-delegated connection", () => {
+    expect(
+      resolveServerJumpHosts([{ hostId: 7 }], [{ hostId: 42 }], "host-sync-id"),
+    ).toEqual([{ hostId: 42 }]);
+  });
+
+  it("keeps client ids for a local id-based connection", () => {
+    expect(resolveServerJumpHosts([{ hostId: 7 }], [{ hostId: 42 }])).toEqual([
+      { hostId: 7 },
+    ]);
   });
 });
 


### PR DESCRIPTION
For sync-delegated terminal connections, replace client-local jump-host row IDs with the IDs stored on the server-side host resolved by `syncId`. Local id-based connections keep their existing behavior, and regression coverage verifies both paths.

Fixes Termix-SSH/Support#1180