### PR TITLE
fix: force classic auth for macOS VNC

### DIFF
--- a/src/backend/hosts/guacamole/macos-vnc-proxy.ts
+++ b/src/backend/hosts/guacamole/macos-vnc-proxy.ts
@@ -1,6 +1,7 @@
 import net from "net";
 
 const RFB_BANNER_LENGTH = 12;
+const VNC_AUTH_SECURITY_TYPE = 2;
 const MACOS_RFB_BANNER = Buffer.from("RFB 003.889\n", "ascii");
 const STANDARD_RFB_BANNER = Buffer.from("RFB 003.008\n", "ascii");
 
@@ -32,17 +33,47 @@ export async function createMacosVncCompatibilityProxy({
     client.pipe(upstream);
 
     let pending = Buffer.alloc(0);
+    const forwardMacosSecurityTypes = (chunk: Buffer) => {
+      pending = Buffer.concat([pending, chunk]);
+      if (pending.length < 1) return;
+
+      const securityTypeCount = pending[0];
+      if (securityTypeCount === 0) {
+        upstream.off("data", forwardMacosSecurityTypes);
+        client.write(pending);
+        upstream.pipe(client);
+        return;
+      }
+      if (pending.length < 1 + securityTypeCount) return;
+
+      upstream.off("data", forwardMacosSecurityTypes);
+      const securityTypes = pending.subarray(1, 1 + securityTypeCount);
+      if (securityTypes.includes(VNC_AUTH_SECURITY_TYPE)) {
+        client.write(Buffer.from([1, VNC_AUTH_SECURITY_TYPE]));
+      } else {
+        client.write(pending.subarray(0, 1 + securityTypeCount));
+      }
+      client.write(pending.subarray(1 + securityTypeCount));
+      upstream.pipe(client);
+    };
+
     const forwardServerBanner = (chunk: Buffer) => {
       pending = Buffer.concat([pending, chunk]);
       if (pending.length < RFB_BANNER_LENGTH) return;
 
       upstream.off("data", forwardServerBanner);
       const banner = pending.subarray(0, RFB_BANNER_LENGTH);
-      client.write(
-        banner.equals(MACOS_RFB_BANNER) ? STANDARD_RFB_BANNER : banner,
-      );
-      client.write(pending.subarray(RFB_BANNER_LENGTH));
-      upstream.pipe(client);
+      const remainder = pending.subarray(RFB_BANNER_LENGTH);
+      if (banner.equals(MACOS_RFB_BANNER)) {
+        client.write(STANDARD_RFB_BANNER);
+        pending = Buffer.alloc(0);
+        upstream.on("data", forwardMacosSecurityTypes);
+        if (remainder.length > 0) forwardMacosSecurityTypes(remainder);
+      } else {
+        client.write(banner);
+        client.write(remainder);
+        upstream.pipe(client);
+      }
     };
     upstream.on("data", forwardServerBanner);
   });

