### PR TITLE
fix: show the full command line in the process inspector

### DIFF
--- a/src/ui/features/host-metrics/cards/managers/ProcessInspectorCard.tsx
+++ b/src/ui/features/host-metrics/cards/managers/ProcessInspectorCard.tsx
@@ -164,7 +164,8 @@ export function ProcessInspectorCard({ hostId }: { hostId: number | null }) {
               {depth > 0 && (
                 <span className="text-muted-foreground/40">└ </span>
               )}
-              {p.command}
+              {/* `comm` is capped at 15 chars by the kernel; the full command line is in args. */}
+              {p.args || p.command}
             </span>
             <button
               onClick={() => kill(p.pid, "TERM")}


### PR DESCRIPTION
## Summary

The Process Inspector's **CMD** column rendered `ps`'s `comm` field, which the kernel caps at 15 characters (`TASK_COMM_LEN`) — so long command names looked cut off regardless of column width (reported on Support as a request to "increase the character length of the cmd column").

The full command line (`args`) was already collected by the backend and only surfaced in the hover tooltip. The column now shows `args` (CSS-truncated with the tooltip kept), falling back to `comm` when a process has no args.

One-line change; `tsc` and prettier clean.