### PR TITLE
Fix Proxmox credential guest imports

### DIFF
--- a/src/backend/database/routes/host-bulk-routes.ts
+++ b/src/backend/database/routes/host-bulk-routes.ts
@@ -105,6 +105,16 @@ export function parseSSHConfig(content: string): SSHConfigHost[] {
   return results;
 }
 
+export function importedHostUsername(
+  connectionType: string,
+  authType: unknown,
+  username: unknown,
+): string | null {
+  if (isNonEmptyString(username)) return username;
+  if (connectionType !== "ssh" || authType === "credential") return "";
+  return null;
+}
+
 export function registerHostBulkRoutes(
   router: Router,
   authenticateJWT: RequestHandler,
@@ -558,10 +568,12 @@ export function registerHostBulkRoutes(
             continue;
           }
 
-          if (
-            effectiveConnectionType === "ssh" &&
-            !isNonEmptyString(hostData.username)
-          ) {
+          const username = importedHostUsername(
+            effectiveConnectionType,
+            hostData.authType,
+            hostData.username,
+          );
+          if (username === null) {
             results.failed++;
             results.errors.push(
               `Host ${i + 1}: Username required for SSH connections`,
@@ -660,12 +672,12 @@ export function registerHostBulkRoutes(
           const sshDataObj: Record<string, unknown> = {
             userId: userId,
             connectionType: effectiveConnectionType,
-            name: hostData.name || `${hostData.username || ""}@${hostData.ip}`,
+            name: hostData.name || `${username}@${hostData.ip}`,
             folder: hostData.folder || "Default",
             tags: Array.isArray(hostData.tags) ? hostData.tags.join(",") : "",
             ip: hostData.ip,
             port: hostData.port,
-            username: hostData.username || null,
+            username,
             pin: hostData.pin || false,
             enableTerminal: hostData.enableTerminal !== false,
             enableTunnel: hostData.enableTunnel !== false,

--- a/src/backend/tests/database/routes/host-bulk-routes.test.ts
+++ b/src/backend/tests/database/routes/host-bulk-routes.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from "vitest";
-import { parseSSHConfig } from "../../../database/routes/host-bulk-routes.js";
+import {
+  importedHostUsername,
+  parseSSHConfig,
+} from "../../../database/routes/host-bulk-routes.js";
 
 describe("parseSSHConfig", () => {
   it("parses a basic Host block", () => {
@@ -100,5 +103,26 @@ Host server
   it("returns empty array for empty input", () => {
     expect(parseSSHConfig("")).toHaveLength(0);
     expect(parseSSHConfig("   \n\n  ")).toHaveLength(0);
+  });
+});
+
+describe("importedHostUsername", () => {
+  it("lets credential-backed SSH hosts inherit the credential username", () => {
+    expect(importedHostUsername("ssh", "credential", "")).toBe("");
+  });
+
+  it("keeps requiring usernames for other SSH authentication modes", () => {
+    expect(importedHostUsername("ssh", "password", "")).toBeNull();
+    expect(importedHostUsername("ssh", "key", undefined)).toBeNull();
+  });
+
+  it("always returns a non-null database value for non-SSH hosts", () => {
+    expect(importedHostUsername("rdp", "password", undefined)).toBe("");
+  });
+
+  it("preserves an explicitly configured host username", () => {
+    expect(importedHostUsername("ssh", "credential", "guest-admin")).toBe(
+      "guest-admin",
+    );
   });
 });


### PR DESCRIPTION
## Summary
- allow credential-backed SSH imports to inherit the credential username
- keep username validation unchanged for password, key, and other SSH authentication modes
- store an empty string instead of `null` when the host username comes from a credential
- cover credential SSH and non-SSH import username behavior with regression tests

## Verification
- `npm test -- --run src/backend/tests/database/routes/host-bulk-routes.test.ts src/backend/tests/database/routes/host-normalizers.test.ts src/backend/tests/database/routes/proxmox-import-auth.test.ts src/ui/tests/components/proxmox/proxmox-import-auth.test.ts`
- `npm run type-check`
- `npm run build`
- targeted ESLint and Prettier checks

Fixes Termix-SSH/Support#1195