### PR TITLE
Fix clearing SSH key type to auto-detect

### DIFF
--- a/src/backend/database/routes/host-normalizers.ts
+++ b/src/backend/database/routes/host-normalizers.ts
@@ -14,6 +14,15 @@ export function isOptionalBoolean(
   return value === undefined || typeof value === "boolean";
 }
 
+export function applyHostKeyTypeUpdate(
+  target: Record<string, unknown>,
+  keyType: unknown,
+): void {
+  if (keyType !== undefined) {
+    target.keyType = keyType || null;
+  }
+}
+
 const PROTOCOL_ENABLE_FIELDS = [
   "enableSsh",
   "enableRdp",

--- a/src/backend/database/routes/host.ts
+++ b/src/backend/database/routes/host.ts
@@ -33,6 +33,7 @@ import {
   createCurrentSharedHostAuthOverrideRepository,
 } from "../repositories/factory.js";
 import {
+  applyHostKeyTypeUpdate,
   containsOwnerPrivateAuthUpdate,
   isNonEmptyString,
   isOptionalBoolean,
@@ -1173,9 +1174,7 @@ router.put(
       if (keyPassword !== undefined) {
         sshDataObj.keyPassword = keyPassword || null;
       }
-      if (keyType) {
-        sshDataObj.keyType = keyType;
-      }
+      applyHostKeyTypeUpdate(sshDataObj, keyType);
       sshDataObj.password = password || null;
     } else if (effectiveAuthType === "credential") {
       sshDataObj.password = password || null;

--- a/src/backend/tests/database/routes/host-normalizers.test.ts
+++ b/src/backend/tests/database/routes/host-normalizers.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import {
+  applyHostKeyTypeUpdate,
   containsOwnerPrivateAuthUpdate,
   isNonEmptyString,
   isOptionalBoolean,
@@ -11,6 +12,24 @@ import {
   stripSensitiveFields,
   transformHostResponse,
 } from "../../../database/routes/host-normalizers.js";
+
+describe("applyHostKeyTypeUpdate", () => {
+  it("clears an existing key type when auto-detect sends null", () => {
+    const update: Record<string, unknown> = { keyType: "ssh-ed25519" };
+
+    applyHostKeyTypeUpdate(update, null);
+
+    expect(update.keyType).toBeNull();
+  });
+
+  it("does not change the key type when the field is omitted", () => {
+    const update: Record<string, unknown> = { keyType: "ssh-ed25519" };
+
+    applyHostKeyTypeUpdate(update, undefined);
+
+    expect(update.keyType).toBe("ssh-ed25519");
+  });
+});
 
 describe("containsOwnerPrivateAuthUpdate", () => {
   it("detects owner-only SSH auth fields, including explicit clears", () => {


### PR DESCRIPTION
## Summary

- treat an explicit `keyType: null` update as a request to restore automatic key detection
- continue preserving the current key type when the field is omitted
- cover both update semantics with focused backend regression tests

Fixes Termix-SSH/Support#1247

## Validation

- `npx vitest run --project backend src/backend/tests/database/routes/host-normalizers.test.ts` (39 passed)
- `npx eslint src/backend/database/routes/host.ts src/backend/database/routes/host-normalizers.ts src/backend/tests/database/routes/host-normalizers.test.ts`
- `npx prettier --check ...`
- `npx tsc --noEmit`
- `git diff --check`