### PR TITLE
fix(terminal): disable local echo on alternate screen

### DIFF
--- a/src/ui/features/terminal/Terminal.tsx
+++ b/src/ui/features/terminal/Terminal.tsx
@@ -906,6 +906,24 @@ const TerminalInner = forwardRef<TerminalHandle, SSHTerminalProps>(
       );
     }
 
+    function applyLocalEchoToOutput(output: string): string {
+      const alternateScreen = updateAlternateScreenMode(
+        output,
+        alternateScreenModeRef.current,
+      );
+      if (
+        alternateScreenModeRef.current ||
+        alternateScreen.isActive ||
+        alternateScreen.sawSequence
+      ) {
+        if (!alternateScreenModeRef.current && alternateScreen.isActive) {
+          localEchoRef.current?.reset();
+        }
+        return output;
+      }
+      return localEchoRef.current?.handleOutput(output) ?? output;
+    }
+
     async function resolvePasswordForPrompt(isSudoPrompt: boolean) {
       let passwordToFill = isSudoPrompt
         ? hostConfig.terminalConfig?.sudoPassword || hostConfig.password
@@ -1457,7 +1475,9 @@ const TerminalInner = forwardRef<TerminalHandle, SSHTerminalProps>(
             }
           }
           trackInput(data);
-          const predicted = localEchoRef.current?.handleInput(data);
+          const predicted = alternateScreenModeRef.current
+            ? ""
+            : localEchoRef.current?.handleInput(data);
           if (predicted) terminal.write(predicted);
           ws.send(JSON.stringify({ type: "input", data }));
         });
@@ -1497,8 +1517,7 @@ const TerminalInner = forwardRef<TerminalHandle, SSHTerminalProps>(
                 currentAutocompleteCommand.current = "";
               }
 
-              const output =
-                localEchoRef.current?.handleOutput(msg.data) ?? msg.data;
+              const output = applyLocalEchoToOutput(msg.data);
               terminal.write(formatTerminalOutput(output));
               // Strip ANSI escape codes before testing — newer sudo versions (Ubuntu 26.04+)
               // emit colored prompts with embedded escape sequences that break the regex.
@@ -1509,8 +1528,7 @@ const TerminalInner = forwardRef<TerminalHandle, SSHTerminalProps>(
               maybeOfferPasswordFill(strippedData);
             } else {
               const stringData = String(msg.data);
-              const output =
-                localEchoRef.current?.handleOutput(stringData) ?? stringData;
+              const output = applyLocalEchoToOutput(stringData);
               terminal.write(formatTerminalOutput(output));
             }
           } else if (msg.type === "error") {

--- a/src/ui/lib/terminal-local-echo.test.ts
+++ b/src/ui/lib/terminal-local-echo.test.ts
@@ -11,7 +11,14 @@ describe("TerminalLocalEcho", () => {
   it("rolls back a prediction when remote output differs", () => {
     const echo = new TerminalLocalEcho("on");
     echo.handleInput("a");
-    expect(echo.handleOutput("z")).toBe("\x1b[1D\x1b[Kz");
+    expect(echo.handleOutput("z")).toBe("\x1b[1D\x1b[1Xz");
+  });
+
+  it("only erases the predicted cells during rollback", () => {
+    const echo = new TerminalLocalEcho("on");
+    echo.handleInput("a");
+    echo.handleInput("b");
+    expect(echo.handleOutput("\x1b[C")).toBe("\x1b[2D\x1b[2X\x1b[C");
   });
 
   it("does not expose password input", () => {

--- a/src/ui/lib/terminal-local-echo.ts
+++ b/src/ui/lib/terminal-local-echo.ts
@@ -81,7 +81,7 @@ export class TerminalLocalEcho {
   private rollback() {
     const count = this.pending.filter((item) => item.predicted).length;
     this.pending = [];
-    return count > 0 ? `\x1b[${count}D\x1b[K` : "";
+    return count > 0 ? `\x1b[${count}D\x1b[${count}X` : "";
   }
 
   private stripAnsi(value: string) {


### PR DESCRIPTION
## Summary
- bypass local echo prediction while an alternate-screen application is active
- reset pending predictions when entering the alternate screen
- limit rollback erasure to the predicted cells instead of erasing the rest of the line

## Verification
- `npx vitest run --project frontend src/ui/lib/terminal-local-echo.test.ts`
- `npx prettier --check src/ui/lib/terminal-local-echo.ts src/ui/lib/terminal-local-echo.test.ts src/ui/features/terminal/Terminal.tsx`
- `npm run type-check`

Fixes Termix-SSH/Support#1230