### PR TITLE
Fix slow remote desktop connections

### DIFF
--- a/src/ui/features/guacamole/GuacamoleDisplay.tsx
+++ b/src/ui/features/guacamole/GuacamoleDisplay.tsx
@@ -443,12 +443,6 @@ export const GuacamoleDisplay = forwardRef<
     const tunnel = new Guacamole.WebSocketTunnel(wsConnection.url);
     const client = new Guacamole.Client(tunnel);
     clientRef.current = client;
-    let connectWatchdog: ReturnType<typeof setTimeout> | null = null;
-    const clearConnectWatchdog = () => {
-      if (!connectWatchdog) return;
-      clearTimeout(connectWatchdog);
-      connectWatchdog = null;
-    };
 
     const display = client.getDisplay();
     const displayElement = display.getElement();
@@ -548,7 +542,6 @@ export const GuacamoleDisplay = forwardRef<
         case 2:
           break;
         case 3:
-          clearConnectWatchdog();
           isConnectingRef.current = false;
           setIsReady(true);
           onConnect?.();
@@ -571,7 +564,6 @@ export const GuacamoleDisplay = forwardRef<
         case 4:
           break;
         case 5:
-          clearConnectWatchdog();
           isConnectingRef.current = false;
           setIsReady(false);
           setHasError(true);
@@ -585,7 +577,6 @@ export const GuacamoleDisplay = forwardRef<
 
     client.onerror = (error: Guacamole.Status) => {
       if (!isMountedRef.current || clientRef.current !== client) return;
-      clearConnectWatchdog();
       const errorMessage = error.message || t("guacamole.connectionError");
       setIsReady(false);
       setHasError(true);
@@ -643,21 +634,8 @@ export const GuacamoleDisplay = forwardRef<
     };
 
     try {
-      connectWatchdog = setTimeout(() => {
-        if (
-          !isMountedRef.current ||
-          clientRef.current !== client ||
-          !isConnectingRef.current
-        ) {
-          return;
-        }
-
-        disconnectClient();
-        void connect();
-      }, 8000);
       client.connect(wsConnection.query);
     } catch (error) {
-      clearConnectWatchdog();
       isConnectingRef.current = false;
       if (!isMountedRef.current) return;
       setIsReady(false);
@@ -671,7 +649,6 @@ export const GuacamoleDisplay = forwardRef<
     onError,
     refreshKeyboardHandlers,
     rescaleDisplay,
-    disconnectClient,
     connectionConfig.protocol,
     connectionConfig.type,
     connectionConfig.dpi,


### PR DESCRIPTION
## Summary
- remove the hard-coded 8-second Guacamole connection watchdog
- stop disconnecting valid RDP/VNC sessions while guacd is still negotiating or authenticating
- stop the watchdog from creating overlapping token retries after a slow connection

Guacamole and guacd already report connection failures and enforce inactivity. The extra frontend watchdog was shorter than normal RDP authentication on the reported setup, so it disconnected the client while guacd was still successfully opening the session.

## Validation
- npm test -- --run src/ui/tests/features/guacamole/GuacamoleDisplay.test.ts src/ui/tests/features/guacamole/guacamole-display-size.test.ts src/ui/tests/api/guacamole-api.test.ts
- npx eslint src/ui/features/guacamole/GuacamoleDisplay.tsx
- npx prettier --check src/ui/features/guacamole/GuacamoleDisplay.tsx
- npm run type-check
- npm run build
- git diff --check

Fixes Termix-SSH/Support#1043