### PR TITLE
fix: restore RDP clipboard paste across browsers

### DIFF
--- a/src/ui/features/guacamole/GuacamoleDisplay.tsx
+++ b/src/ui/features/guacamole/GuacamoleDisplay.tsx
@@ -18,11 +18,7 @@ import {
   resolveConnectionOrigin,
   buildOriginWsUrl,
 } from "@/lib/connection-origin.ts";
-import {
-  isFirefoxBrowser,
-  isPasteShortcut,
-  pasteTextToRemote,
-} from "./guacamole-clipboard.ts";
+import { isPasteShortcut, pasteTextToRemote } from "./guacamole-clipboard.ts";
 import { getGuacamoleDisplaySize } from "./guacamole-display-size.ts";
 import { bindPointerInput } from "./guacamole-pointer.ts";
 import {
@@ -456,31 +452,32 @@ export const GuacamoleDisplay = forwardRef<
     displayElement.setAttribute("tabindex", "0");
     displayElement.style.outline = "none";
 
-    const useNativePasteFallback = isFirefoxBrowser();
-    if (useNativePasteFallback) {
-      displayElement.addEventListener(
-        "keydown",
-        (event) => {
-          if (isPasteShortcut(event)) {
-            event.stopImmediatePropagation();
-          }
-        },
-        true,
-      );
-      displayElement.addEventListener(
-        "paste",
-        (event) => {
-          if (clientRef.current !== client) return;
-          const text = event.clipboardData?.getData("text/plain");
-          if (!text) return;
-
-          event.preventDefault();
+    // Reading navigator.clipboard outside a user gesture is denied by Safari
+    // and commonly denied by Chromium. The paste event carries the text under
+    // the browser's normal permission model, so use it on every browser and
+    // replace the original shortcut with an ordered clipboard update + Ctrl+V.
+    displayElement.addEventListener(
+      "keydown",
+      (event) => {
+        if (isPasteShortcut(event)) {
           event.stopImmediatePropagation();
-          pasteTextToRemote(client, text);
-        },
-        true,
-      );
-    }
+        }
+      },
+      true,
+    );
+    displayElement.addEventListener(
+      "paste",
+      (event) => {
+        if (clientRef.current !== client) return;
+        const text = event.clipboardData?.getData("text/plain");
+        if (!text) return;
+
+        event.preventDefault();
+        event.stopImmediatePropagation();
+        pasteTextToRemote(client, text);
+      },
+      true,
+    );
 
     display.onresize = () => {
       if (!isMountedRef.current || clientRef.current !== client) return;
@@ -759,7 +756,7 @@ export const GuacamoleDisplay = forwardRef<
 
   const syncClipboard = useCallback(() => {
     const client = clientRef.current;
-    if (!client || isFirefoxBrowser() || !navigator.clipboard?.readText) return;
+    if (!client || !navigator.clipboard?.readText) return;
     navigator.clipboard
       .readText()
       .then((text) => {

--- a/src/ui/features/guacamole/guacamole-clipboard.ts
+++ b/src/ui/features/guacamole/guacamole-clipboard.ts
@@ -13,10 +13,6 @@ export interface GuacamoleClipboardClient {
   sendKeyEvent(pressed: number, keysym: number): void;
 }
 
-export function isFirefoxBrowser(userAgent = navigator.userAgent): boolean {
-  return /(?:Firefox|FxiOS)\//.test(userAgent);
-}
-
 export function isPasteShortcut(
   event: Pick<KeyboardEvent, "altKey" | "ctrlKey" | "key" | "metaKey">,
 ): boolean {

--- a/src/ui/tests/features/guacamole/guacamole-clipboard.test.ts
+++ b/src/ui/tests/features/guacamole/guacamole-clipboard.test.ts
@@ -1,25 +1,11 @@
 import { describe, expect, it, vi } from "vitest";
 import {
-  isFirefoxBrowser,
   isPasteShortcut,
   pasteTextToRemote,
   type GuacamoleClipboardClient,
 } from "../../../features/guacamole/guacamole-clipboard.js";
 
-describe("Guacamole Firefox clipboard fallback", () => {
-  it("only enables the native paste path for Firefox", () => {
-    expect(
-      isFirefoxBrowser(
-        "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:140.0) Gecko/20100101 Firefox/140.0",
-      ),
-    ).toBe(true);
-    expect(
-      isFirefoxBrowser(
-        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 Chrome/140.0.0.0",
-      ),
-    ).toBe(false);
-  });
-
+describe("Guacamole clipboard paste", () => {
   it("recognizes Ctrl+V and Command+V without intercepting Alt+V", () => {
     expect(
       isPasteShortcut({


### PR DESCRIPTION
将 Guacamole 的原生 paste 事件处理从 Firefox 专用改为所有浏览器通用，直接使用用户触发事件携带的文本更新远端剪贴板，再按顺序发送 Ctrl+V，避免 Safari 和 Chromium 拒绝非用户手势 clipboard.readText 后静默失效。保留原有自动剪贴板同步作为补充，并通过剪贴板单元测试、类型检查、lint 和生产构建，修复 Termix-SSH/Support#1212。