### PR TITLE
fix: resolve synced remote desktop host IDs

### DIFF
--- a/src/ui/api/guacamole-api.ts
+++ b/src/ui/api/guacamole-api.ts
@@ -6,6 +6,7 @@ import {
 } from "@/main-axios";
 import type { AxiosInstance } from "axios";
 import type { GuacamoleConfig } from "@/types/guacamole-config";
+import { resolveRemoteHostId } from "@/lib/remote-server-api";
 
 /**
  * The embedded desktop backend does not bundle guacd, which is why
@@ -185,10 +186,18 @@ export async function getGuacamoleTokenFromHost(
     password?: string;
     domain?: string;
   },
+  syncId?: string | null,
 ): Promise<GuacamoleTokenResponse> {
   try {
+    const remoteHostId = isElectron()
+      ? await resolveRemoteHostId(syncId)
+      : null;
+    if (isElectron() && syncId && remoteHostId === null) {
+      throw new Error("The synced host does not exist on the remote server");
+    }
+    const targetHostId = remoteHostId ?? hostId;
     const response = await guacamoleApi().post(
-      `/guacamole/connect-host/${hostId}`,
+      `/guacamole/connect-host/${targetHostId}`,
       {
         ...(protocol ? { protocol } : {}),
         ...(promptedCredentials?.username

--- a/src/ui/features/guacamole/GuacamoleApp.tsx
+++ b/src/ui/features/guacamole/GuacamoleApp.tsx
@@ -134,7 +134,7 @@ interface GuacamoleAppInnerProps {
   hostId: number;
   hostConfig: Pick<
     SSHHost,
-    "connectionType" | "domain" | "guacamoleConfig" | "rdpAuthType"
+    "connectionType" | "domain" | "guacamoleConfig" | "rdpAuthType" | "syncId"
   >;
   hostName: string;
   tabId?: string;
@@ -256,6 +256,7 @@ const GuacamoleAppInner = React.forwardRef<
       hostId,
       protocol,
       promptedCredentials ?? undefined,
+      hostConfig.syncId,
     );
     if (result) {
       setToken(result.token);
@@ -268,6 +269,7 @@ const GuacamoleAppInner = React.forwardRef<
     protocol,
     promptedCredentials,
     resolvedProtocolForConnect,
+    hostConfig.syncId,
     addLog,
     t,
   ]);

--- a/src/ui/tests/api/guacamole-api.test.ts
+++ b/src/ui/tests/api/guacamole-api.test.ts
@@ -9,12 +9,16 @@ const remoteApiMock = vi.hoisted(() => ({
   post: vi.fn(async () => ({ data: { token: "remote-token" } })),
 }));
 const isElectronMock = vi.hoisted(() => vi.fn(() => false));
+const resolveRemoteHostIdMock = vi.hoisted(() => vi.fn());
 
 vi.mock("@/main-axios", () => ({
   authApi: authApiMock,
   getRemoteGuacamoleApi: () => remoteApiMock,
   isElectron: isElectronMock,
   handleApiError: (error: unknown) => error,
+}));
+vi.mock("@/lib/remote-server-api", () => ({
+  resolveRemoteHostId: resolveRemoteHostIdMock,
 }));
 
 import {
@@ -27,6 +31,7 @@ beforeEach(() => {
   authApiMock.post.mockClear();
   remoteApiMock.get.mockClear();
   remoteApiMock.post.mockClear();
+  resolveRemoteHostIdMock.mockReset();
 });
 
 describe("guacamole API origin", () => {
@@ -60,15 +65,21 @@ describe("guacamole API origin", () => {
 
   it("sends the connect-host payload unchanged to the remote server", async () => {
     isElectronMock.mockReturnValue(true);
+    resolveRemoteHostIdMock.mockResolvedValue(41);
 
-    await getGuacamoleTokenFromHost(9, "rdp", {
-      username: "admin",
-      password: "secret",
-      domain: "EXAMPLE",
-    });
+    await getGuacamoleTokenFromHost(
+      9,
+      "rdp",
+      {
+        username: "admin",
+        password: "secret",
+        domain: "EXAMPLE",
+      },
+      "host-sync-id",
+    );
 
     expect(remoteApiMock.post).toHaveBeenCalledWith(
-      "/guacamole/connect-host/9",
+      "/guacamole/connect-host/41",
       {
         protocol: "rdp",
         promptedUsername: "admin",
@@ -76,6 +87,7 @@ describe("guacamole API origin", () => {
         promptedDomain: "EXAMPLE",
       },
     );
+    expect(resolveRemoteHostIdMock).toHaveBeenCalledWith("host-sync-id");
   });
 
   it("sends an empty prompted domain for local RDP accounts", async () => {
@@ -93,5 +105,15 @@ describe("guacamole API origin", () => {
       promptedPassword: "secret",
       promptedDomain: "",
     });
+  });
+
+  it("does not fall back to a colliding local id when sync resolution fails", async () => {
+    isElectronMock.mockReturnValue(true);
+    resolveRemoteHostIdMock.mockResolvedValue(null);
+
+    await expect(
+      getGuacamoleTokenFromHost(9, "rdp", undefined, "missing-sync-id"),
+    ).rejects.toThrow("The synced host does not exist on the remote server");
+    expect(remoteApiMock.post).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Closes Termix-SSH/Support#1188.

Electron 发起 RDP、VNC 和 Telnet 连接前通过 syncId 解析远端 host ID，避免把本地数据库 ID 发给远端 Guacamole，并在映射缺失时安全失败。