### PR TITLE
fix(remote-sync): expose local login notification

### DIFF
--- a/electron/preload.js
+++ b/electron/preload.js
@@ -9,6 +9,7 @@ const ALLOWED_INVOKE_CHANNELS = new Set([
   "get-remote-sync-jwt",
   "get-remote-sync-status",
   "get-remote-sync-user-info",
+  "notify-local-login",
   "remote-sync-now",
   "save-desktop-settings",
   "save-remote-sync-config",

--- a/scripts/electron-security-boundary.test.ts
+++ b/scripts/electron-security-boundary.test.ts
@@ -18,4 +18,9 @@ describe("Electron security boundary", () => {
       "invoke: (channel, ...args) => ipcRenderer.invoke(channel, ...args)",
     );
   });
+
+  it("allows the renderer to hand the local session to Remote Sync", () => {
+    expect(main).toContain('ipcMain.handle("notify-local-login"');
+    expect(preload).toContain('"notify-local-login"');
+  });
 });


### PR DESCRIPTION
## Summary
- allow the existing `notify-local-login` IPC request through the preload allowlist
- cover both the main-process handler and preload exposure in the Electron security boundary test

## Verification
- `npx vitest run --project scripts scripts/electron-security-boundary.test.ts`
- `npm run type-check`
- `npm run lint -- --quiet`
- Prettier and diff checks

Fixes Termix-SSH/Support#1241