### PR TITLE
fix: authenticate unwatched hosts during the status probe

### DIFF
--- a/src/backend/hosts/metrics/host-status.test.ts
+++ b/src/backend/hosts/metrics/host-status.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  needsStatusPollAuthentication,
   statusAfterAuthentication,
   statusAfterReachabilityCheck,
 } from "./host-status.js";
@@ -20,5 +21,12 @@ describe("host availability status", () => {
   it("downgrades failed authentication without hiding reachability", () => {
     expect(statusAfterAuthentication(false, "online")).toBe("reachable");
     expect(statusAfterAuthentication(false, "offline")).toBe("offline");
+  });
+
+  it("authenticates in the status probe unless a metrics poll will do it", () => {
+    expect(needsStatusPollAuthentication(false, false)).toBe(true);
+    expect(needsStatusPollAuthentication(false, true)).toBe(true);
+    expect(needsStatusPollAuthentication(true, false)).toBe(true);
+    expect(needsStatusPollAuthentication(true, true)).toBe(false);
   });
 });

--- a/src/backend/hosts/metrics/host-status.ts
+++ b/src/backend/hosts/metrics/host-status.ts
@@ -15,3 +15,18 @@ export function statusAfterAuthentication(
   if (authenticated) return "online";
   return current === "offline" ? "offline" : "reachable";
 }
+
+/**
+ * Whether the cheap status probe must also authenticate over SSH.
+ *
+ * "online" means authenticated, and normally the metrics poll proves that.
+ * That poll only runs while someone is viewing the host, so an unwatched host
+ * with metrics enabled would otherwise never leave "reachable" - while a host
+ * with metrics disabled, whose probe always authenticates, shows online.
+ */
+export function needsStatusPollAuthentication(
+  metricsEnabled: boolean,
+  hasViewers: boolean,
+): boolean {
+  return !metricsEnabled || !hasViewers;
+}

--- a/src/backend/hosts/metrics/index.ts
+++ b/src/backend/hosts/metrics/index.ts
@@ -71,6 +71,7 @@ import {
 } from "./helpers.js";
 import {
   type HostStatus,
+  needsStatusPollAuthentication,
   statusAfterAuthentication,
   statusAfterReachabilityCheck,
 } from "./host-status.js";
@@ -581,7 +582,10 @@ class PollingManager {
       if (
         isOnline &&
         supportsMetrics(refreshedHost) &&
-        !config?.statsConfig.metricsEnabled
+        needsStatusPollAuthentication(
+          !!config?.statsConfig.metricsEnabled,
+          this.activeViewers.has(refreshedHost.id),
+        )
       ) {
         try {
           await withSshConnection(refreshedHost, async () => undefined);


### PR DESCRIPTION
## Summary

Reported on Support (2.7.1): every host shows **reachable** and none shows online.

Since 2.7.0, `online` means Termix authenticated over SSH and `reachable` means only the port answered. For hosts with metrics collection **enabled**, the status probe skipped authentication and relied on the metrics poll to prove it — but the metrics poll only runs while someone has the host's Dashboard / Host Metrics open (`registerMetricsViewer`). So an unwatched host with metrics on sat at `reachable` forever, while a host with metrics **off** (whose probe authenticates every tick since the 2.7.1 fix) showed `online`. Same host, different setting, opposite answer.

### Change

`needsStatusPollAuthentication(metricsEnabled, hasViewers)` in `host-status.ts`: the probe authenticates whenever no metrics poll will do it — i.e. metrics disabled, or nobody is viewing the host. Hosts being viewed keep the old behaviour (the metrics poll authenticates). Cost: one SSH connection per status interval for unwatched hosts, which is exactly what metrics-off hosts already paid.

Sidebar CPU/RAM still only appears while a host is being viewed; that is unchanged (and by design).

### Testing

Unit test for the decision table; full `host-status` tests pass; `tsc` and lint clean.