### PR TITLE
Fix permanent file-transfer completion toasts

### DIFF
--- a/src/ui/features/file-manager/FileManager.tsx
+++ b/src/ui/features/file-manager/FileManager.tsx
@@ -1268,7 +1268,7 @@ function FileManagerContent({
 
       toast.success(
         t("fileManager.fileDownloadedSuccessfully", { name: file.name }),
-        { id: toastId },
+        { id: toastId, duration: undefined },
       );
     } catch (error: unknown) {
       const err = error instanceof Error ? error : null;
@@ -1282,10 +1282,13 @@ function FileManagerContent({
             ip: currentHost?.ip,
             port: currentHost?.port,
           }),
-          { id: toastId },
+          { id: toastId, duration: undefined },
         );
       } else {
-        toast.error(t("fileManager.failedToDownloadFile"), { id: toastId });
+        toast.error(t("fileManager.failedToDownloadFile"), {
+          id: toastId,
+          duration: undefined,
+        });
       }
       console.error("Download failed:", error);
     }

--- a/src/ui/features/file-manager/transferProgressMonitor.tsx
+++ b/src/ui/features/file-manager/transferProgressMonitor.tsx
@@ -226,6 +226,7 @@ function showDefaultCompletionToast(
         id: toastId,
         description: metrics || undefined,
         className: TOAST_CLASS,
+        duration: undefined,
       },
     );
     return;
@@ -236,6 +237,7 @@ function showDefaultCompletionToast(
     id: toastId,
     description: metrics || undefined,
     className: TOAST_CLASS,
+    duration: undefined,
   });
 }
 
@@ -319,6 +321,7 @@ export function beginTransferProgressMonitoring(
       toast.error(`${t("transfer.transferError")}: ${message}`, {
         id: progressToast,
         className: TOAST_CLASS,
+        duration: undefined,
       });
       markTransferNotified(transferId);
       throw error;

--- a/src/ui/tests/features/file-manager/transfer-progress-toast.test.ts
+++ b/src/ui/tests/features/file-manager/transfer-progress-toast.test.ts
@@ -1,0 +1,36 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const success = vi.fn();
+vi.mock("sonner", () => ({
+  toast: {
+    success: (...args: unknown[]) => success(...args),
+  },
+}));
+
+vi.mock("@/main-axios.ts", () => ({}));
+vi.mock("../../../features/file-manager/transferNotificationStore.ts", () => ({
+  markTransferNotified: vi.fn(),
+}));
+
+import { showTransferCompletionToast } from "../../../features/file-manager/transferProgressMonitor.tsx";
+
+describe("transfer completion toast", () => {
+  beforeEach(() => {
+    success.mockReset();
+  });
+
+  it("clears the infinite duration inherited from the progress toast", () => {
+    showTransferCompletionToast(
+      { transferId: "transfer-1", status: "completed" },
+      ((key: string) => key) as never,
+      "progress-toast",
+    );
+
+    expect(success).toHaveBeenCalledWith("transfer.transferSuccess", {
+      id: "progress-toast",
+      description: undefined,
+      className: "!pr-10 !pl-4 transfer-progress-toast",
+      duration: undefined,
+    });
+  });
+});

--- a/src/ui/tests/features/file-manager/transfer-progress-toast.test.ts
+++ b/src/ui/tests/features/file-manager/transfer-progress-toast.test.ts
@@ -21,7 +21,11 @@ describe("transfer completion toast", () => {
 
   it("clears the infinite duration inherited from the progress toast", () => {
     showTransferCompletionToast(
-      { transferId: "transfer-1", status: "completed" },
+      {
+        transferId: "transfer-1",
+        status: "success",
+        phase: "verifying",
+      },
       ((key: string) => key) as never,
       "progress-toast",
     );


### PR DESCRIPTION
## Summary

- clear the infinite progress duration when download success/error replaces a loading toast
- reset the duration for completed, partial, and polling-error transfer notifications
- cover completion-toast option merging with a focused regression test

Fixes Termix-SSH/Support#1255

## Validation

- `npx vitest run --project frontend src/ui/tests/features/file-manager/transfer-progress-toast.test.ts`
- `npx eslint src/ui/features/file-manager/FileManager.tsx src/ui/features/file-manager/transferProgressMonitor.tsx src/ui/tests/features/file-manager/transfer-progress-toast.test.ts` (0 errors; one pre-existing unused `windowId` warning in FileManager)
- `npx prettier --check ...`
- `npx tsc --noEmit`
- `git diff --check`