### PR TITLE
fix(file-manager): align chunked upload contract

### DIFF
--- a/src/ui/api/ssh-file-operations-api.ts
+++ b/src/ui/api/ssh-file-operations-api.ts
@@ -461,19 +461,20 @@ export async function uploadSSHFile(
         const end = Math.min(start + CHUNK_SIZE_BYTES, file.size);
         const chunkBlob = file.slice(start, end);
 
-        const form = new FormData();
-        form.append("sessionId", sessionId);
-        form.append("path", path);
-        form.append("fileName", fileName);
-        form.append("chunkIndex", String(i));
-        form.append("totalChunks", String(totalChunks));
-        form.append("totalSize", String(file.size));
-        form.append("chunk", chunkBlob, fileName);
-
-        const response = await getFileManagerApiForSession(sessionId).postForm(
+        const response = await getFileManagerApiForSession(sessionId).post(
           "/ssh/uploadFileChunk",
-          form,
-          { timeout: 0 },
+          chunkBlob,
+          {
+            params: {
+              sessionId,
+              path,
+              fileName,
+              offset: start,
+              totalSize: file.size,
+            },
+            headers: { "Content-Type": "application/octet-stream" },
+            timeout: 0,
+          },
         );
 
         bytesSent = end;

--- a/src/ui/tests/api/ssh-file-operations-api.test.ts
+++ b/src/ui/tests/api/ssh-file-operations-api.test.ts
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const fileManagerApiMock = vi.hoisted(() => ({
+  post: vi.fn(async () => ({ data: { complete: false } })),
+}));
+
+vi.mock("@/main-axios", () => ({
+  authApi: { defaults: {} },
+  fileManagerApi: { defaults: {} },
+  getFileManagerApiForSession: () => fileManagerApiMock,
+  handleApiError: (error: unknown) => {
+    throw error;
+  },
+  setSessionOrigin: vi.fn(),
+  clearSessionOrigin: vi.fn(),
+}));
+vi.mock("@/lib/connection-origin", () => ({
+  resolveConnectionOrigin: vi.fn(),
+}));
+vi.mock("@/lib/frontend-logger", () => ({
+  fileLogger: {
+    info: vi.fn(),
+    success: vi.fn(),
+  },
+}));
+vi.mock("@/lib/file-list-request-cache", () => ({
+  getCachedFileList: vi.fn(),
+}));
+vi.mock("@/lib/file-content-request-cache", () => ({
+  getCachedFileContent: vi.fn(),
+  invalidateCachedFileContent: vi.fn(),
+}));
+
+import { uploadSSHFile } from "../../api/ssh-file-operations-api";
+
+describe("chunked SSH file uploads", () => {
+  beforeEach(() => {
+    fileManagerApiMock.post.mockClear();
+  });
+
+  it("sends raw chunks with the byte offset expected by the server", async () => {
+    const fileSize = 1.5 * 1024 * 1024 * 1024 + 1;
+    const file = {
+      size: fileSize,
+      slice: vi.fn(() => new Blob(["chunk"])),
+    } as unknown as File;
+
+    await uploadSSHFile("session-1", "/uploads", "archive.img", file);
+
+    expect(fileManagerApiMock.post).toHaveBeenCalledTimes(193);
+    expect(fileManagerApiMock.post).toHaveBeenNthCalledWith(
+      1,
+      "/ssh/uploadFileChunk",
+      expect.any(Blob),
+      {
+        params: {
+          sessionId: "session-1",
+          path: "/uploads",
+          fileName: "archive.img",
+          offset: 0,
+          totalSize: fileSize,
+        },
+        headers: { "Content-Type": "application/octet-stream" },
+        timeout: 0,
+      },
+    );
+    expect(fileManagerApiMock.post).toHaveBeenLastCalledWith(
+      "/ssh/uploadFileChunk",
+      expect.any(Blob),
+      expect.objectContaining({
+        params: expect.objectContaining({ offset: 1.5 * 1024 * 1024 * 1024 }),
+      }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- send large-file chunks as raw `application/octet-stream` bodies
- pass the byte offset and upload metadata through query parameters expected by the backend
- add a regression test covering the first and final chunk offsets

## Verification
- `npx vitest run --project frontend src/ui/tests/api/ssh-file-operations-api.test.ts`
- `npx prettier --check src/ui/api/ssh-file-operations-api.ts src/ui/tests/api/ssh-file-operations-api.test.ts`
- `npm run type-check`

Fixes Termix-SSH/Support#1232