--- a/src/backend/tests/hosts/guacamole/macos-vnc-proxy.test.ts
+++ b/src/backend/tests/hosts/guacamole/macos-vnc-proxy.test.ts
@@ -32,14 +32,20 @@ async function read(socket: net.Socket, length: number): Promise<Buffer> {
 }
 
 describe("createMacosVncCompatibilityProxy", () => {
-  it("normalizes Apple's private RFB banner and preserves later traffic", async () => {
+  it("normalizes Apple's private RFB banner and forces classic VNC auth", async () => {
     let clientBanner = "";
+    let selectedSecurityType = 0;
     const target = net.createServer((socket) => {
       socket.write("RFB 003.");
       socket.write("889\n");
       socket.once("data", (data) => {
         clientBanner = data.toString("ascii");
-        socket.write("security-types");
+        socket.write(Buffer.from([5, 30, 33]));
+        socket.write(Buffer.from([36, 2, 35]));
+        socket.once("data", (selection) => {
+          selectedSecurityType = selection[0];
+          socket.write("desktop-data");
+        });
       });
     });
     const targetPort = await listen(target);
@@ -58,12 +64,18 @@ describe("createMacosVncCompatibilityProxy", () => {
       "RFB 003.008\n",
     );
     client.write("RFB 003.008\n");
-    expect((await read(client, 14)).toString("ascii")).toBe("security-types");
+    expect([...(await read(client, 2))]).toEqual([1, 2]);
+    client.write(Buffer.from([2]));
+    expect((await read(client, 12)).toString("ascii")).toBe("desktop-data");
     expect(clientBanner).toBe("RFB 003.008\n");
+    expect(selectedSecurityType).toBe(2);
   });
 
-  it("passes standard RFB banners through unchanged", async () => {
-    const target = net.createServer((socket) => socket.write("RFB 003.008\n"));
+  it("passes standard RFB negotiation through unchanged", async () => {
+    const target = net.createServer((socket) => {
+      socket.write("RFB 003.008\n");
+      socket.once("data", () => socket.write(Buffer.from([2, 30, 2])));
+    });
     const targetPort = await listen(target);
     closers.push(() => target.close());
     const proxy = await createMacosVncCompatibilityProxy({
@@ -76,5 +88,28 @@ describe("createMacosVncCompatibilityProxy", () => {
     const client = net.createConnection(proxy.port, "127.0.0.1");
     closers.push(() => client.destroy());
     expect((await read(client, 12)).toString("ascii")).toBe("RFB 003.008\n");
+    client.write("RFB 003.008\n");
+    expect([...(await read(client, 3))]).toEqual([2, 30, 2]);
+  });
+
+  it("passes Apple's security types through when VNC auth is unavailable", async () => {
+    const target = net.createServer((socket) => {
+      socket.write("RFB 003.889\n");
+      socket.once("data", () => socket.write(Buffer.from([2, 30, 33])));
+    });
+    const targetPort = await listen(target);
+    closers.push(() => target.close());
+    const proxy = await createMacosVncCompatibilityProxy({
+      targetHost: "127.0.0.1",
+      targetPort,
+      bindHost: "127.0.0.1",
+    });
+    closers.push(proxy.close);
+
+    const client = net.createConnection(proxy.port, "127.0.0.1");
+    closers.push(() => client.destroy());
+    expect((await read(client, 12)).toString("ascii")).toBe("RFB 003.008\n");
+    client.write("RFB 003.008\n");
+    expect([...(await read(client, 3))]).toEqual([2, 30, 33]);
   });
 });


### PR DESCRIPTION
# Overview

Follow-up to #1311: macOS Screen Sharing connections without a username still fail after the `RFB 003.889` banner is normalized because macOS advertises Apple-specific security types before classic VNC authentication.

- [ ] Added: ...
- [x] Updated: macOS VNC compatibility negotiation
- [ ] Removed: ...
- [x] Fixed: username-less macOS VNC connections using the dedicated VNC viewer password

# Changes Made

- Detect the security-type list that follows Apple's private RFB banner.
- When classic VNC password authentication (type `2`) is available, advertise only that type to guacd so libvncclient does not select Apple Remote Desktop authentication (type `30`) with an empty username.
- Preserve the original negotiation for standard RFB servers and for Apple servers that do not offer type `2`.
- Cover fragmented Apple banners/security lists and pass-through behavior with regression tests.

# Verification

- `vitest run src/backend/tests/hosts/guacamole/macos-vnc-proxy.test.ts` — 3 tests passed.
- ESLint passed for both changed files.
- `npm run type-check` passed.
- Production Docker image build passed.
- End-to-end verified against a real macOS Screen Sharing server advertising `RFB 003.889` and security types `30,33,36,2,35`: Termix → guacd 1.6.0 → compatibility proxy → macOS authenticated successfully and rendered the macOS lock screen in the browser.

# Related Issues

- Closes Termix-SSH/Support#1208
- Related to Termix-SSH/Support#1015
- Follow-up to #1311
- Related to Termix-SSH/Support#1206

# Screenshots / Demos

The end-to-end desktop render was verified locally; no screenshot is attached because it contains a private machine's lock screen.

# Checklist

- [x] Code follows project style guidelines
- [x] Supports mobile and desktop UI/app (if applicable)
- [x] I have read [Contributing.md](https://github.com/Termix-SSH/Termix/blob/main/CONTRIBUTING.md)
- [x] This is not a translation request. See [docs](https://docs.termix.site/translations)
