### PR TITLE
fix: use matching Undici fetch for private AI providers

### DIFF
--- a/src/backend/ai/providers/http.ts
+++ b/src/backend/ai/providers/http.ts
@@ -1,4 +1,4 @@
-import { getFetchDispatcher } from "../../utils/proxy-agent.js";
+import { fetchWithProxy } from "../../utils/proxy-agent.js";
 import { safeOutboundFetch } from "../../utils/safe-outbound-fetch.js";
 import { evaluateEgress, readPrivateAllowlist } from "../egress.js";
 import { AiProviderError } from "./types.js";
@@ -9,8 +9,8 @@ import { AiProviderError } from "./types.js";
  *
  * Public hosts use safeOutboundFetch, which re-checks the resolved address at
  * connect time. Allowlisted private hosts cannot use it (its whole job is to
- * refuse them), so they fall back to plain fetch with the proxy dispatcher --
- * still respecting corporate proxy configuration.
+ * refuse them), so they use the installed Undici fetch implementation with
+ * its matching proxy dispatcher -- still respecting proxy configuration.
  */
 export async function providerFetch(
   url: string,
@@ -24,10 +24,7 @@ export async function providerFetch(
   }
 
   if (decision.isPrivate) {
-    return fetch(url, {
-      ...init,
-      dispatcher: getFetchDispatcher(url),
-    } as RequestInit);
+    return fetchWithProxy(url, init);
   }
 
   return safeOutboundFetch(url, init) as unknown as Promise<Response>;

--- a/src/backend/tests/ai/provider-http.test.ts
+++ b/src/backend/tests/ai/provider-http.test.ts
@@ -1,0 +1,46 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const fetchWithProxy = vi.fn();
+const getFetchDispatcher = vi.fn();
+const safeOutboundFetch = vi.fn();
+const readPrivateAllowlist = vi.fn();
+const evaluateEgress = vi.fn();
+const globalFetch = vi.fn();
+
+vi.mock("../../utils/proxy-agent.js", () => ({
+  fetchWithProxy,
+  getFetchDispatcher,
+}));
+vi.mock("../../utils/safe-outbound-fetch.js", () => ({ safeOutboundFetch }));
+vi.mock("../../ai/egress.js", () => ({
+  readPrivateAllowlist,
+  evaluateEgress,
+}));
+
+const { providerFetch } = await import("../../ai/providers/http.js");
+
+describe("providerFetch", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal("fetch", globalFetch);
+    readPrivateAllowlist.mockResolvedValue(["192.168.1.50"]);
+  });
+
+  it("uses the matching Undici fetch implementation for private providers", async () => {
+    const response = { ok: true, status: 200 } as Response;
+    const init = { method: "GET" };
+    evaluateEgress.mockReturnValue({ allowed: true, isPrivate: true });
+    fetchWithProxy.mockResolvedValue(response);
+
+    await expect(
+      providerFetch("http://192.168.1.50:11434/api/tags", init),
+    ).resolves.toBe(response);
+
+    expect(fetchWithProxy).toHaveBeenCalledWith(
+      "http://192.168.1.50:11434/api/tags",
+      init,
+    );
+    expect(globalFetch).not.toHaveBeenCalled();
+    expect(safeOutboundFetch).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
# Overview

Fix allowlisted private AI providers failing with `fetch failed` when Termix runs with a different bundled Undici version than its installed `undici` package.

- [x] Fixed: Private AI provider requests now use the installed Undici `fetch` implementation with its matching dispatcher.
- [x] Added: Regression coverage for the private-provider request path.

# Changes Made

- Route allowlisted private provider requests through the existing `fetchWithProxy` helper.
- Preserve proxy handling and the existing private-endpoint allowlist checks.
- Avoid passing an Undici 8 dispatcher to Node's bundled Undici 7 `fetch`, which fails with `UND_ERR_INVALID_ARG: invalid onRequestStart method`.

# Related Issues

- Closes #1298

# Screenshots / Demos

- I tested this fix successfully on my self-hosted Termix 2.7.1 Docker deployment with Ollama on an allowlisted private endpoint. Model discovery and streamed chat both work after the fix.

# Testing

- 26 focused backend tests passed.
- TypeScript project check passed.
- ESLint passed for the changed files.

# Checklist

- [x] Code follows project style guidelines
- [x] Supports mobile and desktop UI/app (not applicable; backend-only change)
- [x] I have read [Contributing.md](https://github.com/Termix-SSH/Termix/blob/main/CONTRIBUTING.md)
- [x] This is not a translation request. See [docs](https://docs.termix.site/translations)
