### PR TITLE
fix: reset hosts virtualizer after editor round-trip

### DIFF
--- a/src/ui/sidebar/HostsPanel.tsx
+++ b/src/ui/sidebar/HostsPanel.tsx
@@ -1033,48 +1033,48 @@ export function HostsPanel({
         update={updateSidebarPrefs}
       />
 
-      <div
-        className={`flex flex-col flex-1 min-h-0 ${managerEditing ? "hidden" : ""}`}
-      >
-        <SidebarTree
-          children={
-            hostTree
-              ? groupHosts(
-                  applyFilters(
-                    sortHostTree(hostTree, sortKey, pinnedFirst),
-                    filterState,
-                  ),
-                  groupKey,
-                  groupLabel,
-                ).children
-              : []
-          }
-          onOpenTab={onOpenTab}
-          onEditHost={onEditHost}
-          onShareHost={(host) => setShareModalHost(host)}
-          onProxmoxDiscover={(host) => {
-            const cfg = host.proxmoxConfig;
-            setProxmoxHostId(Number(host.id));
-            setProxmoxDefaultCredentialId(cfg?.defaultCredentialId ?? null);
-            setProxmoxDefaultAuthType(cfg?.defaultAuthType ?? undefined);
-            setProxmoxDefaultUsername(undefined);
-            setProxmoxDialogOpen(true);
-          }}
-          query={hostSearch.trim().toLowerCase()}
-          selectionMode={selectionMode}
-          onToggleSelectionMode={toggleSelectionMode}
-          loading={loading}
-          onExportSelected={(ids) => {
-            setExportPreselection(new Set(ids));
-            setExportDialogOpen(true);
-          }}
-          arrangeLocked={arrangeLocked}
-          density={sidebarPrefs.display.density}
-          trayTrigger={sidebarPrefs.display.trayTrigger}
-          showTags={sidebarPrefs.display.showTags}
-          openOnDoubleClick={sidebarPrefs.display.openOnDoubleClick}
-        />
-      </div>
+      {!managerEditing && (
+        <div className="flex flex-col flex-1 min-h-0">
+          <SidebarTree
+            children={
+              hostTree
+                ? groupHosts(
+                    applyFilters(
+                      sortHostTree(hostTree, sortKey, pinnedFirst),
+                      filterState,
+                    ),
+                    groupKey,
+                    groupLabel,
+                  ).children
+                : []
+            }
+            onOpenTab={onOpenTab}
+            onEditHost={onEditHost}
+            onShareHost={(host) => setShareModalHost(host)}
+            onProxmoxDiscover={(host) => {
+              const cfg = host.proxmoxConfig;
+              setProxmoxHostId(Number(host.id));
+              setProxmoxDefaultCredentialId(cfg?.defaultCredentialId ?? null);
+              setProxmoxDefaultAuthType(cfg?.defaultAuthType ?? undefined);
+              setProxmoxDefaultUsername(undefined);
+              setProxmoxDialogOpen(true);
+            }}
+            query={hostSearch.trim().toLowerCase()}
+            selectionMode={selectionMode}
+            onToggleSelectionMode={toggleSelectionMode}
+            loading={loading}
+            onExportSelected={(ids) => {
+              setExportPreselection(new Set(ids));
+              setExportDialogOpen(true);
+            }}
+            arrangeLocked={arrangeLocked}
+            density={sidebarPrefs.display.density}
+            trayTrigger={sidebarPrefs.display.trayTrigger}
+            showTags={sidebarPrefs.display.showTags}
+            openOnDoubleClick={sidebarPrefs.display.openOnDoubleClick}
+          />
+        </div>
+      )}
 
       <div
         className={managerEditing ? "flex flex-col flex-1 min-h-0" : "hidden"}


### PR DESCRIPTION
Fixes Termix-SSH/Support#1221

Unmount the Hosts sidebar tree while the host editor is active so returning to the list creates a fresh virtualizer instead of reusing stale measured ranges from the hidden tree.

Validation:
- `npx eslint src/ui/sidebar/HostsPanel.tsx`
- `npm run type-check`
- `git diff --check`