### PR TITLE
Fix passkey login in desktop iframe

### DIFF
--- a/src/ui/auth/ElectronLoginForm.tsx
+++ b/src/ui/auth/ElectronLoginForm.tsx
@@ -317,7 +317,7 @@ export function ElectronLoginForm({
           className="w-full h-full border-0"
           title="Server Authentication"
           sandbox="allow-same-origin allow-scripts allow-forms allow-popups allow-popups-to-escape-sandbox allow-storage-access-by-user-activation allow-top-navigation allow-top-navigation-by-user-activation allow-modals allow-downloads"
-          allow="clipboard-read; clipboard-write"
+          allow="clipboard-read; clipboard-write; publickey-credentials-get; publickey-credentials-create"
         />
       </div>
     </div>

--- a/src/ui/tests/auth/ElectronLoginForm.test.tsx
+++ b/src/ui/tests/auth/ElectronLoginForm.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { ElectronLoginForm } from "../../auth/ElectronLoginForm";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+describe("ElectronLoginForm", () => {
+  it("delegates WebAuthn permissions to the embedded login page", () => {
+    render(
+      <ElectronLoginForm
+        serverUrl="https://termix.example.com"
+        onAuthSuccess={vi.fn()}
+        onChangeServer={vi.fn()}
+      />,
+    );
+
+    const permissions = screen
+      .getByTitle("Server Authentication")
+      .getAttribute("allow");
+
+    expect(permissions).toContain("publickey-credentials-get");
+    expect(permissions).toContain("publickey-credentials-create");
+  });
+});


### PR DESCRIPTION
## Summary

- delegate WebAuthn get/create permissions to the embedded Electron login page
- cover the iframe permission contract with a focused frontend regression test

Fixes Termix-SSH/Support#1244

## Validation

- `npx vitest run --project frontend src/ui/tests/auth/ElectronLoginForm.test.tsx`
- `npx eslint src/ui/auth/ElectronLoginForm.tsx src/ui/tests/auth/ElectronLoginForm.test.tsx`
- `npx prettier --check src/ui/auth/ElectronLoginForm.tsx src/ui/tests/auth/ElectronLoginForm.test.tsx`
- `npx tsc --noEmit`
- `git diff --check`