### PR TITLE
test: update Guacamole toolbar display mock

### DIFF
--- a/src/ui/tests/features/guacamole/GuacamoleToolbar.test.tsx
+++ b/src/ui/tests/features/guacamole/GuacamoleToolbar.test.tsx
@@ -89,6 +89,7 @@ describe("GuacamoleToolbar Windows key", () => {
         sendMouse: vi.fn(),
         setClipboard: vi.fn(),
         getFilesystem: () => null,
+        uploadFile: vi.fn(),
         zoomIn: vi.fn(() => 1.25),
         zoomOut: vi.fn(() => 0.75),
         resetZoom: vi.fn(() => 1),


### PR DESCRIPTION
Follow-up integration fix for #1356 and #1357. The RDP upload change made `uploadFile` part of `GuacamoleDisplayHandle`; add it to the toolbar visibility test mock so the combined `dev-2.8.0` tree passes TypeScript validation.

Validation:
- `npx vitest run src/ui/tests/features/guacamole/GuacamoleToolbar.test.tsx`
- `npm run type-check`
- targeted ESLint