### PR TITLE
fix: use compatible fetch dispatcher for Tailscale

### DIFF
--- a/src/backend/database/routes/tailscale-routes.ts
+++ b/src/backend/database/routes/tailscale-routes.ts
@@ -4,7 +4,7 @@ import {
   type Router as ExpressRouter,
 } from "express";
 import { apiLogger } from "../../utils/logger.js";
-import { getFetchDispatcher } from "../../utils/proxy-agent.js";
+import { fetchWithProxy } from "../../utils/proxy-agent.js";
 import { createCurrentSettingsRepository } from "../repositories/factory.js";
 
 interface TailscaleDevice {
@@ -74,12 +74,11 @@ export function registerTailscaleRoutes(
       );
 
       const url = `${apiBase}/tailnet/-/devices?fields=all`;
-      const response = await fetch(url, {
+      const response = await fetchWithProxy(url, {
         headers: {
           Authorization: `Bearer ${apiKey}`,
           "User-Agent": "Termix/1.0",
         },
-        dispatcher: getFetchDispatcher(url),
       });
 
       if (!response.ok) {

--- a/src/backend/tests/utils/proxy-agent.test.ts
+++ b/src/backend/tests/utils/proxy-agent.test.ts
@@ -1,0 +1,41 @@
+import { createServer } from "node:http";
+import { afterEach, describe, expect, it } from "vitest";
+import { fetchWithProxy } from "../../utils/proxy-agent.js";
+
+describe("fetchWithProxy", () => {
+  const savedProxies = {
+    HTTP_PROXY: process.env.HTTP_PROXY,
+    HTTPS_PROXY: process.env.HTTPS_PROXY,
+    http_proxy: process.env.http_proxy,
+    https_proxy: process.env.https_proxy,
+  };
+
+  afterEach(() => {
+    for (const [name, value] of Object.entries(savedProxies)) {
+      if (value === undefined) delete process.env[name];
+      else process.env[name] = value;
+    }
+  });
+
+  it("uses a dispatcher compatible with the selected fetch implementation", async () => {
+    delete process.env.HTTP_PROXY;
+    delete process.env.HTTPS_PROXY;
+    delete process.env.http_proxy;
+    delete process.env.https_proxy;
+    const server = createServer((_request, response) => response.end("ok"));
+    await new Promise<void>((resolve) =>
+      server.listen(0, "127.0.0.1", resolve),
+    );
+
+    try {
+      const address = server.address();
+      if (!address || typeof address === "string") throw new Error("No port");
+      const response = await fetchWithProxy(`http://127.0.0.1:${address.port}`);
+      expect(await response.text()).toBe("ok");
+    } finally {
+      await new Promise<void>((resolve, reject) =>
+        server.close((error) => (error ? reject(error) : resolve())),
+      );
+    }
+  });
+});

--- a/src/backend/utils/proxy-agent.ts
+++ b/src/backend/utils/proxy-agent.ts
@@ -1,4 +1,4 @@
-import { Agent, ProxyAgent } from "undici";
+import { Agent, ProxyAgent, fetch as undiciFetch } from "undici";
 import type { Dispatcher } from "undici-types";
 
 const directAgent = new Agent({
@@ -38,4 +38,14 @@ export function getProxyAgent(targetUrl?: string): Dispatcher | undefined {
 
 export function getFetchDispatcher(targetUrl: string): Dispatcher {
   return getProxyAgent(targetUrl) ?? (directAgent as unknown as Dispatcher);
+}
+
+export function fetchWithProxy(
+  url: string,
+  init: RequestInit = {},
+): Promise<Response> {
+  return undiciFetch(url, {
+    ...init,
+    dispatcher: getFetchDispatcher(url),
+  });
 }


### PR DESCRIPTION
Closes Termix-SSH/Support#1185.

统一使用 npm Undici 的 fetch 与 dispatcher，避免 Node 内置 fetch 和 Undici 8 Agent 的 ABI 冲突，并补充真实 HTTP 回归测试。