### PR TITLE
Fix Proxmox discovery for sudo users

### DIFF
--- a/src/backend/database/routes/proxmox.ts
+++ b/src/backend/database/routes/proxmox.ts
@@ -18,6 +18,7 @@ import {
   serializeProxmoxJumpHosts,
 } from "./proxmox-jump-hosts.js";
 import { isSafeNodeName } from "../../hosts/proxmox-shared.js";
+import { execElevated } from "../../hosts/metrics/managers/exec-elevated.js";
 
 const router = express.Router();
 const proxmoxLogger = logger;
@@ -69,6 +70,26 @@ function execCommand(
       });
     });
   });
+}
+
+export async function execPveshCommand(
+  client: SSHClient,
+  command: string,
+  sudoPassword: string | undefined,
+  timeoutMs = 25000,
+): Promise<string> {
+  if (!sudoPassword) {
+    return execCommand(client, command, timeoutMs);
+  }
+
+  const result = await execElevated(client, command, sudoPassword, {
+    forceSudo: true,
+    timeoutMs,
+  });
+  if (result.code !== 0) {
+    throw new Error(result.stderr || `Command exited with code ${result.code}`);
+  }
+  return result.stdout;
 }
 
 // Parse all IPs from LXC net config, then return the one matching the preferred prefix.
@@ -407,9 +428,10 @@ async function discoverProxmoxGuestsForHost(
       throw error;
     }
 
-    const resourcesJson = await execCommand(
+    const resourcesJson = await execPveshCommand(
       client,
       "pvesh get /cluster/resources --output-format json 2>/dev/null",
+      host.sudoPassword,
     );
 
     let resources: Array<Record<string, unknown>>;
@@ -458,9 +480,10 @@ async function discoverProxmoxGuestsForHost(
       if (g.type === "lxc") {
         let configIp: string | null = null;
         try {
-          const cfgJson = await execCommand(
+          const cfgJson = await execPveshCommand(
             client,
             `pvesh get /nodes/${g.node}/lxc/${g.vmid}/config --output-format json 2>/dev/null`,
+            host.sudoPassword,
             25000,
           );
           configIp = parseLxcIp(JSON.parse(cfgJson), config.preferredPrefixes);
@@ -472,9 +495,10 @@ async function discoverProxmoxGuestsForHost(
         // Fall back to the live interface list for running containers.
         if (g.status === "running") {
           try {
-            const ifRaw = await execCommand(
+            const ifRaw = await execPveshCommand(
               client,
               `pvesh get /nodes/${g.node}/lxc/${g.vmid}/interfaces --output-format json 2>/dev/null`,
+              host.sudoPassword,
               12000,
             );
             const data = JSON.parse(ifRaw);
@@ -504,9 +528,10 @@ async function discoverProxmoxGuestsForHost(
       }
       if (g.type === "qemu" && g.status === "running") {
         try {
-          const ifJson = await execCommand(
+          const ifJson = await execPveshCommand(
             client,
             `pvesh get /nodes/${g.node}/qemu/${g.vmid}/agent/network-get-interfaces --output-format json 2>/dev/null`,
+            host.sudoPassword,
             12000,
           );
           const data = JSON.parse(ifJson);

--- a/src/backend/tests/database/routes/proxmox-sudo.test.ts
+++ b/src/backend/tests/database/routes/proxmox-sudo.test.ts
@@ -1,0 +1,49 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Client } from "ssh2";
+
+const execElevated = vi.fn();
+vi.mock("../../../hosts/metrics/managers/exec-elevated.js", () => ({
+  execElevated: (...args: unknown[]) => execElevated(...args),
+}));
+
+import { execPveshCommand } from "../../../database/routes/proxmox.js";
+
+const client = {} as Client;
+
+describe("Proxmox discovery sudo execution", () => {
+  beforeEach(() => {
+    execElevated.mockReset();
+  });
+
+  it("forces pvesh through the stored sudo credentials", async () => {
+    execElevated.mockResolvedValue({
+      stdout: '[{"type":"qemu"}]',
+      stderr: "",
+      code: 0,
+      usedSudo: true,
+    });
+
+    await expect(
+      execPveshCommand(client, "pvesh get /cluster/resources", "secret", 12000),
+    ).resolves.toBe('[{"type":"qemu"}]');
+    expect(execElevated).toHaveBeenCalledWith(
+      client,
+      "pvesh get /cluster/resources",
+      "secret",
+      { forceSudo: true, timeoutMs: 12000 },
+    );
+  });
+
+  it("surfaces a failed elevated pvesh command", async () => {
+    execElevated.mockResolvedValue({
+      stdout: "",
+      stderr: "pvesh failed",
+      code: 255,
+      usedSudo: true,
+    });
+
+    await expect(
+      execPveshCommand(client, "pvesh get /cluster/resources", "secret"),
+    ).rejects.toThrow("pvesh failed");
+  });
+});


### PR DESCRIPTION
## Summary

- run every Proxmox discovery `pvesh` read through the existing elevated-command path when the host has a stored sudo password
- preserve direct execution for root hosts without sudo credentials
- cover forced elevation and failed-command propagation with focused regression tests

Fixes Termix-SSH/Support#1246

## Validation

- `npx vitest run --project backend src/backend/tests/database/routes/proxmox-sudo.test.ts src/backend/tests/hosts/metrics/managers/exec-elevated.test.ts`
- `npx eslint src/backend/database/routes/proxmox.ts src/backend/tests/database/routes/proxmox-sudo.test.ts`
- `npx prettier --check src/backend/database/routes/proxmox.ts src/backend/tests/database/routes/proxmox-sudo.test.ts`
- `npx tsc --noEmit`
- `git diff --check`