### PR TITLE
fix: reflect live SSH sessions in host status

### DIFF
--- a/src/backend/hosts/metrics/index.ts
+++ b/src/backend/hosts/metrics/index.ts
@@ -53,6 +53,7 @@ import { registerHostMetricsHistoryRoutes } from "./history-routes.js";
 import { registerProxmoxStatsRoutes } from "./proxmox-stats-routes.js";
 import { registerProxmoxStatsHistoryRoutes } from "./proxmox-stats-history-routes.js";
 import { ProxmoxPollingManager } from "./proxmox-stats-polling.js";
+import { hostSessionStatus } from "../terminal/host-session-status.js";
 import { AlertEngine } from "./alert-engine.js";
 import {
   notifyAutomationMetrics,
@@ -206,11 +207,42 @@ class PollingManager {
   private statusInFlight = new Set<number>();
   private metricsInFlight = new Set<number>();
   private initialMetricsRequested = new Set<number>();
+  private terminalOnlineHosts = new Set<number>();
+  private metricsAuthenticatedHosts = new Set<number>();
+  private unsubscribeHostSessionStatus: () => void;
 
   constructor() {
+    this.unsubscribeHostSessionStatus = hostSessionStatus.subscribe(
+      (hostId, online) => this.setTerminalSessionOnline(hostId, online),
+    );
     this.viewerCleanupInterval = setInterval(() => {
       this.cleanupInactiveViewers();
     }, 60000);
+  }
+
+  private setTerminalSessionOnline(hostId: number, online: boolean): void {
+    if (online) {
+      this.terminalOnlineHosts.add(hostId);
+      const config = this.pollingConfigs.get(hostId);
+      if (config && isTcpPingEnabled(config.statsConfig)) {
+        this.statusStore.set(hostId, {
+          status: "online",
+          lastChecked: new Date().toISOString(),
+        });
+      }
+      return;
+    }
+
+    this.terminalOnlineHosts.delete(hostId);
+    if (
+      !this.metricsAuthenticatedHosts.has(hostId) &&
+      this.statusStore.get(hostId)?.status === "online"
+    ) {
+      this.statusStore.set(hostId, {
+        status: "reachable",
+        lastChecked: new Date().toISOString(),
+      });
+    }
   }
 
   /**
@@ -586,10 +618,13 @@ class PollingManager {
       // authenticates and can promote a host to "online") never runs for
       // them.
       const statusEntry: StatusEntry = {
-        status: statusAfterReachabilityCheck(
-          isOnline,
-          this.statusStore.get(refreshedHost.id)?.status,
-        ),
+        status:
+          isOnline && this.terminalOnlineHosts.has(refreshedHost.id)
+            ? "online"
+            : statusAfterReachabilityCheck(
+                isOnline,
+                this.statusStore.get(refreshedHost.id)?.status,
+              ),
         lastChecked: new Date().toISOString(),
       };
       this.statusStore.set(refreshedHost.id, statusEntry);
@@ -651,6 +686,7 @@ class PollingManager {
     try {
       const metrics = await collectMetrics(refreshedHost, () => {
         authenticated = true;
+        this.metricsAuthenticatedHosts.add(refreshedHost.id);
         this.statusStore.set(refreshedHost.id, {
           status: statusAfterAuthentication(true),
           lastChecked: new Date().toISOString(),
@@ -673,11 +709,14 @@ class PollingManager {
       authFailureTracker.reset(refreshedHost.id);
     } catch (error) {
       if (!authenticated) {
+        this.metricsAuthenticatedHosts.delete(refreshedHost.id);
         this.statusStore.set(refreshedHost.id, {
-          status: statusAfterAuthentication(
-            false,
-            this.statusStore.get(refreshedHost.id)?.status,
-          ),
+          status: this.terminalOnlineHosts.has(refreshedHost.id)
+            ? "online"
+            : statusAfterAuthentication(
+                false,
+                this.statusStore.get(refreshedHost.id)?.status,
+              ),
           lastChecked: new Date().toISOString(),
         });
       }
@@ -973,6 +1012,7 @@ class PollingManager {
   }
 
   destroy(): void {
+    this.unsubscribeHostSessionStatus();
     clearInterval(this.viewerCleanupInterval);
     for (const hostId of this.pollingConfigs.keys()) {
       this.stopPollingForHost(hostId);

--- a/src/backend/hosts/terminal/host-session-status.test.ts
+++ b/src/backend/hosts/terminal/host-session-status.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi } from "vitest";
+import { HostSessionStatus } from "./host-session-status.js";
+
+describe("HostSessionStatus", () => {
+  it("reports only the first connection and last disconnection per host", () => {
+    const status = new HostSessionStatus();
+    const listener = vi.fn();
+    status.subscribe(listener);
+
+    const closeFirst = status.register(7);
+    const closeSecond = status.register(7);
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener).toHaveBeenLastCalledWith(7, true);
+
+    closeFirst();
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    closeSecond();
+    expect(listener).toHaveBeenLastCalledWith(7, false);
+    expect(listener).toHaveBeenCalledTimes(2);
+  });
+
+  it("makes connection cleanup idempotent", () => {
+    const status = new HostSessionStatus();
+    const listener = vi.fn();
+    status.subscribe(listener);
+
+    const close = status.register(9);
+    close();
+    close();
+
+    expect(listener.mock.calls).toEqual([
+      [9, true],
+      [9, false],
+    ]);
+  });
+});

--- a/src/backend/hosts/terminal/host-session-status.ts
+++ b/src/backend/hosts/terminal/host-session-status.ts
@@ -1,0 +1,38 @@
+type HostSessionStatusListener = (hostId: number, online: boolean) => void;
+
+export class HostSessionStatus {
+  private counts = new Map<number, number>();
+  private listeners = new Set<HostSessionStatusListener>();
+
+  register(hostId: number): () => void {
+    const count = this.counts.get(hostId) ?? 0;
+    this.counts.set(hostId, count + 1);
+    if (count === 0) this.emit(hostId, true);
+
+    let active = true;
+    return () => {
+      if (!active) return;
+      active = false;
+
+      const next = (this.counts.get(hostId) ?? 1) - 1;
+      if (next > 0) {
+        this.counts.set(hostId, next);
+        return;
+      }
+
+      this.counts.delete(hostId);
+      this.emit(hostId, false);
+    };
+  }
+
+  subscribe(listener: HostSessionStatusListener): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  private emit(hostId: number, online: boolean): void {
+    for (const listener of this.listeners) listener(hostId, online);
+  }
+}
+
+export const hostSessionStatus = new HostSessionStatus();

--- a/src/backend/hosts/terminal/index.ts
+++ b/src/backend/hosts/terminal/index.ts
@@ -72,6 +72,7 @@ import {
   createWebSocketDuplex,
   waitForWebSocketOpen,
 } from "../cloudflare-websocket.js";
+import { hostSessionStatus } from "./host-session-status.js";
 
 interface ConnectToHostData {
   cols: number;
@@ -1615,9 +1616,11 @@ wss.on("connection", async (ws: WebSocket, req) => {
     let tailscaleCheckPending = false;
     let tailscaleForcePasswordAttempted = false;
     let isTailscaleRetrying = false;
+    let clearOnlineStatus: (() => void) | null = null;
 
     let resolvedHostData:
       | (Record<string, unknown> & {
+          id?: number;
           ip?: string;
           port?: number;
           username?: string;
@@ -1751,6 +1754,8 @@ wss.on("connection", async (ws: WebSocket, req) => {
         });
       }
     }
+
+    const statusHostId = resolvedHostData?.id ?? id;
 
     // Resolve credentials server-side when frontend doesn't provide them
     let resolvedCredentials = {
@@ -1921,6 +1926,7 @@ wss.on("connection", async (ws: WebSocket, req) => {
     });
 
     sshConn.on("ready", () => {
+      clearOnlineStatus ??= hostSessionStatus.register(statusHostId);
       clearTimeout(connectionTimeout);
       isTailscaleRetrying = false;
       if (tailscaleCheckPending) {
@@ -2816,6 +2822,9 @@ wss.on("connection", async (ws: WebSocket, req) => {
       if (isTailscaleRetrying) {
         return;
       }
+
+      clearOnlineStatus?.();
+      clearOnlineStatus = null;
 
       clearTimeout(connectionTimeout);
       sshLogger.info("SSH connection closed", {


### PR DESCRIPTION
A successful interactive SSH connection now promotes the host status to `online`, even when background metrics cannot authenticate with that host. The status falls back to `reachable` only after the last live session closes.

This keeps routine status polling TCP-only, so RADIUS/Duo-backed hosts do not receive periodic authentication prompts. It also preserves an `online` result proven independently by metrics collection. Synced desktop/server hosts use the resolved server-side host ID when publishing session state.

Validation:
- `npx eslint src/backend/hosts/terminal/host-session-status.ts src/backend/hosts/terminal/host-session-status.test.ts src/backend/hosts/terminal/index.ts src/backend/hosts/metrics/index.ts`
- `npx vitest run src/backend/tests/hosts/metrics src/backend/hosts/metrics src/backend/hosts/terminal/host-session-status.test.ts` (115 tests)
- `npm run type-check`
- `git diff --check`