### PR TITLE
fix: allow exec on shared hosts

### DIFF
--- a/src/backend/database/routes/snippets.ts
+++ b/src/backend/database/routes/snippets.ts
@@ -12,8 +12,8 @@ import {
   resolveSnippetCommand,
 } from "./snippets-execution.js";
 import { logAudit, getRequestMeta } from "../../utils/audit-logger.js";
+import { resolveHostById } from "../../hosts/host-resolver.js";
 import {
-  createCurrentHostResolutionRepository,
   createCurrentRbacAccessRepository,
   createCurrentRoleRepository,
   createCurrentSnippetRepository,
@@ -587,32 +587,16 @@ router.post(
       }
 
       const { Client } = await import("ssh2");
-      const repository = createCurrentHostResolutionRepository();
-      const host = await repository.findHostById(parseInt(hostId), userId);
+      const host = await resolveHostById(parseInt(hostId), userId);
 
-      if (!host || host.userId !== userId) {
+      if (!host) {
         return res.status(404).json({ error: "Host not found" });
       }
 
-      let password = host.password;
-      let privateKey = host.key;
-      let passphrase = host.keyPassword;
-      let authType = host.authType;
-
-      if (host.credentialId) {
-        const cred = await repository.findCredentialByIdForUser(
-          host.credentialId as number,
-          userId,
-        );
-
-        if (cred) {
-          authType = (cred.authType || authType) as string;
-          password = (cred.password || undefined) as string | undefined;
-          privateKey = (cred.privateKey || cred.key || undefined) as
-            string | undefined;
-          passphrase = (cred.keyPassword || undefined) as string | undefined;
-        }
-      }
+      const password = host.password;
+      const privateKey = host.key;
+      const passphrase = host.keyPassword;
+      const authType = host.authType;
 
       const conn = new Client();
       let output = "";

--- a/src/backend/tests/database/routes/snippets-shared-host.test.ts
+++ b/src/backend/tests/database/routes/snippets-shared-host.test.ts
@@ -1,0 +1,20 @@
+import fs from "fs";
+import path from "path";
+import { describe, expect, it } from "vitest";
+
+describe("snippet execution host access", () => {
+  it("uses the shared-host-aware resolver", () => {
+    const source = fs.readFileSync(
+      path.resolve(__dirname, "../../../database/routes/snippets.ts"),
+      "utf8",
+    );
+    const executeRoute = source.slice(
+      source.indexOf('router.post(\n  "/execute"'),
+    );
+
+    expect(executeRoute).toContain(
+      "const host = await resolveHostById(parseInt(hostId), userId)",
+    );
+    expect(executeRoute).not.toContain("host.userId !== userId");
+  });
+});


### PR DESCRIPTION
Fixes Termix-SSH/Support#1226

Resolve command-execution targets through the shared-host-aware host resolver instead of requiring direct ownership. This makes `termix exec` honor the same `connect` permission as interactive SSH while preserving normal RBAC checks, owner-key decryption, shared credential rules, and removal of owner-only operational secrets.

The redundant direct credential lookup is removed because `resolveHostById` already returns the effective authentication material.

Validation:
- 15 snippet execution tests
- `npm run build:backend`
- targeted ESLint and Prettier
- `git diff --check`