### PR TITLE
Fix Fleet command results layout

### DIFF
--- a/src/ui/sidebar/FleetsPanel.tsx
+++ b/src/ui/sidebar/FleetsPanel.tsx
@@ -74,7 +74,7 @@ function ResultsList({ results }: { results: FleetHostResult[] }) {
   const { t } = useTranslation();
   if (results.length === 0) return null;
   return (
-    <div className="flex flex-col gap-2 max-h-80 overflow-y-auto">
+    <div className="flex flex-col gap-2">
       {results.map((r) => (
         <div
           key={r.hostId}


### PR DESCRIPTION
## Summary
- remove the fixed 320px cap from Fleet command results
- let the existing Fleet panel scroller use the available sidebar height
- remove the nested scrollbar that left most of tall panes unused

## Verification
- `npm run type-check`
- `npm run build`
- targeted ESLint and Prettier checks

Fixes Termix-SSH/Support#1197