### PR TITLE
fix: add OIDC environment recovery override

### DIFF
--- a/src/backend/database/routes/sso-provider-routes.ts
+++ b/src/backend/database/routes/sso-provider-routes.ts
@@ -7,7 +7,10 @@ import { authLogger } from "../../utils/logger.js";
 import { AuthManager } from "../../utils/auth-manager.js";
 import type { SSOProviderType } from "../../../types/index.js";
 import { createCurrentSsoProviderRepository } from "../repositories/factory.js";
-import { getOIDCConfigFromEnv } from "./user-oidc-utils.js";
+import {
+  getOIDCConfigFromEnv,
+  isOIDCEnvOverrideEnabled,
+} from "./user-oidc-utils.js";
 import {
   decryptSsoConfigSecrets,
   encryptSsoConfigSecrets,
@@ -16,6 +19,19 @@ import { isTrustedProxyAuthEnabled } from "../../utils/trusted-proxy-auth.js";
 
 function isOidcLike(type: SSOProviderType): boolean {
   return type === "oidc" || type === "github" || type === "google";
+}
+
+export function isValidOidcIssuer(value: unknown): boolean {
+  if (typeof value !== "string") return false;
+  try {
+    const url = new URL(value);
+    return (
+      ["http:", "https:"].includes(url.protocol) &&
+      !/\/userinfo\/?$/i.test(url.pathname)
+    );
+  } catch {
+    return false;
+  }
 }
 
 const authManager = AuthManager.getInstance();
@@ -95,13 +111,19 @@ export function registerSSOProviderRoutes(router: Router): void {
    */
   router.get("/sso-providers", async (_req, res) => {
     try {
+      const envConfig = getOIDCConfigFromEnv();
+      if (envConfig && isOIDCEnvOverrideEnabled()) {
+        return res.json([
+          { id: 0, name: "SSO", type: "oidc", displayOrder: 0 },
+        ]);
+      }
+
       const providers =
         await createCurrentSsoProviderRepository().listEnabledPublic();
 
       // If no DB providers exist, synthesize one from env vars so SSO login
       // remains available when configured purely via environment variables.
       if (providers.length === 0) {
-        const envConfig = getOIDCConfigFromEnv();
         if (envConfig) {
           providers.push({ id: 0, name: "SSO", type: "oidc", displayOrder: 0 });
         }
@@ -220,6 +242,12 @@ export function registerSSOProviderRoutes(router: Router): void {
         if (missing.length > 0 && type === "oidc") {
           return res.status(400).json({
             error: `Missing required OIDC fields: ${missing.join(", ")}`,
+          });
+        }
+        if (c.issuer_url && !isValidOidcIssuer(c.issuer_url)) {
+          return res.status(400).json({
+            error:
+              "Issuer URL must be an HTTP(S) issuer and not a userinfo endpoint",
           });
         }
         if (
@@ -353,6 +381,16 @@ export function registerSSOProviderRoutes(router: Router): void {
           ),
           ...rawConfig,
         };
+        if (
+          isOidcLike(effectiveType) &&
+          mergedConfig.issuer_url &&
+          !isValidOidcIssuer(mergedConfig.issuer_url)
+        ) {
+          return res.status(400).json({
+            error:
+              "Issuer URL must be an HTTP(S) issuer and not a userinfo endpoint",
+          });
+        }
         encryptedConfig = await encryptProviderConfig(
           mergedConfig,
           userId,

--- a/src/backend/database/routes/user-oidc-utils.ts
+++ b/src/backend/database/routes/user-oidc-utils.ts
@@ -105,6 +105,10 @@ export function getOIDCConfigFromEnv(): OIDCConfig | null {
   };
 }
 
+export function isOIDCEnvOverrideEnabled(): boolean {
+  return process.env.OIDC_ENV_OVERRIDE?.toLowerCase() === "true";
+}
+
 /**
  * Normalizes a group name for comparison. Providers are inconsistent about
  * whether they emit bare names (`devops-interns`) or full paths
@@ -438,6 +442,11 @@ export async function loadProviderConfig(
   providerType: SSOProviderType;
   providerDbId: number | null;
 } | null> {
+  const envConfig = getOIDCConfigFromEnv();
+  if (envConfig && isOIDCEnvOverrideEnabled()) {
+    return { config: envConfig, providerType: "oidc", providerDbId: null };
+  }
+
   if (providerId != null) {
     try {
       const row =
@@ -485,7 +494,6 @@ export async function loadProviderConfig(
   }
 
   // Fallback: env vars
-  const envConfig = getOIDCConfigFromEnv();
   if (envConfig) {
     return { config: envConfig, providerType: "oidc", providerDbId: null };
   }
@@ -542,6 +550,14 @@ export async function resolveProviderByIssuer(issuer: string): Promise<{
   providerDbId: number | null;
 } | null> {
   const target = normalizeIssuer(issuer);
+  const envConfig = getOIDCConfigFromEnv();
+  if (
+    envConfig?.issuer_url &&
+    isOIDCEnvOverrideEnabled() &&
+    normalizeIssuer(envConfig.issuer_url) === target
+  ) {
+    return { config: envConfig, providerType: "oidc", providerDbId: null };
+  }
 
   try {
     const rows = await createCurrentSsoProviderRepository().listEnabled();
@@ -569,7 +585,6 @@ export async function resolveProviderByIssuer(issuer: string): Promise<{
     });
   }
 
-  const envConfig = getOIDCConfigFromEnv();
   if (
     envConfig?.issuer_url &&
     normalizeIssuer(envConfig.issuer_url) === target

--- a/src/backend/tests/database/routes/sso-provider-routes.test.ts
+++ b/src/backend/tests/database/routes/sso-provider-routes.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../../../utils/auth-manager.js", () => ({
+  AuthManager: {
+    getInstance: () => ({ createAdminMiddleware: vi.fn() }),
+  },
+}));
+
+const { isValidOidcIssuer } =
+  await import("../../../database/routes/sso-provider-routes.js");
+
+describe("isValidOidcIssuer", () => {
+  it("rejects userinfo endpoints used as issuer URLs", () => {
+    expect(
+      isValidOidcIssuer("https://auth.example/application/o/userinfo/"),
+    ).toBe(false);
+  });
+
+  it("accepts an Authentik application issuer", () => {
+    expect(isValidOidcIssuer("https://auth.example/application/o/termix")).toBe(
+      true,
+    );
+  });
+});

--- a/src/backend/tests/database/routes/user-oidc-utils.test.ts
+++ b/src/backend/tests/database/routes/user-oidc-utils.test.ts
@@ -21,6 +21,7 @@ const {
   resolveOidcMappedRoles,
   verifyOIDCToken,
   describeFetchFailure,
+  isOIDCEnvOverrideEnabled,
 } = await import("../../../database/routes/user-oidc-utils.js");
 
 const BACKCHANNEL_LOGOUT_EVENT =
@@ -281,6 +282,7 @@ describe("getOIDCConfigFromEnv", () => {
     "OIDC_SCOPES",
     "OIDC_ALLOWED_USERS",
     "OIDC_ADMIN_GROUP",
+    "OIDC_ENV_OVERRIDE",
   ];
   const saved: Record<string, string | undefined> = {};
 
@@ -333,6 +335,12 @@ describe("getOIDCConfigFromEnv", () => {
     const config = getOIDCConfigFromEnv();
     expect(config?.identifier_path).toBe("email");
     expect(config?.scopes).toBe("openid");
+  });
+
+  it("only enables database recovery override when explicitly requested", () => {
+    expect(isOIDCEnvOverrideEnabled()).toBe(false);
+    process.env.OIDC_ENV_OVERRIDE = "true";
+    expect(isOIDCEnvOverrideEnabled()).toBe(true);
   });
 });
 


### PR DESCRIPTION
Closes Termix-SSH/Support#1187.

新增 OIDC_ENV_OVERRIDE 紧急恢复开关以绕过损坏的数据库 provider，并拒绝把 userinfo endpoint 保存为 issuer URL。