### PR TITLE
fix(file-manager): make bulk uploads resilient

### DIFF
--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -663,7 +663,7 @@ http {
 
         location /ssh/file_manager/ {
             client_max_body_size 5G;
-            client_body_timeout 300s;
+            client_body_timeout 3600s;
 
             add_header X-Content-Type-Options nosniff always;
             add_header Cache-Control "no-store, no-cache, must-revalidate" always;
@@ -676,8 +676,8 @@ http {
             proxy_set_header X-Forwarded-Proto $proxy_x_forwarded_proto;
 
             proxy_connect_timeout 60s;
-            proxy_send_timeout 300s;
-            proxy_read_timeout 300s;
+            proxy_send_timeout 3600s;
+            proxy_read_timeout 3600s;
 
             proxy_request_buffering off;
             proxy_buffering off;
@@ -685,7 +685,7 @@ http {
 
         location /host/file_manager/ssh/ {
             client_max_body_size 5G;
-            client_body_timeout 300s;
+            client_body_timeout 3600s;
 
             add_header X-Content-Type-Options nosniff always;
             add_header Cache-Control "no-store, no-cache, must-revalidate" always;
@@ -698,8 +698,8 @@ http {
             proxy_set_header X-Forwarded-Proto $proxy_x_forwarded_proto;
 
             proxy_connect_timeout 60s;
-            proxy_send_timeout 300s;
-            proxy_read_timeout 300s;
+            proxy_send_timeout 3600s;
+            proxy_read_timeout 3600s;
 
             proxy_request_buffering off;
             proxy_buffering off;

--- a/src/backend/hosts/file-manager/content-routes.ts
+++ b/src/backend/hosts/file-manager/content-routes.ts
@@ -1337,6 +1337,20 @@ export function registerFileContentRoutes(
       let fileName: string | undefined;
       let uploadStartTime: number;
       let resolved = false;
+      let requestAborted = false;
+      let cleanupStarted = false;
+      let destroyUpload: (() => void) | undefined;
+
+      const abortUpload = () => {
+        if (req.complete || cleanupStarted) return;
+        requestAborted = true;
+        cleanupStarted = true;
+        destroyUpload?.();
+      };
+
+      req.once("aborted", abortUpload);
+      req.once("error", abortUpload);
+      req.once("close", abortUpload);
 
       const bb = Busboy({ headers: req.headers });
 
@@ -1401,10 +1415,27 @@ export function registerFileContentRoutes(
           getSessionSftp(sshConn)
             .then((sftp) => {
               const writeStream = sftp.createWriteStream(fullPath);
+              const removePartialFile = () => {
+                writeStream.destroy();
+                sftp.unlink(fullPath, (err) => {
+                  if (err) {
+                    fileLogger.error(
+                      "Failed to remove partial file after aborted upload:",
+                      err,
+                    );
+                  }
+                });
+              };
+              destroyUpload = removePartialFile;
+
+              if (requestAborted) {
+                removePartialFile();
+                return;
+              }
 
               writeStream.on("error", (err) => {
                 fileLogger.error("SFTP write stream error during upload:", err);
-                if (!resolved) {
+                if (!resolved && !requestAborted) {
                   resolved = true;
                   res
                     .status(500)
@@ -1432,30 +1463,10 @@ export function registerFileContentRoutes(
                 });
               });
 
-              writeStream.on("close", () => {
-                if (resolved) return;
-                resolved = true;
-                fileLogger.success("Streaming file upload completed", {
-                  operation: "file_upload_stream_complete",
-                  sessionId,
-                  userId,
-                  path: fullPath,
-                  duration: Date.now() - uploadStartTime,
-                });
-                res.json({
-                  message: "File uploaded successfully",
-                  path: fullPath,
-                  toast: {
-                    type: "success",
-                    message: `File uploaded: ${fullPath}`,
-                  },
-                });
-              });
-
               fileStream.on("error", (err) => {
                 fileLogger.error("File read stream error during upload:", err);
                 writeStream.destroy();
-                if (!resolved) {
+                if (!resolved && !requestAborted) {
                   resolved = true;
                   res
                     .status(500)
@@ -1470,7 +1481,7 @@ export function registerFileContentRoutes(
             .catch((err: Error) => {
               fileStream.resume();
               fileLogger.error("SFTP session error during stream upload:", err);
-              if (!resolved) {
+              if (!resolved && !requestAborted) {
                 resolved = true;
                 res.status(500).json({ error: `SFTP error: ${err.message}` });
               }
@@ -1480,7 +1491,7 @@ export function registerFileContentRoutes(
 
       bb.on("error", (err: Error) => {
         fileLogger.error("Busboy parse error during stream upload:", err);
-        if (!resolved) {
+        if (!resolved && !requestAborted) {
           resolved = true;
           res.status(500).json({ error: `Upload parse error: ${err.message}` });
         }

--- a/src/backend/hosts/file-manager/index.ts
+++ b/src/backend/hosts/file-manager/index.ts
@@ -3178,6 +3178,11 @@ try {
     }
   });
 
+  // Uploads are streamed and may legitimately take longer than Node's default
+  // five-minute request deadline. Connection liveness is handled by the proxy
+  // and socket-level timeouts instead of a total request duration cap.
+  server.requestTimeout = 0;
+
   server.on("error", (err) => {
     fileLogger.error("File Manager server error", err, {
       operation: "file_manager_server_error",

--- a/src/ui/features/file-manager/FileManager.tsx
+++ b/src/ui/features/file-manager/FileManager.tsx
@@ -93,7 +93,7 @@ import type {
   PendingSudoOperation,
   SSHConnectionError,
 } from "./file-manager-types.ts";
-import { formatFileSize } from "./file-manager-utils.ts";
+import { formatFileSize, runWithConcurrency } from "./file-manager-utils.ts";
 import {
   invalidateCachedFileList,
   peekCachedFileList,
@@ -1145,15 +1145,13 @@ function FileManagerContent({
     }
   }
 
-  function handleFilesDropped(fileList: FileList) {
+  async function handleFilesDropped(fileList: FileList) {
     if (!sshSessionId) {
       toast.error(t("fileManager.noSSHConnection"));
       return;
     }
 
-    Array.from(fileList).forEach((file) => {
-      handleUploadFile(file);
-    });
+    await runWithConcurrency(Array.from(fileList), 3, handleUploadFile);
   }
 
   async function handleUploadFile(file: File) {

--- a/src/ui/features/file-manager/file-manager-utils.ts
+++ b/src/ui/features/file-manager/file-manager-utils.ts
@@ -15,3 +15,21 @@ export function formatFileSize(bytes?: number): string {
     size < 10 && unitIndex > 0 ? size.toFixed(1) : Math.round(size).toString();
   return `${formattedSize} ${units[unitIndex]}`;
 }
+
+export async function runWithConcurrency<T>(
+  items: T[],
+  limit: number,
+  task: (item: T) => Promise<void>,
+): Promise<void> {
+  let nextIndex = 0;
+  const workerCount = Math.min(Math.max(1, limit), items.length);
+
+  await Promise.all(
+    Array.from({ length: workerCount }, async () => {
+      while (nextIndex < items.length) {
+        const item = items[nextIndex++];
+        await task(item);
+      }
+    }),
+  );
+}

--- a/src/ui/tests/features/file-manager/file-manager-utils.test.ts
+++ b/src/ui/tests/features/file-manager/file-manager-utils.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from "vitest";
-import { formatFileSize } from "../../../features/file-manager/file-manager-utils.js";
+import {
+  formatFileSize,
+  runWithConcurrency,
+} from "../../../features/file-manager/file-manager-utils.js";
 
 describe("formatFileSize", () => {
   it("returns a dash for undefined or null", () => {
@@ -29,5 +32,22 @@ describe("formatFileSize", () => {
   it("scales up to larger units", () => {
     expect(formatFileSize(1024 * 1024 * 1024)).toBe("1.0 GB");
     expect(formatFileSize(1024 * 1024 * 1024 * 1024)).toBe("1.0 TB");
+  });
+
+  it("limits concurrent work", async () => {
+    let active = 0;
+    let maxActive = 0;
+    const completed: number[] = [];
+
+    await runWithConcurrency([1, 2, 3, 4, 5], 2, async (item) => {
+      active += 1;
+      maxActive = Math.max(maxActive, active);
+      await new Promise((resolve) => setTimeout(resolve, 1));
+      completed.push(item);
+      active -= 1;
+    });
+
+    expect(maxActive).toBe(2);
+    expect(completed.sort()).toEqual([1, 2, 3, 4, 5]);
   });
 });


### PR DESCRIPTION
## Summary
- cap simultaneous browser uploads at three per selection
- remove the Node request-duration ceiling and extend file-manager proxy timeouts
- destroy aborted SFTP streams and remove partial remote files
- only report streamed uploads as complete after the writable stream finishes

## Verification
- `npx vitest run --project frontend src/ui/tests/features/file-manager/file-manager-utils.test.ts`
- `npx vitest run --project backend src/backend/tests/hosts/file-manager/content-routes.test.ts`
- `npm run lint -- --quiet`
- `npm run type-check`

Fixes Termix-SSH/Support#1231