### PR TITLE
Fix Proxmox scheduled sync

### DIFF
--- a/src/backend/database/routes/proxmox-jump-hosts.ts
+++ b/src/backend/database/routes/proxmox-jump-hosts.ts
@@ -1,0 +1,17 @@
+export function parseProxmoxJumpHosts(raw: unknown): unknown[] | null {
+  if (!raw) return null;
+  if (Array.isArray(raw)) return raw;
+  if (typeof raw !== "string") return null;
+
+  try {
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+export function serializeProxmoxJumpHosts(raw: unknown): string | null {
+  const parsed = parseProxmoxJumpHosts(raw);
+  return parsed ? JSON.stringify(parsed) : null;
+}

--- a/src/backend/database/routes/proxmox.ts
+++ b/src/backend/database/routes/proxmox.ts
@@ -13,6 +13,10 @@ import { SSHHostKeyVerifier } from "../../hosts/host-key-verifier.js";
 import { resolveHostById } from "../../hosts/host-resolver.js";
 import { createJumpHostChain } from "../../hosts/jump-host-chain.js";
 import { resolveProxmoxImportAuth } from "./proxmox-import-auth.js";
+import {
+  parseProxmoxJumpHosts,
+  serializeProxmoxJumpHosts,
+} from "./proxmox-jump-hosts.js";
 import { isSafeNodeName } from "../../hosts/proxmox-shared.js";
 
 const router = express.Router();
@@ -182,20 +186,6 @@ type ProxmoxSyncResult = {
   skipped: number;
   errors: string[];
 };
-
-function parseJumpHostsField(raw: unknown): unknown[] | null {
-  if (!raw) return null;
-  if (Array.isArray(raw)) return raw;
-  if (typeof raw === "string") {
-    try {
-      const parsed = JSON.parse(raw);
-      return Array.isArray(parsed) ? parsed : null;
-    } catch {
-      return null;
-    }
-  }
-  return null;
-}
 
 function parseJsonObject(value: unknown): Record<string, unknown> {
   if (!value) return {};
@@ -599,7 +589,7 @@ async function discoverProxmoxGuestsForHost(
       guests,
       credentialId: hostCredentialId,
       defaultCredentialId: config.defaultCredentialId,
-      jumpHosts: parseJumpHostsField(
+      jumpHosts: parseProxmoxJumpHosts(
         (host as unknown as { jumpHosts?: unknown }).jumpHosts,
       ),
       config,
@@ -770,9 +760,7 @@ async function syncProxmoxHost(
         telnetPort: null,
         defaultPath: "/",
         tunnelConnections: "[]",
-        jumpHosts:
-          (discovery.host as unknown as { jumpHosts?: string | null })
-            .jumpHosts ?? null,
+        jumpHosts: serializeProxmoxJumpHosts(discovery.jumpHosts),
         quickActions: null,
         statsConfig: null,
         dockerConfig: null,

--- a/src/backend/tests/database/routes/proxmox-jump-hosts.test.ts
+++ b/src/backend/tests/database/routes/proxmox-jump-hosts.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import {
+  parseProxmoxJumpHosts,
+  serializeProxmoxJumpHosts,
+} from "../../../database/routes/proxmox-jump-hosts.js";
+
+describe("Proxmox jump-host persistence", () => {
+  const jumpHosts = [{ hostId: 7 }, { hostId: 9 }];
+
+  it("serializes resolved arrays before inserting a synced guest", () => {
+    expect(serializeProxmoxJumpHosts(jumpHosts)).toBe(
+      '[{"hostId":7},{"hostId":9}]',
+    );
+  });
+
+  it("keeps stored JSON strings stable", () => {
+    const stored = '[{"hostId":7}]';
+    expect(serializeProxmoxJumpHosts(stored)).toBe(stored);
+    expect(parseProxmoxJumpHosts(stored)).toEqual([{ hostId: 7 }]);
+  });
+
+  it("turns missing or malformed values into null", () => {
+    expect(serializeProxmoxJumpHosts(null)).toBeNull();
+    expect(serializeProxmoxJumpHosts("invalid")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- serialize resolved Proxmox jump-host arrays before inserting synced guests into SQLite
- keep manual discovery responses normalized without changing their behavior
- add regression coverage for array, stored JSON, and malformed jump-host values

## Validation
- npm test -- --run src/backend/tests/database/routes/proxmox-jump-hosts.test.ts src/backend/tests/database/host-repository.test.ts src/backend/tests/database/routes/proxmox-import-auth.test.ts
- npm run lint
- npm run type-check
- npm run build

Fixes Termix-SSH/Support#1196