### PR TITLE
fix: make terminal clipboard shortcuts layout independent

### DIFF
--- a/src/ui/features/terminal/Terminal.tsx
+++ b/src/ui/features/terminal/Terminal.tsx
@@ -80,7 +80,7 @@ import {
   getNextTerminalFontSize,
   getTerminalFontZoomDirection,
 } from "./terminal-font-zoom.ts";
-import { isTabKeyEvent } from "./terminal-key-event.ts";
+import { isPhysicalShortcutKey, isTabKeyEvent } from "./terminal-key-event.ts";
 import { installTouchWheelCoordinator } from "./touch-wheel-coordinator.ts";
 import { loadTouchInputSettings } from "./touch-input-settings-store.ts";
 import { quoteTerminalImagePath } from "./terminal-image-path.ts";
@@ -2869,7 +2869,7 @@ const TerminalInner = forwardRef<TerminalHandle, SSHTerminalProps>(
           !e.shiftKey &&
           !e.altKey &&
           !e.metaKey &&
-          e.key.toLowerCase() === "c" &&
+          isPhysicalShortcutKey(e, "KeyC", "c") &&
           terminal.hasSelection()
         ) {
           const selection = terminal.getSelection();
@@ -2883,13 +2883,16 @@ const TerminalInner = forwardRef<TerminalHandle, SSHTerminalProps>(
         }
 
         if (
-          ((e.metaKey && !e.shiftKey && !e.ctrlKey && !e.altKey) ||
-            (e.ctrlKey &&
-              !e.shiftKey &&
-              !e.altKey &&
-              !e.metaKey &&
-              e.key === "Insert")) &&
-          (e.key.toLowerCase() === "c" || e.key === "Insert")
+          (e.metaKey &&
+            !e.shiftKey &&
+            !e.ctrlKey &&
+            !e.altKey &&
+            isPhysicalShortcutKey(e, "KeyC", "c")) ||
+          (e.ctrlKey &&
+            !e.shiftKey &&
+            !e.altKey &&
+            !e.metaKey &&
+            e.key === "Insert")
         ) {
           const selection = terminal.getSelection();
           if (selection) {
@@ -2905,7 +2908,7 @@ const TerminalInner = forwardRef<TerminalHandle, SSHTerminalProps>(
           e.shiftKey &&
           !e.altKey &&
           !e.metaKey &&
-          e.key.toLowerCase() === "c"
+          isPhysicalShortcutKey(e, "KeyC", "c")
         ) {
           const selection = terminal.getSelection();
           if (selection) {
@@ -2922,7 +2925,7 @@ const TerminalInner = forwardRef<TerminalHandle, SSHTerminalProps>(
           e.shiftKey &&
           !e.altKey &&
           !e.metaKey &&
-          e.key.toLowerCase() === "v"
+          isPhysicalShortcutKey(e, "KeyV", "v")
         ) {
           e.preventDefault();
           e.stopPropagation();
@@ -2937,7 +2940,7 @@ const TerminalInner = forwardRef<TerminalHandle, SSHTerminalProps>(
           !e.shiftKey &&
           !e.altKey &&
           !e.metaKey &&
-          e.key.toLowerCase() === "v"
+          isPhysicalShortcutKey(e, "KeyV", "v")
         ) {
           // Let the browser handle Ctrl+V natively, the paste event
           // listener will intercept the result without triggering the

--- a/src/ui/features/terminal/terminal-key-event.ts
+++ b/src/ui/features/terminal/terminal-key-event.ts
@@ -1,3 +1,13 @@
 export function isTabKeyEvent(event: KeyboardEvent): boolean {
   return event.key === "Tab" || event.code === "Tab" || event.keyCode === 9;
 }
+
+export function isPhysicalShortcutKey(
+  event: Pick<KeyboardEvent, "code" | "key">,
+  code: string,
+  fallbackKey: string,
+): boolean {
+  return event.code
+    ? event.code === code
+    : event.key.toLowerCase() === fallbackKey;
+}

--- a/src/ui/tests/features/terminal/terminal-key-event.test.ts
+++ b/src/ui/tests/features/terminal/terminal-key-event.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { isTabKeyEvent } from "@/features/terminal/terminal-key-event";
+import {
+  isPhysicalShortcutKey,
+  isTabKeyEvent,
+} from "@/features/terminal/terminal-key-event";
 
 describe("isTabKeyEvent", () => {
   it.each([
@@ -16,6 +19,29 @@ describe("isTabKeyEvent", () => {
   it("does not treat another key as Tab", () => {
     expect(isTabKeyEvent(new KeyboardEvent("keydown", { key: "Enter" }))).toBe(
       false,
+    );
+  });
+});
+
+describe("isPhysicalShortcutKey", () => {
+  it("matches copy and paste by physical code under a Cyrillic layout", () => {
+    expect(isPhysicalShortcutKey({ key: "с", code: "KeyC" }, "KeyC", "c")).toBe(
+      true,
+    );
+    expect(isPhysicalShortcutKey({ key: "м", code: "KeyV" }, "KeyV", "v")).toBe(
+      true,
+    );
+  });
+
+  it("does not confuse another physical key with a translated character", () => {
+    expect(isPhysicalShortcutKey({ key: "c", code: "KeyV" }, "KeyC", "c")).toBe(
+      false,
+    );
+  });
+
+  it("falls back to key when code is unavailable", () => {
+    expect(isPhysicalShortcutKey({ key: "C", code: "" }, "KeyC", "c")).toBe(
+      true,
     );
   });
 });


### PR DESCRIPTION
Match terminal copy and paste shortcuts by physical `KeyboardEvent.code`, while retaining the existing `key` fallback when a browser does not provide a code. This restores Ctrl/Cmd+C and Ctrl+Shift+C/V under non-Latin keyboard layouts without changing Insert shortcuts.

Fixes Termix-SSH/Support#1183