### PR TITLE
feat(local-terminal): add copy/paste support

### DIFF
--- a/src/ui/features/local-terminal/LocalTerminal.tsx
+++ b/src/ui/features/local-terminal/LocalTerminal.tsx
@@ -1,10 +1,19 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { FitAddon } from "@xterm/addon-fit";
+import { ClipboardAddon } from "@xterm/addon-clipboard";
 import { useXTerm } from "react-xtermjs";
+import { toast } from "sonner";
+import { useTranslation } from "react-i18next";
 import { useTheme } from "@/components/theme-provider";
 import { resolveTermixThemeColors } from "@/features/terminal/terminal-theme";
 import { DEFAULT_TERMINAL_CONFIG, TERMINAL_FONTS } from "@/lib/terminal-themes";
 import { ensureTerminalFontsLoaded } from "@/features/terminal/terminal-global-styles";
+import {
+  handleTerminalClipboardKeyEvent,
+  createTerminalContextMenuHandler,
+} from "@/features/terminal/terminal-clipboard";
+import { RobustClipboardProvider } from "@/lib/clipboard-provider";
+import { copyToClipboard, readFromClipboard } from "@/lib/clipboard";
 
 export function LocalTerminal({
   instanceId,
@@ -13,6 +22,7 @@ export function LocalTerminal({
   instanceId: string;
   isVisible: boolean;
 }) {
+  const { t } = useTranslation();
   const { theme: appTheme } = useTheme();
   const { instance: terminal, ref: xtermRef } = useXTerm();
   const fitAddonRef = useRef<FitAddon | null>(null);
@@ -55,9 +65,43 @@ export function LocalTerminal({
   useEffect(() => {
     if (!terminal || !window.electronAPI?.isElectron) return;
     const fitAddon = new FitAddon();
+    const clipboardProvider = new RobustClipboardProvider();
+    const clipboardAddon = new ClipboardAddon(undefined, clipboardProvider);
     fitAddonRef.current = fitAddon;
     terminal.loadAddon(fitAddon);
+    terminal.loadAddon(clipboardAddon);
     fitAddon.fit();
+
+    async function writeTextToClipboard(text: string): Promise<boolean> {
+      const ok = await copyToClipboard(text);
+      if (!ok) toast.error(t("terminal.clipboardWriteFailed"));
+      return ok;
+    }
+
+    async function readTextFromClipboard(): Promise<string> {
+      const text = await readFromClipboard();
+      if (!text) toast.error(t("terminal.clipboardReadFailed"));
+      return text;
+    }
+
+    const clipboardActions = { writeTextToClipboard, readTextFromClipboard };
+
+    terminal.attachCustomKeyEventHandler((e: KeyboardEvent): boolean => {
+      if (e.type !== "keydown") return true;
+      // No native "paste" event listener here (unlike the SSH terminal), so
+      // plain Ctrl/Cmd+V reads the clipboard explicitly rather than relying
+      // on the browser's own paste event.
+      return handleTerminalClipboardKeyEvent(e, terminal, clipboardActions, {
+        plainPasteMode: "explicit",
+      });
+    });
+
+    const handleContextMenu = createTerminalContextMenuHandler(
+      terminal,
+      clipboardActions,
+    );
+    const element = xtermRef.current;
+    element?.addEventListener("contextmenu", handleContextMenu);
 
     let disposed = false;
     let removeData = () => {};
@@ -102,13 +146,15 @@ export function LocalTerminal({
       input.dispose();
       removeData();
       removeExit();
+      element?.removeEventListener("contextmenu", handleContextMenu);
+      clipboardProvider.dispose();
       const sessionId = sessionIdRef.current;
       sessionIdRef.current = null;
       if (sessionId) window.electronAPI.closeLocalTerminal(sessionId);
       fitAddonRef.current = null;
       fitAddon.dispose();
     };
-  }, [fit, instanceId, shell, terminal, xtermRef]);
+  }, [fit, instanceId, shell, t, terminal, xtermRef]);
 
   useEffect(() => {
     if (isVisible) requestAnimationFrame(fit);

--- a/src/ui/features/terminal/Terminal.tsx
+++ b/src/ui/features/terminal/Terminal.tsx
@@ -24,7 +24,6 @@ import {
   buildOriginWsUrl,
 } from "@/lib/connection-origin.ts";
 import {
-  getCookie,
   isElectron,
   logActivity,
   getSnippets,
@@ -80,9 +79,13 @@ import {
   getNextTerminalFontSize,
   getTerminalFontZoomDirection,
 } from "./terminal-font-zoom.ts";
-import { isPhysicalShortcutKey, isTabKeyEvent } from "./terminal-key-event.ts";
+import { isTabKeyEvent } from "./terminal-key-event.ts";
 import { installTouchWheelCoordinator } from "./touch-wheel-coordinator.ts";
 import { loadTouchInputSettings } from "./touch-input-settings-store.ts";
+import {
+  handleTerminalClipboardKeyEvent,
+  createTerminalContextMenuHandler,
+} from "./terminal-clipboard.ts";
 import { quoteTerminalImagePath } from "./terminal-image-path.ts";
 import {
   getUserPreferences,
@@ -1098,10 +1101,6 @@ const TerminalInner = forwardRef<TerminalHandle, SSHTerminalProps>(
         hostConfig.id,
       ],
     );
-
-    function getUseRightClickCopyPaste() {
-      return getCookie("rightClickCopyPaste") !== "false";
-    }
 
     function attemptReconnection() {
       if (
@@ -2529,28 +2528,11 @@ const TerminalInner = forwardRef<TerminalHandle, SSHTerminalProps>(
         }
       });
       const element = xtermRef.current;
-      const handleContextMenu = (e: MouseEvent) => {
-        if (e.ctrlKey && onOpenFileManager) {
-          e.preventDefault();
-          e.stopPropagation();
-          onOpenFileManager();
-          return;
-        }
-
-        if (getUseRightClickCopyPaste()) {
-          e.preventDefault();
-          e.stopPropagation();
-          if (terminal.hasSelection()) {
-            const text = terminal.getSelection();
-            writeTextToClipboard(text).then(() => terminal.clearSelection());
-          } else {
-            readTextFromClipboard().then((text) => {
-              if (text) terminal.paste(text);
-            });
-          }
-          return;
-        }
-      };
+      const handleContextMenu = createTerminalContextMenuHandler(
+        terminal,
+        { writeTextToClipboard, readTextFromClipboard },
+        { onCtrlClick: onOpenFileManager },
+      );
       element?.addEventListener("contextmenu", handleContextMenu);
 
       const handlePaste = (e: ClipboardEvent) => {
@@ -2865,86 +2847,13 @@ const TerminalInner = forwardRef<TerminalHandle, SSHTerminalProps>(
         }
 
         if (
-          e.ctrlKey &&
-          !e.shiftKey &&
-          !e.altKey &&
-          !e.metaKey &&
-          isPhysicalShortcutKey(e, "KeyC", "c") &&
-          terminal.hasSelection()
+          !handleTerminalClipboardKeyEvent(
+            e,
+            terminal,
+            { writeTextToClipboard, readTextFromClipboard },
+            { plainPasteMode: "native" },
+          )
         ) {
-          const selection = terminal.getSelection();
-          if (selection) {
-            e.preventDefault();
-            e.stopPropagation();
-            writeTextToClipboard(selection);
-            terminal.clearSelection();
-            return false;
-          }
-        }
-
-        if (
-          (e.metaKey &&
-            !e.shiftKey &&
-            !e.ctrlKey &&
-            !e.altKey &&
-            isPhysicalShortcutKey(e, "KeyC", "c")) ||
-          (e.ctrlKey &&
-            !e.shiftKey &&
-            !e.altKey &&
-            !e.metaKey &&
-            e.key === "Insert")
-        ) {
-          const selection = terminal.getSelection();
-          if (selection) {
-            e.preventDefault();
-            e.stopPropagation();
-            writeTextToClipboard(selection);
-            return false;
-          }
-        }
-
-        if (
-          e.ctrlKey &&
-          e.shiftKey &&
-          !e.altKey &&
-          !e.metaKey &&
-          isPhysicalShortcutKey(e, "KeyC", "c")
-        ) {
-          const selection = terminal.getSelection();
-          if (selection) {
-            e.preventDefault();
-            e.stopPropagation();
-            writeTextToClipboard(selection);
-            terminal.clearSelection();
-            return false;
-          }
-        }
-
-        if (
-          e.ctrlKey &&
-          e.shiftKey &&
-          !e.altKey &&
-          !e.metaKey &&
-          isPhysicalShortcutKey(e, "KeyV", "v")
-        ) {
-          e.preventDefault();
-          e.stopPropagation();
-          readTextFromClipboard().then((text) => {
-            if (text) terminal.paste(text);
-          });
-          return false;
-        }
-
-        if (
-          e.ctrlKey &&
-          !e.shiftKey &&
-          !e.altKey &&
-          !e.metaKey &&
-          isPhysicalShortcutKey(e, "KeyV", "v")
-        ) {
-          // Let the browser handle Ctrl+V natively, the paste event
-          // listener will intercept the result without triggering the
-          // clipboard permission popup
           return false;
         }
 

--- a/src/ui/features/terminal/terminal-clipboard.ts
+++ b/src/ui/features/terminal/terminal-clipboard.ts
@@ -1,0 +1,152 @@
+import type { Terminal } from "@xterm/xterm";
+import { getCookie } from "@/main-axios.ts";
+import { isPhysicalShortcutKey } from "./terminal-key-event";
+
+export function getUseRightClickCopyPaste(): boolean {
+  return getCookie("rightClickCopyPaste") !== "false";
+}
+
+export interface TerminalClipboardActions {
+  writeTextToClipboard: (text: string) => Promise<unknown>;
+  readTextFromClipboard: () => Promise<string>;
+}
+
+export interface TerminalClipboardKeyOptions {
+  /**
+   * How a plain Ctrl/Cmd+V with no other modifiers is handled.
+   * "native" (default, matches the SSH terminal) leaves the key alone so the
+   * browser's own paste event fires - this avoids re-triggering the OS
+   * clipboard permission prompt on every keystroke, but requires the caller
+   * to also listen for the DOM "paste" event.
+   * "explicit" reads the clipboard directly instead, for terminals with no
+   * such paste event listener of their own.
+   */
+  plainPasteMode?: "native" | "explicit";
+}
+
+/**
+ * Shared copy/paste keyboard shortcuts for xterm-based terminals:
+ * Ctrl/Cmd+C copies the current selection (Ctrl+C also clears it, matching
+ * its dual use as SIGINT when nothing is selected), Ctrl+Insert copies
+ * without clearing, and Ctrl+Shift+C / Ctrl+Shift+V always copy/paste
+ * regardless of selection state. Returns false (having called
+ * preventDefault/stopPropagation) once it has handled the event, true
+ * otherwise so callers can keep processing the keydown.
+ */
+export function handleTerminalClipboardKeyEvent(
+  e: KeyboardEvent,
+  terminal: Terminal,
+  { writeTextToClipboard, readTextFromClipboard }: TerminalClipboardActions,
+  { plainPasteMode = "native" }: TerminalClipboardKeyOptions = {},
+): boolean {
+  const isCopyKey = isPhysicalShortcutKey(e, "KeyC", "c");
+  const isPasteKey = isPhysicalShortcutKey(e, "KeyV", "v");
+
+  if (
+    e.ctrlKey &&
+    !e.shiftKey &&
+    !e.altKey &&
+    !e.metaKey &&
+    isCopyKey &&
+    terminal.hasSelection()
+  ) {
+    const selection = terminal.getSelection();
+    if (selection) {
+      e.preventDefault();
+      e.stopPropagation();
+      writeTextToClipboard(selection);
+      terminal.clearSelection();
+      return false;
+    }
+  }
+
+  if (
+    (e.metaKey && !e.shiftKey && !e.ctrlKey && !e.altKey && isCopyKey) ||
+    (e.ctrlKey && !e.shiftKey && !e.altKey && !e.metaKey && e.key === "Insert")
+  ) {
+    const selection = terminal.getSelection();
+    if (selection) {
+      e.preventDefault();
+      e.stopPropagation();
+      writeTextToClipboard(selection);
+      return false;
+    }
+  }
+
+  if (e.ctrlKey && e.shiftKey && !e.altKey && !e.metaKey && isCopyKey) {
+    const selection = terminal.getSelection();
+    if (selection) {
+      e.preventDefault();
+      e.stopPropagation();
+      writeTextToClipboard(selection);
+      terminal.clearSelection();
+      return false;
+    }
+  }
+
+  if (e.ctrlKey && e.shiftKey && !e.altKey && !e.metaKey && isPasteKey) {
+    e.preventDefault();
+    e.stopPropagation();
+    readTextFromClipboard().then((text) => {
+      if (text) terminal.paste(text);
+    });
+    return false;
+  }
+
+  const plainModPaste =
+    ((e.ctrlKey && !e.metaKey) || (e.metaKey && !e.ctrlKey)) &&
+    !e.shiftKey &&
+    !e.altKey &&
+    isPasteKey;
+  if (plainModPaste) {
+    if (plainPasteMode === "explicit") {
+      e.preventDefault();
+      e.stopPropagation();
+      readTextFromClipboard().then((text) => {
+        if (text) terminal.paste(text);
+      });
+    }
+    // "native": leave the event alone so the browser's own paste event fires.
+    return false;
+  }
+
+  return true;
+}
+
+export interface TerminalContextMenuOptions {
+  /** Optional Ctrl+right-click passthrough, e.g. to open a file manager. */
+  onCtrlClick?: () => void;
+}
+
+/**
+ * Builds a "contextmenu" listener implementing right-click copy/paste:
+ * copies the selection if one exists, otherwise pastes. Gated behind the
+ * user's "rightClickCopyPaste" preference cookie.
+ */
+export function createTerminalContextMenuHandler(
+  terminal: Terminal,
+  { writeTextToClipboard, readTextFromClipboard }: TerminalClipboardActions,
+  { onCtrlClick }: TerminalContextMenuOptions = {},
+): (e: MouseEvent) => void {
+  return (e: MouseEvent) => {
+    if (e.ctrlKey && onCtrlClick) {
+      e.preventDefault();
+      e.stopPropagation();
+      onCtrlClick();
+      return;
+    }
+
+    if (!getUseRightClickCopyPaste()) return;
+
+    e.preventDefault();
+    e.stopPropagation();
+    if (terminal.hasSelection()) {
+      const text = terminal.getSelection();
+      writeTextToClipboard(text).then(() => terminal.clearSelection());
+    } else {
+      readTextFromClipboard().then((text) => {
+        if (text) terminal.paste(text);
+      });
+    }
+  };
+}


### PR DESCRIPTION
Local terminal had no clipboard wiring, so selected text couldn't be copied. Extracted the SSH terminal's copy/paste shortcut and right-click handling into a shared terminal-clipboard module and wired it into both terminals, removing duplicated logic in the process.

# Overview

Adds copy/paste support to the local terminal, which had no clipboard wiring at all. Also extracts the SSH terminal's copy/paste keyboard shortcut and right-click handling into a shared module so both terminals now share one implementation instead of duplicating the logic.

- [x] Added: clipboard copy/paste support for the local terminal (`Ctrl/Cmd+C`, `Ctrl+Insert`, `Ctrl+Shift+C`, `Ctrl+Shift+V`, and right-click copy/paste)
- [x] Updated: SSH terminal (`Terminal.tsx`) refactored to consume the same shared clipboard module instead of its own inline copy/paste logic
- [ ] Removed: ...
- [x] Fixed: selected text in the local terminal could not be copied

# Changes Made

- Added `src/ui/features/terminal/terminal-clipboard.ts` exporting:
  - `handleTerminalClipboardKeyEvent` — handles `Ctrl/Cmd+C` (copies selection, clears it), `Ctrl+Insert` (copies without clearing), `Ctrl+Shift+C`/`Ctrl+Shift+V` (always copy/paste), and a `plainPasteMode` option (`"native"` lets the browser's own paste event fire, used by the SSH terminal to avoid repeated OS clipboard permission prompts; `"explicit"` reads the clipboard directly, used by the local terminal, which has no native paste listener of its own)
  - `createTerminalContextMenuHandler` — right-click copy/paste, gated by the existing `rightClickCopyPaste` cookie preference, with an optional Ctrl+right-click passthrough (used by the SSH terminal to open the file manager)
- `LocalTerminal.tsx` now loads `ClipboardAddon`/`RobustClipboardProvider` and wires the shared key/context-menu handlers into its xterm instance
- `Terminal.tsx` (SSH) replaced its four inline copy/paste `if` blocks and its local context-menu handler with calls into the shared module — net removal of ~108 lines with no behavior change

# Related Issues

- N/A

# Screenshots / Demos

- N/A

# Checklist

- [x] Code follows project style guidelines
- [x] Supports mobile and desktop UI/app (if applicable)
- [x] I have read [Contributing.md](https://github.com/Termix-SSH/Termix/blob/main/CONTRIBUTING.md)
- [x] This is not a translation request. See [docs](https://docs.termix.site/translations)
