### PR TITLE
fix(homepage): validate clock widget timezones

### DIFF
--- a/src/ui/features/homepage/clock-timezone.ts
+++ b/src/ui/features/homepage/clock-timezone.ts
@@ -1,0 +1,28 @@
+/** IANA zone names use underscores, but people type and paste spaces. */
+export function normalizeTimezone(timezone: string): string {
+  return timezone.trim().replace(/\s+/g, "_");
+}
+
+export function isValidTimezone(timezone: string): boolean {
+  try {
+    new Intl.DateTimeFormat("en-US", { timeZone: timezone });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Normalizes the timezone a user typed and reports whether it is usable.
+ * A blank field is valid: it means "use local time".
+ */
+export function validateClockTimezone(timezone: unknown): {
+  timezone?: string;
+  valid: boolean;
+} {
+  if (typeof timezone !== "string" || timezone.trim() === "") {
+    return { timezone: undefined, valid: true };
+  }
+  const normalized = normalizeTimezone(timezone);
+  return { timezone: normalized, valid: isValidTimezone(normalized) };
+}

--- a/src/ui/features/homepage/dialogs/ClockEditForm.tsx
+++ b/src/ui/features/homepage/dialogs/ClockEditForm.tsx
@@ -2,12 +2,16 @@ import { useTranslation } from "react-i18next";
 import { Input } from "@/components/input";
 import { Switch } from "@/components/switch";
 import type { ClockConfig, WidgetEditFormProps } from "@/types/homepage-types";
+import { validateClockTimezone } from "../clock-timezone";
 
 export function ClockEditForm({
   config,
   onChange,
 }: WidgetEditFormProps<ClockConfig>) {
   const { t } = useTranslation();
+
+  const invalidTimezone = !validateClockTimezone(config.timezone).valid;
+
   return (
     <div className="flex flex-col gap-3">
       <div className="flex flex-col gap-1">
@@ -20,8 +24,16 @@ export function ClockEditForm({
             onChange({ ...config, timezone: e.target.value || undefined })
           }
           placeholder="America/New_York (leave blank for local)"
-          className="h-8 text-sm"
+          aria-invalid={invalidTimezone}
+          className={
+            invalidTimezone ? "h-8 text-sm border-destructive" : "h-8 text-sm"
+          }
         />
+        {invalidTimezone && (
+          <p className="text-[10px] text-destructive">
+            {t("homepage.invalidTimezone")}
+          </p>
+        )}
       </div>
       <div className="flex items-center justify-between">
         <label className="text-xs font-medium text-foreground">

--- a/src/ui/features/homepage/dialogs/WidgetEditDialog.tsx
+++ b/src/ui/features/homepage/dialogs/WidgetEditDialog.tsx
@@ -76,6 +76,7 @@ import { ServiceGridEditForm } from "./ServiceGridEditForm";
 import { DashboardLinksEditForm } from "./DashboardLinksEditForm";
 import { SearchLinksEditForm } from "./SearchLinksEditForm";
 import { LinkTreeEditForm } from "./LinkTreeEditForm";
+import { validateClockTimezone } from "../clock-timezone";
 
 interface WidgetEditDialogProps {
   widget: CanvasWidget | null;
@@ -100,8 +101,20 @@ export function WidgetEditDialog({
 
   if (!widget) return null;
 
+  // Configs that need checking before they can be stored. The clock keeps the
+  // normalized zone rather than the raw input, so "America/New York" is filed
+  // as "America/New_York"; the form flags an unusable one and Save stays off.
+  const clockTimezone =
+    widget.typeId === "clock" ? validateClockTimezone(config.timezone) : null;
+  const configInvalid = clockTimezone ? !clockTimezone.valid : false;
+
   const handleSave = () => {
-    onSave(widget.id, title || null, config);
+    if (configInvalid) return;
+    onSave(
+      widget.id,
+      title || null,
+      clockTimezone ? { ...config, timezone: clockTimezone.timezone } : config,
+    );
     onClose();
   };
 
@@ -368,7 +381,7 @@ export function WidgetEditDialog({
           <Button variant="outline" size="sm" onClick={onClose}>
             {t("homepage.cancel")}
           </Button>
-          <Button size="sm" onClick={handleSave}>
+          <Button size="sm" onClick={handleSave} disabled={configInvalid}>
             {t("homepage.save")}
           </Button>
         </DialogFooter>

--- a/src/ui/features/homepage/widgets/ClockWidget.tsx
+++ b/src/ui/features/homepage/widgets/ClockWidget.tsx
@@ -8,9 +8,16 @@ import {
 } from "@/types/homepage-types";
 import { WidgetTitle } from "./WidgetTitle";
 import { usePageVisibleInterval } from "@/hooks/use-page-visible-interval";
+import { isValidTimezone } from "../clock-timezone";
 
 function ClockWidget({ widget, config }: WidgetComponentProps<ClockConfig>) {
-  const { timezone, showSeconds, format } = config;
+  const { showSeconds, format } = config;
+  // Configs saved before the edit dialog validated timezones can still hold an
+  // unusable one (e.g. "America/New York"), which makes toLocaleTimeString throw.
+  const timezone =
+    config.timezone && isValidTimezone(config.timezone)
+      ? config.timezone
+      : undefined;
   const [now, setNow] = useState(new Date());
 
   // Minute-level is enough without seconds; pause when the tab is backgrounded.

--- a/src/ui/locales/en.json
+++ b/src/ui/locales/en.json
@@ -227,6 +227,7 @@
     "icon": "Icon",
     "expanded": "Expanded by default",
     "timezone": "Timezone",
+    "invalidTimezone": "Invalid timezone. Use an IANA name such as America/New_York",
     "showSeconds": "Show seconds",
     "format12h": "12-hour",
     "format24h": "24-hour",

--- a/src/ui/tests/features/homepage/ClockTimezone.test.tsx
+++ b/src/ui/tests/features/homepage/ClockTimezone.test.tsx
@@ -1,0 +1,183 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, cleanup, fireEvent } from "@testing-library/react";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+import { ClockWidget } from "../../../features/homepage/widgets/ClockWidget";
+import { ClockEditForm } from "../../../features/homepage/dialogs/ClockEditForm";
+import {
+  normalizeTimezone,
+  validateClockTimezone,
+} from "../../../features/homepage/clock-timezone";
+import type { CanvasWidget, ClockConfig } from "@/types/homepage-types";
+
+const widget: CanvasWidget = {
+  id: 1,
+  typeId: "clock",
+  title: "Clock",
+  config: {},
+  x: 0,
+  y: 0,
+  w: 8,
+  h: 5,
+  zOrder: 0,
+};
+
+function renderClock(config: Partial<ClockConfig> = {}) {
+  return render(
+    <ClockWidget
+      widget={widget}
+      config={{ showSeconds: false, format: "24h", ...config }}
+    />,
+  );
+}
+
+function renderForm(config: Partial<ClockConfig> = {}) {
+  const onChange = vi.fn();
+  render(
+    <ClockEditForm
+      config={{ showSeconds: false, format: "24h", ...config }}
+      onChange={onChange}
+    />,
+  );
+  return {
+    onChange,
+    input: screen.getByPlaceholderText(/America\/New_York/) as HTMLInputElement,
+  };
+}
+
+afterEach(cleanup);
+
+describe("ClockWidget timezone handling", () => {
+  it("renders instead of throwing when a saved config holds an invalid timezone", () => {
+    // Regression: "America/New York" (space, not underscore) made
+    // toLocaleTimeString throw a RangeError and took down the whole canvas.
+    expect(() => renderClock({ timezone: "America/New York" })).not.toThrow();
+    expect(screen.queryByText("America/New York")).toBeNull();
+  });
+
+  it("falls back to local time formatting for an invalid timezone", () => {
+    renderClock({ timezone: "Not/AZone" });
+    const local = new Date().toLocaleTimeString(undefined, {
+      hour: "2-digit",
+      minute: "2-digit",
+      hour12: false,
+    });
+    expect(screen.getByText(local)).toBeTruthy();
+  });
+
+  it("keeps and displays a valid timezone", () => {
+    renderClock({ timezone: "America/New_York" });
+    expect(screen.getByText("America/New_York")).toBeTruthy();
+  });
+
+  it("shows no timezone label when none is configured", () => {
+    const { container } = renderClock();
+    expect(
+      container.querySelector('[class*="text-muted-foreground/60"]'),
+    ).toBeNull();
+  });
+
+  it("formats in the configured timezone, not the host timezone", () => {
+    renderClock({ timezone: "Asia/Tokyo" });
+    const tokyo = new Date().toLocaleTimeString(undefined, {
+      hour: "2-digit",
+      minute: "2-digit",
+      hour12: false,
+      timeZone: "Asia/Tokyo",
+    });
+    expect(screen.getByText(tokyo)).toBeTruthy();
+  });
+});
+
+describe("validateClockTimezone", () => {
+  it("turns spaces into underscores", () => {
+    expect(validateClockTimezone("America/New York")).toEqual({
+      timezone: "America/New_York",
+      valid: true,
+    });
+  });
+
+  it("trims surrounding whitespace", () => {
+    expect(validateClockTimezone("  Europe/Paris  ")).toEqual({
+      timezone: "Europe/Paris",
+      valid: true,
+    });
+  });
+
+  it("reports an unusable zone as invalid but still returns it normalized", () => {
+    expect(validateClockTimezone("Not/AZone")).toEqual({
+      timezone: "Not/AZone",
+      valid: false,
+    });
+  });
+
+  it("treats blank input as clearing the timezone", () => {
+    expect(validateClockTimezone("   ")).toEqual({
+      timezone: undefined,
+      valid: true,
+    });
+    expect(validateClockTimezone(undefined)).toEqual({
+      timezone: undefined,
+      valid: true,
+    });
+  });
+
+  it("normalizes every run of whitespace", () => {
+    expect(normalizeTimezone("America/Argentina/Buenos  Aires")).toBe(
+      "America/Argentina/Buenos_Aires",
+    );
+  });
+});
+
+describe("ClockEditForm", () => {
+  it("stores what the user typed without rewriting it mid-edit", () => {
+    const { onChange, input } = renderForm();
+    fireEvent.change(input, { target: { value: "America/Los Angeles" } });
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ timezone: "America/Los Angeles" }),
+    );
+  });
+
+  it("flags an unusable zone the same way FolderMetadataDialog flags a duplicate name", () => {
+    const { input } = renderForm({ timezone: "Not/AZone" });
+    expect(input.getAttribute("aria-invalid")).toBe("true");
+    expect(input.className).toContain("border-destructive");
+    expect(screen.getByText("homepage.invalidTimezone")).toBeTruthy();
+  });
+
+  it("accepts a zone typed with a space, since it is normalized before checking", () => {
+    const { input } = renderForm({ timezone: "America/New York" });
+    expect(input.getAttribute("aria-invalid")).toBe("false");
+    expect(screen.queryByText("homepage.invalidTimezone")).toBeNull();
+  });
+
+  it("says nothing about an empty field", () => {
+    const { input } = renderForm();
+    expect(input.getAttribute("aria-invalid")).toBe("false");
+    expect(screen.queryByText("homepage.invalidTimezone")).toBeNull();
+  });
+
+  it("clears the timezone when the field is emptied", () => {
+    const { onChange, input } = renderForm({ timezone: "Europe/Paris" });
+    fireEvent.change(input, { target: { value: "" } });
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ timezone: undefined }),
+    );
+  });
+
+  it("preserves the other clock settings when the timezone changes", () => {
+    const { onChange, input } = renderForm({
+      showSeconds: true,
+      format: "12h",
+    });
+    fireEvent.change(input, { target: { value: "UTC" } });
+    expect(onChange).toHaveBeenCalledWith({
+      timezone: "UTC",
+      showSeconds: true,
+      format: "12h",
+    });
+  });
+});

--- a/src/ui/tests/features/homepage/WidgetEditDialogClock.test.tsx
+++ b/src/ui/tests/features/homepage/WidgetEditDialogClock.test.tsx
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, cleanup, fireEvent } from "@testing-library/react";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+import { WidgetEditDialog } from "../../../features/homepage/dialogs/WidgetEditDialog";
+import type { CanvasWidget } from "@/types/homepage-types";
+
+function clockWidget(timezone?: string): CanvasWidget {
+  return {
+    id: 7,
+    typeId: "clock",
+    title: "Clock",
+    config: { timezone, showSeconds: true, format: "24h" },
+    x: 0,
+    y: 0,
+    w: 8,
+    h: 5,
+    zOrder: 0,
+  };
+}
+
+function open(timezone?: string) {
+  const onSave = vi.fn();
+  const onClose = vi.fn();
+  render(
+    <WidgetEditDialog
+      widget={clockWidget(timezone)}
+      onSave={onSave}
+      onClose={onClose}
+    />,
+  );
+  return {
+    onSave,
+    onClose,
+    input: screen.getByPlaceholderText(/America\/New_York/) as HTMLInputElement,
+    save: screen
+      .getByText("homepage.save")
+      .closest("button") as HTMLButtonElement,
+  };
+}
+
+afterEach(cleanup);
+
+describe("WidgetEditDialog clock timezone validation", () => {
+  it("stores the normalized zone when the user typed a space", () => {
+    const { onSave, onClose, input, save } = open();
+    fireEvent.change(input, { target: { value: "America/New York" } });
+    expect(screen.queryByText("homepage.invalidTimezone")).toBeNull();
+    expect(save.disabled).toBe(false);
+
+    fireEvent.click(save);
+
+    expect(onSave).toHaveBeenCalledWith(
+      7,
+      "Clock",
+      expect.objectContaining({ timezone: "America/New_York" }),
+    );
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("disables Save while the zone is unusable", () => {
+    const { onSave, onClose, input, save } = open();
+    fireEvent.change(input, { target: { value: "Not/AZone" } });
+
+    expect(save.disabled).toBe(true);
+    expect(screen.getByText("homepage.invalidTimezone")).toBeTruthy();
+
+    fireEvent.click(save);
+    expect(onSave).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("re-enables Save once the zone becomes usable", () => {
+    const { onSave, input, save } = open();
+    fireEvent.change(input, { target: { value: "Not/AZone" } });
+    expect(save.disabled).toBe(true);
+
+    fireEvent.change(input, { target: { value: "Asia/Tokyo" } });
+    expect(save.disabled).toBe(false);
+    expect(screen.queryByText("homepage.invalidTimezone")).toBeNull();
+
+    fireEvent.click(save);
+    expect(onSave).toHaveBeenCalledWith(
+      7,
+      "Clock",
+      expect.objectContaining({ timezone: "Asia/Tokyo" }),
+    );
+  });
+
+  it("saves a blank field as no timezone", () => {
+    const { onSave, input, save } = open("Europe/Paris");
+    fireEvent.change(input, { target: { value: "  " } });
+    fireEvent.click(save);
+
+    expect(onSave).toHaveBeenCalledWith(
+      7,
+      "Clock",
+      expect.objectContaining({ timezone: undefined }),
+    );
+  });
+});


### PR DESCRIPTION
# Overview

- [x] Fixed: an invalid timezone on a Clock widget threw `RangeError` during render and took the homepage canvas down with it
- [x] Added: timezone validation in the Clock edit dialog, with an inline message and a disabled Save
- [x] Updated: `ClockWidget` now falls back to local time for configs already stored with an unusable zone

# Changes Made

- `src/ui/features/homepage/clock-timezone.ts` (new) — `normalizeTimezone`, `isValidTimezone` and `validateClockTimezone`, shared by the widget and the dialog so the check lives in one place.
- `ClockEditForm.tsx` — flags an unusable zone the same way `FolderMetadataDialog` flags a duplicate folder name: `aria-invalid`, `border-destructive`, and an inline `text-destructive` message.
- `WidgetEditDialog.tsx` — one `typeId === "clock"` branch: Save is disabled while the zone is unusable, `handleSave` guards again, and the normalized zone is what gets stored, so `America/New York` is saved as `America/New_York` instead of being rejected. No other widget form is touched.
- `ClockWidget.tsx` — validates before formatting, falling back to local time (and hiding the zone label) for configs saved before this change, so an existing broken homepage recovers on its own.
- `en.json` — one new key, `homepage.invalidTimezone`.
- Tests — `ClockTimezone.test.tsx` and `WidgetEditDialogClock.test.tsx`, 38 assertions covering the widget fallback, the normalizer, the inline error, and Save being blocked and then re-enabled.

# Related Issues

- Related to Termix-SSH/Support#1238

# Screenshots / Demos

Invalid zone: the field is flagged and Save is disabled, so it can no longer be stored.

<img width="452" height="388" alt="invalid zone, error shown, Save disabled" src="https://github.com/user-attachments/assets/2f6e9b89-e9e5-4309-8842-4bc1892e33a5" />

A space instead of an underscore is accepted and normalized on save — no error, Save enabled.

<img width="452" height="388" alt="space accepted, Save enabled" src="https://github.com/user-attachments/assets/65d19d0c-3169-4994-a37c-8898322b6028" />

Saved result — the widget renders the zone as `America/New_York`:

<img width="424" height="271" alt="widget rendering America/New_York" src="https://github.com/user-attachments/assets/f5eaf021-59dd-41f6-8801-7232c2c7896f" />

Before this change, that same config threw during render and took the canvas down with it:

```
RangeError: Invalid time zone specified: America/New York
```

# Checklist

- [x] Code follows project style guidelines
- [x] Supports mobile and desktop UI/app (if applicable)
- [x] I have read [Contributing.md](https://github.com/Termix-SSH/Termix/blob/main/CONTRIBUTING.md)
- [x] This is not a translation request. See [docs](https://docs.termix.site/translations)
