### PR TITLE
Fix split screen layout selection

### DIFF
--- a/src/ui/AppShell.tsx
+++ b/src/ui/AppShell.tsx
@@ -550,8 +550,9 @@ export function AppShell({
     });
   }, []);
   const skipSplitSyncRef = useRef(false);
+  const activeTabAvailable = tabs.some((tab) => tab.id === activeTabId);
   useEffect(() => {
-    const active = tabsRef.current.find((tab) => tab.id === activeTabId);
+    const active = tabs.find((tab) => tab.id === activeTabId);
     const config = active?.type === "split-screen" ? active.splitConfig : null;
     skipSplitSyncRef.current = true;
     if (!config) {
@@ -565,7 +566,7 @@ export function AppShell({
     setRowSizes(config.rowSizes);
     setRowColSizes(config.rowColSizes);
     setFocusedPaneIndex(0);
-  }, [activeTabId]);
+  }, [activeTabId, activeTabAvailable]);
 
   useEffect(() => {
     if (skipSplitSyncRef.current) {


### PR DESCRIPTION
让 Split Screen 状态同步同时响应活动 tab 是否已提交，避免 Safari 或并发更新中先切换 ID、后插入 split tab 时把所选布局永久重置为 none。已通过 split 状态专项测试、type-check 与 production build，修复 Termix-SSH/Support#1207。