### PR TITLE
fix(backend): report port conflicts on the service ports

### DIFF
--- a/src/backend/hosts/docker/index.ts
+++ b/src/backend/hosts/docker/index.ts
@@ -16,6 +16,7 @@ import {
   getRequestUserId,
   registerDockerSshRoutes,
 } from "./routes.js";
+import { listenOnServicePort } from "../../utils/service-listen.js";
 
 const sshLogger = logger;
 
@@ -47,14 +48,20 @@ registerDockerContainerRoutes(app, {
 
 const PORT = 30007;
 
-app.listen(PORT, "127.0.0.1", async () => {
-  try {
-    await authManager.initialize();
-  } catch (err) {
-    sshLogger.error("Failed to initialize Docker backend", err, {
-      operation: "startup",
-    });
-  }
+listenOnServicePort({
+  app,
+  port: PORT,
+  logger: sshLogger,
+  serviceName: "docker",
+  onListening: async () => {
+    try {
+      await authManager.initialize();
+    } catch (err) {
+      sshLogger.error("Failed to initialize Docker backend", err, {
+        operation: "startup",
+      });
+    }
+  },
 });
 
 process.on("SIGINT", () => {

--- a/src/backend/hosts/file-manager/index.ts
+++ b/src/backend/hosts/file-manager/index.ts
@@ -68,6 +68,7 @@ import { registerFileDownloadRoutes } from "./download-routes.js";
 import { registerFileActionRoutes } from "./action-routes.js";
 import { applyAgentAuth } from "../terminal-auth-helpers.js";
 import { applyCACertIfPresent } from "./ca-cert-auth.js";
+import { listenOnServicePort } from "../../utils/service-listen.js";
 
 /**
  * The host id came from whichever database the client is displaying. If this
@@ -3168,14 +3169,20 @@ process.on("SIGTERM", () => {
 const PORT = 30004;
 
 try {
-  const server = app.listen(PORT, "127.0.0.1", async () => {
-    try {
-      await authManager.initialize();
-    } catch (err) {
-      fileLogger.error("Failed to initialize AuthManager", err, {
-        operation: "auth_init_error",
-      });
-    }
+  const server = listenOnServicePort({
+    app,
+    port: PORT,
+    logger: fileLogger,
+    serviceName: "file-manager",
+    onListening: async () => {
+      try {
+        await authManager.initialize();
+      } catch (err) {
+        fileLogger.error("Failed to initialize AuthManager", err, {
+          operation: "auth_init_error",
+        });
+      }
+    },
   });
 
   // Uploads are streamed and may legitimately take longer than Node's default

--- a/src/backend/hosts/metrics/index.ts
+++ b/src/backend/hosts/metrics/index.ts
@@ -97,6 +97,7 @@ import {
   requestQueue,
   statusPollLimiter,
 } from "./state.js";
+import { listenOnServicePort } from "../../utils/service-listen.js";
 
 const authManager = AuthManager.getInstance();
 const permissionManager = PermissionManager.getInstance();
@@ -3103,20 +3104,26 @@ process.on("SIGTERM", () => {
 });
 
 const PORT = 30005;
-app.listen(PORT, "127.0.0.1", async () => {
-  try {
-    await authManager.initialize();
-  } catch (err) {
-    statsLogger.error("Failed to initialize AuthManager", err, {
-      operation: "auth_init_error",
-    });
-  }
+listenOnServicePort({
+  app,
+  port: PORT,
+  logger: statsLogger,
+  serviceName: "metrics",
+  onListening: async () => {
+    try {
+      await authManager.initialize();
+    } catch (err) {
+      statsLogger.error("Failed to initialize AuthManager", err, {
+        operation: "auth_init_error",
+      });
+    }
 
-  setInterval(
-    () => {
-      authFailureTracker.cleanup();
-      pollingBackoff.cleanup();
-    },
-    10 * 60 * 1000,
-  );
+    setInterval(
+      () => {
+        authFailureTracker.cleanup();
+        pollingBackoff.cleanup();
+      },
+      10 * 60 * 1000,
+    );
+  },
 });

--- a/src/backend/hosts/tmux/index.ts
+++ b/src/backend/hosts/tmux/index.ts
@@ -43,6 +43,7 @@ import {
 } from "./monitor-helpers.js";
 import type { SSHHost, AuthenticatedRequest } from "../../../types/index.js";
 import { getTmuxAuthBehavior } from "./auth-utils.js";
+import { listenOnServicePort } from "../../utils/service-listen.js";
 
 const PANE_ID_RE = /^%\d+$/;
 // tmux session names cannot contain ":" or "."; keep to a conservative
@@ -923,4 +924,9 @@ app.put("/tmux_monitor/:hostId/tags", async (req, res) => {
 });
 
 const PORT = 30010;
-app.listen(PORT, "127.0.0.1", () => {});
+listenOnServicePort({
+  app,
+  port: PORT,
+  logger: sshLogger,
+  serviceName: "tmux",
+});

--- a/src/backend/hosts/tunnel/index.ts
+++ b/src/backend/hosts/tunnel/index.ts
@@ -22,6 +22,7 @@ import {
 
 import { registerTunnelRoutes } from "./routes.js";
 import { initializeAutoStartTunnels } from "./manager.js";
+import { attachServicePortConflictHandler } from "../../utils/service-listen.js";
 
 const authManager = AuthManager.getInstance();
 
@@ -99,6 +100,8 @@ c2sRelayWss.on("connection", (ws, req) => {
     }
   });
 });
+
+attachServicePortConflictHandler(server, PORT, tunnelLogger, "tunnel");
 
 server.listen(PORT, "127.0.0.1", () => {
   setTimeout(() => {

--- a/src/backend/services/dashboard.ts
+++ b/src/backend/services/dashboard.ts
@@ -13,6 +13,7 @@ import {
   createCurrentRoleRepository,
 } from "../database/repositories/factory.js";
 import { DataCrypto } from "../utils/data-crypto.js";
+import { listenOnServicePort } from "../utils/service-listen.js";
 
 const app = express();
 app.set("trust proxy", "loopback");
@@ -318,12 +319,18 @@ app.delete("/activity/reset", async (req, res) => {
 app.use("/service-links", dashboardServiceLinksRouter);
 
 const PORT = 30006;
-app.listen(PORT, "127.0.0.1", async () => {
-  try {
-    await authManager.initialize();
-  } catch (err) {
-    dashboardLogger.error("Failed to initialize AuthManager", err, {
-      operation: "auth_init_error",
-    });
-  }
+listenOnServicePort({
+  app,
+  port: PORT,
+  logger: dashboardLogger,
+  serviceName: "dashboard",
+  onListening: async () => {
+    try {
+      await authManager.initialize();
+    } catch (err) {
+      dashboardLogger.error("Failed to initialize AuthManager", err, {
+        operation: "auth_init_error",
+      });
+    }
+  },
 });

--- a/src/backend/services/homepage.ts
+++ b/src/backend/services/homepage.ts
@@ -3,6 +3,8 @@ import cookieParser from "cookie-parser";
 import { createCorsMiddleware } from "../utils/cors-config.js";
 import { createCompressionMiddleware } from "../utils/compression-config.js";
 import { AuthManager } from "../utils/auth-manager.js";
+import { listenOnServicePort } from "../utils/service-listen.js";
+import { homepageLogger } from "../utils/logger.js";
 import { homepageItemsRouter } from "../database/routes/homepage-items-routes.js";
 import { homepageLayoutRouter } from "../database/routes/homepage-layout-routes.js";
 import { homepageFaviconRouter } from "../database/routes/homepage-favicon-routes.js";
@@ -33,6 +35,11 @@ app.use("/homepage/rss", homepageRssRouter);
 app.use("/homepage/ping", homepagePingRouter);
 app.use("/homepage/proxy", homepageProxyRouter);
 
-app.listen(PORT, "127.0.0.1", () => {});
+listenOnServicePort({
+  app,
+  port: PORT,
+  logger: homepageLogger,
+  serviceName: "homepage",
+});
 
 export default app;

--- a/src/backend/tests/utils/service-listen.test.ts
+++ b/src/backend/tests/utils/service-listen.test.ts
@@ -1,0 +1,146 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import path from "node:path";
+import express from "express";
+import http from "http";
+import type { AddressInfo } from "net";
+import { listenOnServicePort } from "../../utils/service-listen.js";
+import { Logger } from "../../utils/logger.js";
+
+function testLogger() {
+  const logger = new Logger("TEST", "🧪", "#000000");
+  return {
+    logger,
+    error: vi.spyOn(logger, "error").mockImplementation(() => {}),
+  };
+}
+
+function occupyPort(): Promise<{ port: number; release: () => void }> {
+  return new Promise((resolve) => {
+    const blocker = http.createServer();
+    blocker.listen(0, "127.0.0.1", () => {
+      resolve({
+        port: (blocker.address() as AddressInfo).port,
+        release: () => blocker.close(),
+      });
+    });
+  });
+}
+
+const servers: http.Server[] = [];
+
+afterEach(() => {
+  while (servers.length) servers.pop()?.close();
+  vi.restoreAllMocks();
+});
+
+describe("listenOnServicePort", () => {
+  it("starts the service and reports listening on a free port", async () => {
+    const { logger, error } = testLogger();
+    const onListening = vi.fn();
+
+    const server = listenOnServicePort({
+      app: express(),
+      port: 0,
+      logger,
+      serviceName: "test",
+      onListening,
+    });
+    servers.push(server);
+
+    await vi.waitFor(() => expect(onListening).toHaveBeenCalledOnce());
+    expect(server.listening).toBe(true);
+    expect(error).not.toHaveBeenCalled();
+  });
+
+  // The bug this helper exists for: express's app.listen(port, host, cb)
+  // registers cb as the server's error handler too, so a port conflict
+  // invoked the "service started" callback and emitted nothing at all.
+  it("does not report the service as started when the port is taken", async () => {
+    const { port, release } = await occupyPort();
+    const { logger } = testLogger();
+    const onListening = vi.fn();
+    const exit = vi
+      .spyOn(process, "exit")
+      .mockImplementation(() => undefined as never);
+
+    const server = listenOnServicePort({
+      app: express(),
+      port,
+      logger,
+      serviceName: "test",
+      onListening,
+    });
+    servers.push(server);
+
+    await vi.waitFor(() => expect(exit).toHaveBeenCalledWith(1));
+    expect(onListening).not.toHaveBeenCalled();
+    release();
+  });
+
+  it("names the conflicting port so the desktop can surface it", async () => {
+    const { port, release } = await occupyPort();
+    const { logger, error } = testLogger();
+    vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+
+    servers.push(
+      listenOnServicePort({
+        app: express(),
+        port,
+        logger,
+        serviceName: "metrics",
+      }),
+    );
+
+    await vi.waitFor(() => expect(error).toHaveBeenCalled());
+    const [message, , context] = error.mock.calls[0];
+    expect(message).toContain(String(port));
+    expect(context).toMatchObject({
+      operation: "service_port_conflict",
+      port,
+      service: "metrics",
+    });
+    release();
+  });
+
+  it("leaves any other listen error to the process-level handlers", async () => {
+    const { logger } = testLogger();
+    const exit = vi
+      .spyOn(process, "exit")
+      .mockImplementation(() => undefined as never);
+    const server = listenOnServicePort({
+      app: express(),
+      port: 0,
+      logger,
+      serviceName: "test",
+    });
+    servers.push(server);
+
+    const notPortConflict = Object.assign(new Error("boom"), { code: "EPERM" });
+    expect(() => server.emit("error", notPortConflict)).toThrow("boom");
+    expect(exit).not.toHaveBeenCalled();
+  });
+});
+
+// express's app.listen() swallows a bind failure by design (see
+// service-listen.ts), so no service may reach for it again.
+describe("backend services", () => {
+  function sourceFiles(dir: string): string[] {
+    return readdirSync(dir).flatMap((entry) => {
+      const full = path.join(dir, entry);
+      if (statSync(full).isDirectory()) {
+        return entry === "tests" ? [] : sourceFiles(full);
+      }
+      return full.endsWith(".ts") ? [full] : [];
+    });
+  }
+
+  it("never bind a port with express's app.listen()", () => {
+    const offenders = sourceFiles(path.resolve("src/backend"))
+      // service-listen.ts names the call only to document why it is banned.
+      .filter((file) => !file.endsWith(path.join("utils", "service-listen.ts")))
+      .filter((file) => /\bapp\.listen\(/.test(readFileSync(file, "utf8")));
+
+    expect(offenders).toEqual([]);
+  });
+});

--- a/src/backend/utils/service-listen.ts
+++ b/src/backend/utils/service-listen.ts
@@ -1,0 +1,84 @@
+import http from "http";
+import type { RequestListener } from "http";
+import type { Logger } from "./logger.js";
+
+interface ServiceListenOptions {
+  app: RequestListener;
+  port: number;
+  logger: Logger;
+  /** Used only to identify the service in the conflict log. */
+  serviceName: string;
+  host?: string;
+  onListening?: () => void;
+}
+
+/**
+ * Starts one of the backend's fixed-port services.
+ *
+ * Express's `app.listen(port, host, callback)` registers that callback as
+ * the server's `error` handler as well as its `listening` handler:
+ *
+ *   if (typeof args[args.length - 1] === 'function') {
+ *     var done = args[args.length - 1] = once(args[args.length - 1])
+ *     server.once('error', done)
+ *   }
+ *
+ * so a port conflict called the service's "started" callback with an
+ * EADDRINUSE error as its argument and emitted nothing. Since none of the
+ * services read that argument, a failed bind was indistinguishable from a
+ * successful one: the service logged that it had started, ran its
+ * initialisation, and served nothing, with no error anywhere in the logs.
+ *
+ * Building the server here keeps `listening` and `error` separate. A port
+ * conflict is treated the way database.ts already treats one on the main
+ * HTTP port -- reported with the port that was taken, then exit -- rather
+ * than leaving the backend up with one feature silently missing. Exiting
+ * also gives the desktop app the classified failure it already knows how
+ * to surface, so the user is told which port to free.
+ */
+/**
+ * Reports a port conflict on an already-built service server and stops the
+ * backend, for services that must own their `http.Server` (the tunnel
+ * service attaches a WebSocket upgrade handler to it, for example) and so
+ * cannot go through {@link listenOnServicePort}.
+ */
+export function attachServicePortConflictHandler(
+  server: http.Server,
+  port: number,
+  logger: Logger,
+  serviceName: string,
+): void {
+  server.on("error", (err: NodeJS.ErrnoException) => {
+    if (err.code === "EADDRINUSE") {
+      logger.error(
+        `Port ${port} is already in use. Kill the existing process and retry.`,
+        err,
+        {
+          operation: "service_port_conflict",
+          port,
+          service: serviceName,
+        },
+      );
+      // process.exit() does not return, so nothing below runs in
+      // production; the explicit return keeps that obvious and keeps the
+      // rethrow below reachable only for genuinely unexpected errors.
+      process.exit(1);
+      return;
+    }
+    throw err;
+  });
+}
+
+export function listenOnServicePort({
+  app,
+  port,
+  logger,
+  serviceName,
+  host = "127.0.0.1",
+  onListening,
+}: ServiceListenOptions): http.Server {
+  const server = http.createServer(app);
+  attachServicePortConflictHandler(server, port, logger, serviceName);
+  server.listen(port, host, onListening);
+  return server;
+}


### PR DESCRIPTION
# Overview

A port conflict on any of the backend's secondary service ports (`30003`–`30012`) started nothing and reported nothing. The backend logged a healthy start, the app loaded, and the affected feature was silently dead for the session.

- [x] Added: `src/backend/utils/service-listen.ts` — `listenOnServicePort()` and `attachServicePortConflictHandler()`
- [x] Fixed: all seven fixed-port services now detect and report a conflict instead of pretending to start
- [x] Added: unit tests plus a source-level guard so no service reaches for `app.listen()` again

# Changes Made

Express's `app.listen(port, host, callback)` registers the caller's callback as the server's `error` handler as well as its `listening` handler:

```js
// express/lib/application.js
app.listen = function listen() {
  var server = http.createServer(this)
  var args = slice.call(arguments)
  if (typeof args[args.length - 1] === 'function') {
    var done = args[args.length - 1] = once(args[args.length - 1])
    server.once('error', done)      // <-- the "started" callback
  }
  return server.listen.apply(server, args)
}
```

So a bind failure calls the success callback with the error as its first argument and emits nothing:

```
$ node -e 'require("express")().listen(30005,"127.0.0.1",(...a)=>console.log(a.map(x=>x&&x.code)))'
[ 'EADDRINUSE' ]
```

Every service wrote that callback as `() => {…}` and ignored its arguments, so a failed bind was indistinguishable from a successful one. This also explains why only `30001` ever behaved sensibly — `database.ts` does not use `app.listen()`; it builds the server and attaches a real `error` handler.

Worth calling out explicitly: **adding `.on("error")` to the services would not have fixed this.** Express consumes the event through `once('error', done)` before any later handler could run. The callback has to stop being passed to `listen()` at all, which is what the new helper does.

`listenOnServicePort()` builds the server so `listening` and `error` stay separate, and handles a conflict the way `database.ts` already does — name the port, then exit — rather than running on with one feature missing. Exiting is also what lets the desktop tell the user which port to free, via the classifier added in #1382. The tunnel service owns its own `http.Server` for the WebSocket upgrade path, so it takes the same handler through `attachServicePortConflictHandler()`.

Converted: tunnel `30003`, file-manager `30004`, metrics `30005`, dashboard `30006`, docker `30007`, tmux `30010`, homepage `30012`.

**Deliberately out of scope:** the WebSocket services on `30002`, `30008`, `30009` and `30011` use `new WebSocketServer({ host, port })` rather than `app.listen()`. They are not affected by this express behaviour and do emit an error, so they are left alone here; happy to fold them in if you would rather have one uniform policy.

Behaviour note: `file-manager` previously logged a conflict via a handler registered *after* `app.listen()` but kept running. It now exits like the others. Its existing runtime `server.on("error")` logging and its `requestTimeout = 0` are unchanged.

# Related Issues

- Fixes Termix-SSH/Support#1260 — cross-repo, so GitHub's closing keywords do not apply here; the issue needs closing by hand on merge, the same way Support#1254 was handled for #1382.
- Follow-up to #1382 / Termix-SSH/Support#1254, which fixed the main-port case.

# Screenshots / Demos

Verified on a real `linux-unpacked` build with `127.0.0.1:30005` held by another process.

**Before** — backend reports success, app loads, metrics silently dead, and `grep -icE "eaddrinuse|uncaught|30005"` across the backend log, the Electron main log and stdout returns `0`:

```
[SUCCESS] [🚀] Termix backend started successfully [op:backend_init_complete,duration:927ms]
```

```
127.0.0.1:30001  termix          127.0.0.1:30005  ← the squatter. termix never got it.
…                                127.0.0.1:30006  termix
```

**After** — same build, same conflict:

```
[backend:stderr] [ERROR] [📊] Port 30005 is already in use. Kill the existing process and retry. [op:service_port_conflict]
Error: listen EADDRINUSE: address already in use 127.0.0.1:30005
Backend process exited with code 1, signal null
Backend failure classified as: port-in-use
```

and the desktop shows, naming the real port:

> **Termix's local server could not start**
> Port 30005 is already in use by another program. This is usually a Termix Docker container or a leftover Termix process from a previous session. Close it, then restart Termix.

**Regression, all ports free:** all 12 service ports bind, `0` conflicts logged, UI renders normally, and `curl 127.0.0.1:30005` returns `401` — the metrics service is up and authenticating.

Tests: 5 new. Four cover the helper (starts and reports listening on a free port; does **not** invoke the ready callback when the port is taken; logs the port and `operation: "service_port_conflict"`; leaves non-`EADDRINUSE` errors to the process handlers). The fifth scans `src/backend` and fails if any file reintroduces `app.listen(`.

`npx vitest run` goes from 2708 to 2713 passing with no new failures — the 119 pre-existing failures on `dev-2.8.0` are unrelated and I confirmed that baseline by stashing. `tsc -b` clean, `npm run lint` 0 errors with the warning count unchanged at 102, `prettier --check` clean.

# Checklist

- [x] Code follows project style guidelines
- [x] Supports mobile and desktop UI/app (if applicable)
- [x] I have read [Contributing.md](https://github.com/Termix-SSH/Termix/blob/main/CONTRIBUTING.md)
- [x] This is not a translation request. See [docs](https://docs.termix.site/translations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
