### PR TITLE
fix(terminal): suppress local echo for contextual password prompts

### DIFF
--- a/src/ui/lib/terminal-local-echo.test.ts
+++ b/src/ui/lib/terminal-local-echo.test.ts
@@ -21,11 +21,23 @@ describe("TerminalLocalEcho", () => {
     expect(echo.handleOutput("\x1b[C")).toBe("\x1b[2D\x1b[2X\x1b[C");
   });
 
-  it("does not expose password input", () => {
+  it.each([
+    ["split prompt", ["Pass", "word: "]],
+    ["sudo prompt", ["[sudo] password for alice: "]],
+    ["ssh-keygen prompt", ["Enter passphrase (empty for no passphrase): "]],
+    ["passwd prompt", ["New password: "]],
+  ])("does not expose input after a %s", (_name, chunks) => {
     const echo = new TerminalLocalEcho("on");
-    expect(echo.handleOutput("Pass")).toBe("Pass");
-    expect(echo.handleOutput("word: ")).toBe("word: ");
+    for (const chunk of chunks) expect(echo.handleOutput(chunk)).toBe(chunk);
     expect(echo.handleInput("s")).toBe("");
+  });
+
+  it("does not treat ordinary password text as a hidden-input prompt", () => {
+    const echo = new TerminalLocalEcho("on");
+    expect(echo.handleOutput("Your password has expired\r\n$ ")).toBe(
+      "Your password has expired\r\n$ ",
+    );
+    expect(echo.handleInput("s")).toBe("s");
   });
 
   it("does not predict control input, paste, or wide characters", () => {

--- a/src/ui/lib/terminal-local-echo.ts
+++ b/src/ui/lib/terminal-local-echo.ts
@@ -1,7 +1,7 @@
 export type LocalEchoMode = "off" | "auto" | "on";
 
 const PASSWORD_PROMPT =
-  /(?:password|passphrase|verification code|one[- ]time|otp|token)\s*[:：]?\s*$/i;
+  /(?:password|passphrase|verification code|one[- ]time|otp|token)(?:[^\r\n:：]{0,160})?[:：]\s*$/i;
 const SAFE_INPUT = /^[\x20-\x7e]$/;
 
 type PendingCharacter = { value: string; sentAt: number; predicted: boolean };


### PR DESCRIPTION
## Summary
- recognize contextual hidden-input prompts such as `[sudo] password for user:`
- recognize ssh-keygen passphrase prompts with explanatory text
- keep ordinary password-related terminal output from suspending local echo

## Verification
- `npx vitest run src/ui/lib/terminal-local-echo.test.ts` (11 passed)
- `npx eslint src/ui/lib/terminal-local-echo.ts src/ui/lib/terminal-local-echo.test.ts`
- `npx tsc -b --force --pretty false`

Fixes Termix-SSH/Support#1258