### PR TITLE
fix: recover expired dashboard metrics sessions

### DIFF
--- a/src/ui/api/host-metrics-status-api.ts
+++ b/src/ui/api/host-metrics-status-api.ts
@@ -256,10 +256,18 @@ export async function stopMetricsPolling(
 
 export async function sendMetricsHeartbeat(
   viewerSessionId: string,
-): Promise<void> {
+): Promise<boolean> {
   try {
-    await statsApi.post("/metrics/heartbeat", { viewerSessionId });
+    const response = await statsApi.post(
+      "/metrics/heartbeat",
+      { viewerSessionId },
+      { validateStatus: (status) => status === 200 || status === 404 },
+    );
+    return response.status !== 404;
   } catch (error) {
+    if (axios.isAxiosError(error) && error.response?.status === 404) {
+      return false;
+    }
     handleApiError(error, "send metrics heartbeat");
     throw error;
   }

--- a/src/ui/dashboard/DashboardTab.tsx
+++ b/src/ui/dashboard/DashboardTab.tsx
@@ -1366,7 +1366,10 @@ export function DashboardTab({
 
         try {
           const existing = newSessions.get(hostId);
-          if (!existing) {
+          if (existing && !(await sendMetricsHeartbeat(existing))) {
+            newSessions.delete(hostId);
+          }
+          if (!newSessions.has(hostId)) {
             const reg = await registerMetricsViewer(hostId);
             if (reg.skipped) return null;
             if (reg.success && reg.viewerSessionId) {
@@ -1489,8 +1492,14 @@ export function DashboardTab({
     if (!isVisible || viewerSessionsRef.current.size === 0) return;
     const heartbeat = setInterval(async () => {
       if (document.visibilityState === "hidden") return;
-      for (const [, sessionId] of viewerSessionsRef.current) {
-        sendMetricsHeartbeat(sessionId).catch(() => {});
+      for (const [hostId, sessionId] of viewerSessionsRef.current) {
+        sendMetricsHeartbeat(sessionId)
+          .then((alive) => {
+            if (!alive && viewerSessionsRef.current.get(hostId) === sessionId) {
+              viewerSessionsRef.current.delete(hostId);
+            }
+          })
+          .catch(() => {});
       }
     }, 30000);
     return () => clearInterval(heartbeat);

--- a/src/ui/tests/api/host-metrics-status-api.test.ts
+++ b/src/ui/tests/api/host-metrics-status-api.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const statsApiMock = vi.hoisted(() => ({ get: vi.fn() }));
+const statsApiMock = vi.hoisted(() => ({ get: vi.fn(), post: vi.fn() }));
 const remoteStatsApiMock = vi.hoisted(() => ({ get: vi.fn() }));
 const sshHostApiMock = vi.hoisted(() => ({ get: vi.fn() }));
 const resolveConnectionOriginMock = vi.hoisted(() => vi.fn());
@@ -24,6 +24,7 @@ vi.mock("@/lib/connection-origin", () => ({
 import {
   getAllServerStatuses,
   getServerMetricsById,
+  sendMetricsHeartbeat,
 } from "../../api/host-metrics-status-api";
 
 beforeEach(() => {
@@ -96,5 +97,23 @@ describe("metrics request coalescing", () => {
     expect(first).toEqual({ cpu: { percent: 12 } });
     expect(second).toBe(first);
     expect(statsApiMock.get).toHaveBeenCalledOnce();
+  });
+});
+
+describe("metrics viewer heartbeat", () => {
+  it("reports a swept viewer session without throwing or logging", async () => {
+    statsApiMock.post.mockResolvedValueOnce({ status: 404 });
+
+    await expect(sendMetricsHeartbeat("expired-viewer")).resolves.toBe(false);
+    expect(statsApiMock.post).toHaveBeenCalledWith(
+      "/metrics/heartbeat",
+      { viewerSessionId: "expired-viewer" },
+      { validateStatus: expect.any(Function) },
+    );
+  });
+
+  it("keeps a live viewer session", async () => {
+    statsApiMock.post.mockResolvedValueOnce({ status: 200 });
+    await expect(sendMetricsHeartbeat("live-viewer")).resolves.toBe(true);
   });
 });


### PR DESCRIPTION
Fixes Termix-SSH/Support#1222

## Summary
- treat a metrics heartbeat 404 as an expired viewer session instead of a generic request failure
- validate existing dashboard viewer sessions when metrics resume and re-register them in the same refresh
- remove asynchronously expired session IDs so later refreshes cannot stay wedged
- keep expected 404 responses out of the console/error path

## Validation
- `npx vitest run src/ui/tests/api/host-metrics-status-api.test.ts`
- `npm run type-check`
- targeted ESLint and Prettier checks
- `git diff --check`