### PR TITLE
fix(hosts): preserve connection origin in editor

### DIFF
--- a/src/ui/sidebar/HostManagerData.ts
+++ b/src/ui/sidebar/HostManagerData.ts
@@ -83,6 +83,7 @@ export function sshHostToHost(h: SSHHostWithStatus): Host {
     sortOrder: h.sortOrder ?? null,
     macAddress: h.macAddress,
     wolBroadcastAddress: h.wolBroadcastAddress,
+    connectionOrigin: h.connectionOrigin ?? null,
     enableSsh: h.enableSsh != null ? h.enableSsh : isSshHost,
     enableTerminal:
       h.enableTerminal ?? (h.enableSsh != null ? h.enableSsh : isSshHost),

--- a/src/ui/tests/sidebar/HostManagerData.test.ts
+++ b/src/ui/tests/sidebar/HostManagerData.test.ts
@@ -16,6 +16,22 @@ describe("sshHostToHost", () => {
     expect(host.wolBroadcastAddress).toBe("192.168.0.255");
   });
 
+  it.each(["local", "remote"] as const)(
+    "preserves the %s connection origin for editing",
+    (connectionOrigin) => {
+      const host = sshHostToHost({
+        id: 1,
+        name: "server",
+        ip: "192.168.0.10",
+        port: 22,
+        username: "root",
+        connectionOrigin,
+      } as SSHHostWithStatus);
+
+      expect(host.connectionOrigin).toBe(connectionOrigin);
+    },
+  );
+
   it("preserves remote shared-host identity for local connection auth", () => {
     const host = sshHostToHost({
       id: -12,


### PR DESCRIPTION
## Summary
- preserve `connectionOrigin` when mapping API hosts into the Host Manager model
- cover both local and remote values with a mapper regression test

## Verification
- `npx vitest run --project frontend src/ui/tests/sidebar/HostManagerData.test.ts`
- `npm run type-check`
- `npm run lint -- --quiet`
- Prettier and diff checks

Fixes Termix-SSH/Support#1239