### PR TITLE
feat(desktop): local filesystem and transfer bridge for the file manager

### DIFF
--- a/electron/local-files.cjs
+++ b/electron/local-files.cjs
@@ -1,0 +1,632 @@
+// Local filesystem access + streamed local<->remote transfers for the
+// desktop app's dual-pane file manager.
+//
+// The renderer has no Node access (contextIsolation), so browsing the user's
+// own disk and moving bytes between it and the backend has to happen here.
+// Uploads/downloads are streamed through Electron's `net` stack against the
+// same file-manager HTTP routes the renderer already uses, so nothing is ever
+// buffered whole in memory and the existing auth (session cookies + bearer
+// JWT supplied by the renderer) keeps working unchanged.
+
+const fs = require("fs");
+const fsp = require("fs/promises");
+const os = require("os");
+const path = require("path");
+const { URL } = require("url");
+const { net } = require("electron");
+
+const IPC = {
+  HOME: "local-fs:home",
+  LIST: "local-fs:list",
+  MKDIR: "local-fs:mkdir",
+  CREATE_FILE: "local-fs:create-file",
+  RENAME: "local-fs:rename",
+  TRASH: "local-fs:trash",
+  ENSURE_DIR: "local-fs:ensure-dir",
+  WALK: "local-fs:walk",
+  REVEAL: "local-fs:reveal",
+  OPEN: "local-fs:open",
+  UPLOAD: "local-transfer:upload",
+  DOWNLOAD: "local-transfer:download",
+  CANCEL: "local-transfer:cancel",
+  PROGRESS: "local-transfer:progress",
+};
+
+const READ_CHUNK_BYTES = 1024 * 1024;
+const PROGRESS_INTERVAL_MS = 150;
+
+const activeTransfers = new Map();
+
+function isAbsoluteLocalPath(candidate) {
+  return typeof candidate === "string" && path.isAbsolute(candidate);
+}
+
+function normalizeLocalPath(candidate) {
+  if (!isAbsoluteLocalPath(candidate)) {
+    throw new Error("A local absolute path is required");
+  }
+  return path.normalize(candidate);
+}
+
+function isHiddenEntry(name) {
+  return name.startsWith(".");
+}
+
+// A single path segment: no separators, not "." / "..", no NULs.
+function requireEntryName(name, what) {
+  const safeName = String(name || "").trim();
+  if (
+    !safeName ||
+    safeName === "." ||
+    safeName === ".." ||
+    /[\/\\\0]/.test(safeName)
+  ) {
+    throw new Error(`Invalid ${what}`);
+  }
+  return safeName;
+}
+
+async function pathExists(target) {
+  try {
+    await fsp.lstat(target);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function describeEntry(dirPath, dirent) {
+  const entryPath = path.join(dirPath, dirent.name);
+  let type = "file";
+  let size = 0;
+  let modifiedTimestamp;
+  let linkTarget;
+
+  try {
+    if (dirent.isSymbolicLink()) {
+      type = "link";
+      try {
+        linkTarget = await fsp.readlink(entryPath);
+      } catch {
+        // dangling or unreadable link
+      }
+      // Follow the link so a symlinked directory still navigates like one.
+      try {
+        const target = await fsp.stat(entryPath);
+        if (target.isDirectory()) type = "directory";
+        size = target.size;
+        modifiedTimestamp = target.mtimeMs;
+      } catch {
+        const own = await fsp.lstat(entryPath);
+        modifiedTimestamp = own.mtimeMs;
+      }
+    } else if (dirent.isDirectory()) {
+      type = "directory";
+      const stat = await fsp.stat(entryPath);
+      modifiedTimestamp = stat.mtimeMs;
+    } else {
+      const stat = await fsp.stat(entryPath);
+      size = stat.size;
+      modifiedTimestamp = stat.mtimeMs;
+    }
+  } catch {
+    // Unreadable entry: still list it so the user sees it exists.
+  }
+
+  return {
+    name: dirent.name,
+    path: entryPath,
+    type,
+    size,
+    modifiedTimestamp,
+    linkTarget,
+    hidden: isHiddenEntry(dirent.name),
+  };
+}
+
+async function listDirectory(dirPath) {
+  const resolved = normalizeLocalPath(dirPath);
+  const dirents = await fsp.readdir(resolved, { withFileTypes: true });
+  const entries = await Promise.all(
+    dirents.map((dirent) => describeEntry(resolved, dirent)),
+  );
+  const parent = path.dirname(resolved);
+  return {
+    path: resolved,
+    parent: parent === resolved ? null : parent,
+    entries,
+  };
+}
+
+// Expands a set of dropped local paths into the flat list of files (with
+// paths relative to the drop root) plus any empty directories, mirroring what
+// the browser's FileSystemEntry walker produces for OS drops.
+async function walkPaths(rootPaths) {
+  const files = [];
+  const emptyDirs = [];
+  let totalBytes = 0;
+
+  async function walkDir(absDir, relDir) {
+    const dirents = await fsp.readdir(absDir, { withFileTypes: true });
+    if (dirents.length === 0) {
+      emptyDirs.push(relDir);
+      return;
+    }
+    for (const dirent of dirents) {
+      const abs = path.join(absDir, dirent.name);
+      const rel = `${relDir}/${dirent.name}`;
+      if (dirent.isDirectory()) {
+        await walkDir(abs, rel);
+      } else if (dirent.isFile()) {
+        const stat = await fsp.stat(abs);
+        files.push({ localPath: abs, relativePath: rel, size: stat.size });
+        totalBytes += stat.size;
+      } else if (dirent.isSymbolicLink()) {
+        // Upload what the link points at, if it is a regular file.
+        try {
+          const stat = await fsp.stat(abs);
+          if (stat.isFile()) {
+            files.push({ localPath: abs, relativePath: rel, size: stat.size });
+            totalBytes += stat.size;
+          }
+        } catch {
+          // dangling link: skip
+        }
+      }
+    }
+  }
+
+  for (const rootPath of rootPaths) {
+    const abs = normalizeLocalPath(rootPath);
+    const stat = await fsp.stat(abs);
+    const name = path.basename(abs);
+    if (stat.isDirectory()) {
+      await walkDir(abs, name);
+    } else if (stat.isFile()) {
+      files.push({ localPath: abs, relativePath: name, size: stat.size });
+      totalBytes += stat.size;
+    }
+  }
+
+  return { files, emptyDirs, totalBytes };
+}
+
+function toHeaderMap(headers) {
+  const out = {};
+  if (!headers || typeof headers !== "object") return out;
+  for (const [key, value] of Object.entries(headers)) {
+    if (value === undefined || value === null) continue;
+    out[key] = String(value);
+  }
+  return out;
+}
+
+function makeProgressReporter(sender, transferId) {
+  let lastSentAt = 0;
+  return (transferred, total, force = false) => {
+    const now = Date.now();
+    if (!force && now - lastSentAt < PROGRESS_INTERVAL_MS) return;
+    lastSentAt = now;
+    if (sender.isDestroyed()) return;
+    sender.send(IPC.PROGRESS, { transferId, transferred, total });
+  };
+}
+
+function collectBody(response) {
+  return new Promise((resolve) => {
+    const chunks = [];
+    response.on("data", (chunk) => chunks.push(chunk));
+    response.on("end", () => resolve(Buffer.concat(chunks).toString("utf8")));
+    response.on("error", () => resolve(""));
+  });
+}
+
+function describeHttpError(statusCode, bodyText) {
+  try {
+    const parsed = JSON.parse(bodyText);
+    if (parsed && typeof parsed.error === "string") return parsed.error;
+    if (parsed && typeof parsed.message === "string") return parsed.message;
+  } catch {
+    // not JSON
+  }
+  return bodyText?.trim() || `Request failed with status ${statusCode}`;
+}
+
+function writeToRequest(request, chunk) {
+  return new Promise((resolve, reject) => {
+    try {
+      request.write(chunk, () => resolve());
+    } catch (error) {
+      reject(error);
+    }
+  });
+}
+
+function createNetRequest(event, method, url) {
+  const parsed = new URL(url);
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    throw new Error("Only http(s) transfer targets are supported");
+  }
+  return net.request({
+    method,
+    url: parsed.toString(),
+    session: event.sender.session,
+    useSessionCookies: true,
+  });
+}
+
+// Streams one local file to the backend's multipart `uploadFileStream` route.
+async function uploadLocalFile(event, options) {
+  const { transferId, url, headers, fields, localPath, fileName } =
+    options || {};
+
+  if (!transferId || !url || !localPath) {
+    throw new Error("Missing upload parameters");
+  }
+
+  const absPath = normalizeLocalPath(localPath);
+  const stat = await fsp.stat(absPath);
+  if (!stat.isFile()) {
+    throw new Error("Only regular files can be uploaded");
+  }
+
+  const boundary = `----TermixLocalUpload${Date.now()}${Math.random()
+    .toString(36)
+    .slice(2)}`;
+  const safeName = String(fileName || path.basename(absPath))
+    .replace(/[\r\n]/g, " ")
+    .replace(/"/g, "%22");
+
+  let preamble = "";
+  for (const [key, value] of Object.entries(fields || {})) {
+    if (value === undefined || value === null) continue;
+    preamble +=
+      `--${boundary}\r\n` +
+      `Content-Disposition: form-data; name="${key}"\r\n\r\n` +
+      `${String(value)}\r\n`;
+  }
+  preamble +=
+    `--${boundary}\r\n` +
+    `Content-Disposition: form-data; name="file"; filename="${safeName}"\r\n` +
+    `Content-Type: application/octet-stream\r\n\r\n`;
+  const epilogue = `\r\n--${boundary}--\r\n`;
+
+  const preambleBuffer = Buffer.from(preamble, "utf8");
+  const epilogueBuffer = Buffer.from(epilogue, "utf8");
+
+  const request = createNetRequest(event, "POST", url);
+  for (const [key, value] of Object.entries(toHeaderMap(headers))) {
+    request.setHeader(key, value);
+  }
+  request.setHeader(
+    "Content-Type",
+    `multipart/form-data; boundary=${boundary}`,
+  );
+  // Without chunked encoding Electron buffers the whole body in the main
+  // process before sending; chunked keeps memory flat for multi-GB files.
+  // Busboy on the backend parses the multipart stream incrementally either way.
+  request.chunkedEncoding = true;
+
+  const report = makeProgressReporter(event.sender, transferId);
+  const readStream = fs.createReadStream(absPath, {
+    highWaterMark: READ_CHUNK_BYTES,
+  });
+
+  const state = {
+    cancelled: false,
+    abort: () => {
+      state.cancelled = true;
+      readStream.destroy();
+      request.abort();
+    },
+  };
+  activeTransfers.set(transferId, state);
+
+  // The server may answer early (auth failure, missing session) while the
+  // body is still streaming; stop pushing bytes as soon as it does.
+  let responded = false;
+  const responsePromise = new Promise((resolve, reject) => {
+    request.on("response", async (response) => {
+      responded = true;
+      const bodyText = await collectBody(response);
+      resolve({ statusCode: response.statusCode, bodyText });
+    });
+    request.on("error", (error) => reject(error));
+    request.on("abort", () => reject(new Error("Transfer cancelled")));
+  });
+  // Avoid an unhandled rejection if we bail out before awaiting below.
+  responsePromise.catch(() => {});
+
+  // A write callback never fires once the request has errored or been
+  // aborted, so every write races against the response promise's rejection.
+  const write = (chunk) =>
+    Promise.race([writeToRequest(request, chunk), responsePromise]);
+
+  try {
+    await write(preambleBuffer);
+    let sent = 0;
+    for await (const chunk of readStream) {
+      if (state.cancelled) throw new Error("Transfer cancelled");
+      if (responded) break;
+      await write(chunk);
+      sent += chunk.length;
+      report(sent, stat.size);
+    }
+    if (!responded) {
+      await write(epilogueBuffer);
+      request.end();
+    }
+
+    const { statusCode, bodyText } = await responsePromise;
+    if (statusCode < 200 || statusCode >= 300) {
+      throw new Error(describeHttpError(statusCode, bodyText));
+    }
+    report(stat.size, stat.size, true);
+    return { success: true, bytes: stat.size };
+  } catch (error) {
+    readStream.destroy();
+    throw error;
+  } finally {
+    activeTransfers.delete(transferId);
+  }
+}
+
+// Streams one remote file (via the backend's `downloadFileStream` route) into
+// a local destination, writing to a temp sibling and renaming on success so
+// a failed transfer never leaves a truncated file behind under the real name.
+async function downloadToLocal(event, options) {
+  const { transferId, url, headers, body, destPath, expectedSize } =
+    options || {};
+
+  if (!transferId || !url || !destPath) {
+    throw new Error("Missing download parameters");
+  }
+
+  const absDest = normalizeLocalPath(destPath);
+  await fsp.mkdir(path.dirname(absDest), { recursive: true });
+  const partialPath = `${absDest}.termix-part`;
+
+  const request = createNetRequest(event, "POST", url);
+  for (const [key, value] of Object.entries(toHeaderMap(headers))) {
+    request.setHeader(key, value);
+  }
+  const payload = Buffer.from(JSON.stringify(body || {}), "utf8");
+  request.setHeader("Content-Type", "application/json");
+  request.setHeader("Content-Length", String(payload.length));
+
+  const report = makeProgressReporter(event.sender, transferId);
+  const state = {
+    cancelled: false,
+    abort: () => {
+      state.cancelled = true;
+      request.abort();
+    },
+  };
+  activeTransfers.set(transferId, state);
+
+  try {
+    await new Promise((resolve, reject) => {
+      let settled = false;
+      const fail = (error) => {
+        if (settled) return;
+        settled = true;
+        reject(error);
+      };
+
+      request.on("error", fail);
+      request.on("abort", () => fail(new Error("Transfer cancelled")));
+      request.on("response", (response) => {
+        const statusCode = response.statusCode;
+        if (statusCode < 200 || statusCode >= 300) {
+          collectBody(response).then((bodyText) =>
+            fail(new Error(describeHttpError(statusCode, bodyText))),
+          );
+          return;
+        }
+
+        const lengthHeader = response.headers["content-length"];
+        const total =
+          Number(
+            Array.isArray(lengthHeader) ? lengthHeader[0] : lengthHeader,
+          ) ||
+          Number(expectedSize) ||
+          undefined;
+
+        const writeStream = fs.createWriteStream(partialPath);
+        let received = 0;
+
+        response.on("data", (chunk) => {
+          received += chunk.length;
+          const ok = writeStream.write(chunk);
+          if (!ok) {
+            response.pause();
+            writeStream.once("drain", () => response.resume());
+          }
+          report(received, total);
+        });
+        response.on("end", () => {
+          writeStream.end(() => {
+            report(received, total ?? received, true);
+            if (settled) return;
+            settled = true;
+            resolve();
+          });
+        });
+        response.on("error", (error) => {
+          writeStream.destroy();
+          fail(error);
+        });
+        writeStream.on("error", (error) => {
+          request.abort();
+          fail(error);
+        });
+      });
+
+      request.write(payload);
+      request.end();
+    });
+
+    await fsp.rename(partialPath, absDest);
+    return { success: true, path: absDest };
+  } catch (error) {
+    await fsp.rm(partialPath, { force: true }).catch(() => {});
+    throw error;
+  } finally {
+    activeTransfers.delete(transferId);
+  }
+}
+
+function wrap(handler) {
+  return async (event, ...args) => {
+    try {
+      const result = await handler(event, ...args);
+      return { success: true, ...(result || {}) };
+    } catch (error) {
+      return {
+        success: false,
+        error: error && error.message ? error.message : String(error),
+        code: error && error.code ? error.code : undefined,
+      };
+    }
+  };
+}
+
+function registerLocalFileHandlers({ ipcMain, shell }) {
+  ipcMain.handle(
+    IPC.HOME,
+    wrap(async () => ({
+      home: os.homedir(),
+      separator: path.sep,
+      platform: process.platform,
+    })),
+  );
+
+  ipcMain.handle(
+    IPC.LIST,
+    wrap(async (_event, dirPath) => listDirectory(dirPath)),
+  );
+
+  ipcMain.handle(
+    IPC.MKDIR,
+    wrap(async (_event, parentPath, name) => {
+      const parent = normalizeLocalPath(parentPath);
+      const safeName = requireEntryName(name, "folder name");
+      const target = path.join(parent, safeName);
+      await fsp.mkdir(target);
+      return { path: target };
+    }),
+  );
+
+  ipcMain.handle(
+    IPC.CREATE_FILE,
+    wrap(async (_event, parentPath, name) => {
+      const parent = normalizeLocalPath(parentPath);
+      const safeName = requireEntryName(name, "file name");
+      const target = path.join(parent, safeName);
+      // "wx" fails if the file already exists rather than truncating it.
+      await fsp.writeFile(target, "", { flag: "wx" });
+      return { path: target };
+    }),
+  );
+
+  ipcMain.handle(
+    IPC.RENAME,
+    wrap(async (_event, oldPath, newName) => {
+      const source = normalizeLocalPath(oldPath);
+      const safeName = requireEntryName(newName, "name");
+      const target = path.join(path.dirname(source), safeName);
+      if (target === source) return { path: source };
+      if (await pathExists(target)) {
+        throw new Error(`"${safeName}" already exists`);
+      }
+      await fsp.rename(source, target);
+      return { path: target };
+    }),
+  );
+
+  // Moves entries to the OS trash (Finder Trash / Recycle Bin) rather than
+  // deleting outright, so a mis-click in the file manager is recoverable.
+  ipcMain.handle(
+    IPC.TRASH,
+    wrap(async (_event, targetPaths) => {
+      if (!Array.isArray(targetPaths) || targetPaths.length === 0) {
+        throw new Error("No local paths provided");
+      }
+      const failed = [];
+      for (const candidate of targetPaths) {
+        const target = normalizeLocalPath(candidate);
+        try {
+          await shell.trashItem(target);
+        } catch (error) {
+          failed.push({
+            path: target,
+            error: error && error.message ? error.message : String(error),
+          });
+        }
+      }
+      return { trashed: targetPaths.length - failed.length, failed };
+    }),
+  );
+
+  ipcMain.handle(
+    IPC.ENSURE_DIR,
+    wrap(async (_event, dirPath) => {
+      const target = normalizeLocalPath(dirPath);
+      await fsp.mkdir(target, { recursive: true });
+      return { path: target };
+    }),
+  );
+
+  ipcMain.handle(
+    IPC.WALK,
+    wrap(async (_event, rootPaths) => {
+      if (!Array.isArray(rootPaths) || rootPaths.length === 0) {
+        throw new Error("No local paths provided");
+      }
+      return walkPaths(rootPaths);
+    }),
+  );
+
+  ipcMain.handle(
+    IPC.REVEAL,
+    wrap(async (_event, targetPath) => {
+      shell.showItemInFolder(normalizeLocalPath(targetPath));
+    }),
+  );
+
+  ipcMain.handle(
+    IPC.OPEN,
+    wrap(async (_event, targetPath) => {
+      const error = await shell.openPath(normalizeLocalPath(targetPath));
+      if (error) throw new Error(error);
+    }),
+  );
+
+  ipcMain.handle(
+    IPC.UPLOAD,
+    wrap((event, options) => uploadLocalFile(event, options)),
+  );
+
+  ipcMain.handle(
+    IPC.DOWNLOAD,
+    wrap((event, options) => downloadToLocal(event, options)),
+  );
+
+  ipcMain.handle(
+    IPC.CANCEL,
+    wrap(async (_event, transferId) => {
+      const state = activeTransfers.get(transferId);
+      if (!state) return { cancelled: false };
+      state.abort();
+      return { cancelled: true };
+    }),
+  );
+}
+
+module.exports = {
+  IPC,
+  registerLocalFileHandlers,
+  // exported for tests / reuse
+  walkPaths,
+  listDirectory,
+};

--- a/electron/local-files.cjs
+++ b/electron/local-files.cjs
@@ -5,15 +5,19 @@
 // own disk and moving bytes between it and the backend has to happen here.
 // Uploads/downloads are streamed through Electron's `net` stack against the
 // same file-manager HTTP routes the renderer already uses, so nothing is ever
-// buffered whole in memory and the existing auth (session cookies + bearer
-// JWT supplied by the renderer) keeps working unchanged.
+// buffered whole in memory.
+//
+// Trust boundary: the renderer never supplies a URL or headers. It names an
+// origin ("local" | "remote") and a route from a fixed allowlist; the main
+// process resolves the actual Termix backend URL and attaches credentials
+// itself (session cookies for the embedded backend, the stored Remote Sync JWT
+// for the remote server). Nothing here can be pointed at another host.
 
 const fs = require("fs");
 const fsp = require("fs/promises");
 const os = require("os");
 const path = require("path");
 const { URL } = require("url");
-const { net } = require("electron");
 
 const IPC = {
   HOME: "local-fs:home",
@@ -23,6 +27,7 @@ const IPC = {
   RENAME: "local-fs:rename",
   TRASH: "local-fs:trash",
   ENSURE_DIR: "local-fs:ensure-dir",
+  EXISTS: "local-fs:exists",
   WALK: "local-fs:walk",
   REVEAL: "local-fs:reveal",
   OPEN: "local-fs:open",
@@ -242,27 +247,102 @@ function writeToRequest(request, chunk) {
   });
 }
 
-function createNetRequest(event, method, url) {
-  const parsed = new URL(url);
-  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
-    throw new Error("Only http(s) transfer targets are supported");
+const TRANSFER_ROUTES = Object.freeze({
+  uploadFileStream: "/ssh/uploadFileStream",
+  downloadFileStream: "/ssh/downloadFileStream",
+});
+
+const DEVICE_ID_PATTERN = /^[A-Za-z0-9._:-]{1,128}$/;
+
+const DEFAULT_LOCAL_FILE_MANAGER_BASE =
+  "http://localhost:30004/ssh/file_manager";
+
+function normalizeHttpBase(candidate, what) {
+  let parsed;
+  try {
+    parsed = new URL(String(candidate || ""));
+  } catch {
+    throw new Error(`${what} is not a valid URL`);
   }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    throw new Error(`${what} must use http or https`);
+  }
+  return parsed.toString().replace(/\/$/, "");
+}
+
+// Resolves where a transfer may go. Only the two file-manager streaming
+// routes are reachable, and only on the embedded backend or the configured
+// Remote Sync server; credentials come from the main process, not the caller.
+function createTargetResolver({
+  localBaseUrl = DEFAULT_LOCAL_FILE_MANAGER_BASE,
+  getRemoteSyncConfig,
+  getRemoteSyncJwt,
+}) {
+  return function resolveTransferTarget({ origin, route, deviceId } = {}) {
+    const routePath = TRANSFER_ROUTES[route];
+    if (!routePath) {
+      throw new Error(`Unknown transfer route: ${String(route)}`);
+    }
+
+    const headers = { "X-Electron-App": "true" };
+    if (deviceId !== undefined && deviceId !== null && deviceId !== "") {
+      if (typeof deviceId !== "string" || !DEVICE_ID_PATTERN.test(deviceId)) {
+        throw new Error("Invalid device id");
+      }
+      headers["X-Termix-Device-ID"] = deviceId;
+    }
+
+    if (origin === "local") {
+      return {
+        url: `${normalizeHttpBase(localBaseUrl, "Local backend URL")}${routePath}`,
+        headers,
+      };
+    }
+
+    if (origin === "remote") {
+      const config =
+        typeof getRemoteSyncConfig === "function"
+          ? getRemoteSyncConfig()
+          : null;
+      if (!config || !config.serverUrl) {
+        throw new Error("Remote sync server is not configured");
+      }
+      const base = normalizeHttpBase(
+        config.serverUrl,
+        "Remote sync server URL",
+      );
+      const jwt =
+        typeof getRemoteSyncJwt === "function" ? getRemoteSyncJwt() : null;
+      if (jwt) headers.Authorization = `Bearer ${jwt}`;
+      return { url: `${base}/ssh/file_manager${routePath}`, headers };
+    }
+
+    throw new Error(`Unknown transfer origin: ${String(origin)}`);
+  };
+}
+
+function createNetRequest(net, event, method, url) {
   return net.request({
     method,
-    url: parsed.toString(),
+    url,
     session: event.sender.session,
     useSessionCookies: true,
   });
 }
 
 // Streams one local file to the backend's multipart `uploadFileStream` route.
-async function uploadLocalFile(event, options) {
-  const { transferId, url, headers, fields, localPath, fileName } =
+async function uploadLocalFile({ net, resolveTransferTarget }, event, options) {
+  const { transferId, origin, deviceId, fields, localPath, fileName } =
     options || {};
 
-  if (!transferId || !url || !localPath) {
+  if (!transferId || !localPath) {
     throw new Error("Missing upload parameters");
   }
+  const { url, headers } = resolveTransferTarget({
+    origin,
+    route: "uploadFileStream",
+    deviceId,
+  });
 
   const absPath = normalizeLocalPath(localPath);
   const stat = await fsp.stat(absPath);
@@ -294,7 +374,7 @@ async function uploadLocalFile(event, options) {
   const preambleBuffer = Buffer.from(preamble, "utf8");
   const epilogueBuffer = Buffer.from(epilogue, "utf8");
 
-  const request = createNetRequest(event, "POST", url);
+  const request = createNetRequest(net, event, "POST", url);
   for (const [key, value] of Object.entries(toHeaderMap(headers))) {
     request.setHeader(key, value);
   }
@@ -371,29 +451,88 @@ async function uploadLocalFile(event, options) {
   }
 }
 
-// Streams one remote file (via the backend's `downloadFileStream` route) into
-// a local destination, writing to a temp sibling and renaming on success so
-// a failed transfer never leaves a truncated file behind under the real name.
-async function downloadToLocal(event, options) {
-  const { transferId, url, headers, body, destPath, expectedSize } =
-    options || {};
+class LocalFileError extends Error {
+  constructor(code, message) {
+    super(message);
+    this.name = "LocalFileError";
+    this.code = code;
+  }
+}
 
-  if (!transferId || !url || !destPath) {
+// Destinations with a download in flight, so two transfers can never race
+// each other onto the same file.
+const activeDestinations = new Set();
+
+function partialPathFor(absDest, transferId) {
+  const token = String(transferId)
+    .replace(/[^A-Za-z0-9_-]/g, "")
+    .slice(0, 48);
+  return `${absDest}.${token || "transfer"}.termix-part`;
+}
+
+// Moves a finished partial file onto its final name. Without `overwrite` the
+// publish is exclusive: an existing file is never replaced, even if it
+// appeared while the download was running.
+async function publishDownload(partialPath, absDest, overwrite) {
+  if (overwrite) {
+    await fsp.rename(partialPath, absDest);
+    return;
+  }
+  try {
+    // link() is atomic and fails with EEXIST if the name is taken.
+    await fsp.link(partialPath, absDest);
+  } catch (error) {
+    if (error && error.code === "EEXIST") {
+      throw new LocalFileError(
+        "EEXIST",
+        `"${path.basename(absDest)}" already exists`,
+      );
+    }
+    // Filesystems without hard links: fall back to an exclusive copy.
+    await fsp
+      .copyFile(partialPath, absDest, fs.constants.COPYFILE_EXCL)
+      .catch((copyError) => {
+        if (copyError && copyError.code === "EEXIST") {
+          throw new LocalFileError(
+            "EEXIST",
+            `"${path.basename(absDest)}" already exists`,
+          );
+        }
+        throw copyError;
+      });
+  }
+  await fsp.rm(partialPath, { force: true });
+}
+
+// Streams one remote file (via the backend's `downloadFileStream` route) into
+// a local destination. Bytes go to a transfer-unique temp sibling first and
+// are published under the real name only on success, so a failed transfer
+// never leaves a truncated file behind. Existing files are refused unless
+// the caller explicitly asked to overwrite.
+async function downloadToLocal({ net, resolveTransferTarget }, event, options) {
+  const { transferId, origin, deviceId, body, destPath, expectedSize } =
+    options || {};
+  const overwrite = options?.overwrite === true;
+
+  if (!transferId || !destPath) {
     throw new Error("Missing download parameters");
   }
+  const { url, headers } = resolveTransferTarget({
+    origin,
+    route: "downloadFileStream",
+    deviceId,
+  });
 
   const absDest = normalizeLocalPath(destPath);
-  await fsp.mkdir(path.dirname(absDest), { recursive: true });
-  const partialPath = `${absDest}.termix-part`;
-
-  const request = createNetRequest(event, "POST", url);
-  for (const [key, value] of Object.entries(toHeaderMap(headers))) {
-    request.setHeader(key, value);
+  if (activeDestinations.has(absDest)) {
+    throw new LocalFileError(
+      "EBUSY",
+      `"${path.basename(absDest)}" is already being downloaded`,
+    );
   }
-  const payload = Buffer.from(JSON.stringify(body || {}), "utf8");
-  request.setHeader("Content-Type", "application/json");
-  request.setHeader("Content-Length", String(payload.length));
+  activeDestinations.add(absDest);
 
+  const partialPath = partialPathFor(absDest, transferId);
   const report = makeProgressReporter(event.sender, transferId);
   const state = {
     cancelled: false,
@@ -402,9 +541,26 @@ async function downloadToLocal(event, options) {
       request.abort();
     },
   };
-  activeTransfers.set(transferId, state);
+  let request = null;
 
   try {
+    if (!overwrite && (await pathExists(absDest))) {
+      throw new LocalFileError(
+        "EEXIST",
+        `"${path.basename(absDest)}" already exists`,
+      );
+    }
+    await fsp.mkdir(path.dirname(absDest), { recursive: true });
+
+    request = createNetRequest(net, event, "POST", url);
+    for (const [key, value] of Object.entries(toHeaderMap(headers))) {
+      request.setHeader(key, value);
+    }
+    const payload = Buffer.from(JSON.stringify(body || {}), "utf8");
+    request.setHeader("Content-Type", "application/json");
+    request.setHeader("Content-Length", String(payload.length));
+    activeTransfers.set(transferId, state);
+
     await new Promise((resolve, reject) => {
       let settled = false;
       const fail = (error) => {
@@ -432,7 +588,8 @@ async function downloadToLocal(event, options) {
           Number(expectedSize) ||
           undefined;
 
-        const writeStream = fs.createWriteStream(partialPath);
+        // "wx": the temp name is ours alone; refuse to reuse a stale one.
+        const writeStream = fs.createWriteStream(partialPath, { flags: "wx" });
         let received = 0;
 
         response.on("data", (chunk) => {
@@ -466,13 +623,14 @@ async function downloadToLocal(event, options) {
       request.end();
     });
 
-    await fsp.rename(partialPath, absDest);
+    await publishDownload(partialPath, absDest, overwrite);
     return { success: true, path: absDest };
   } catch (error) {
     await fsp.rm(partialPath, { force: true }).catch(() => {});
     throw error;
   } finally {
     activeTransfers.delete(transferId);
+    activeDestinations.delete(absDest);
   }
 }
 
@@ -491,35 +649,43 @@ function wrap(handler) {
   };
 }
 
-function registerLocalFileHandlers({ ipcMain, shell }) {
-  ipcMain.handle(
-    IPC.HOME,
-    wrap(async () => ({
+// Builds the IPC handler map from injected dependencies so the whole boundary
+// can be exercised in tests with a Node http shim instead of Electron.
+function createLocalFileHandlers({
+  net,
+  shell,
+  getRemoteSyncConfig,
+  getRemoteSyncJwt,
+  localBaseUrl,
+}) {
+  if (!net || typeof net.request !== "function") {
+    throw new Error("createLocalFileHandlers requires a net implementation");
+  }
+  const resolveTransferTarget = createTargetResolver({
+    localBaseUrl,
+    getRemoteSyncConfig,
+    getRemoteSyncJwt,
+  });
+  const deps = { net, resolveTransferTarget };
+
+  return {
+    [IPC.HOME]: wrap(async () => ({
       home: os.homedir(),
       separator: path.sep,
       platform: process.platform,
     })),
-  );
 
-  ipcMain.handle(
-    IPC.LIST,
-    wrap(async (_event, dirPath) => listDirectory(dirPath)),
-  );
+    [IPC.LIST]: wrap(async (_event, dirPath) => listDirectory(dirPath)),
 
-  ipcMain.handle(
-    IPC.MKDIR,
-    wrap(async (_event, parentPath, name) => {
+    [IPC.MKDIR]: wrap(async (_event, parentPath, name) => {
       const parent = normalizeLocalPath(parentPath);
       const safeName = requireEntryName(name, "folder name");
       const target = path.join(parent, safeName);
       await fsp.mkdir(target);
       return { path: target };
     }),
-  );
 
-  ipcMain.handle(
-    IPC.CREATE_FILE,
-    wrap(async (_event, parentPath, name) => {
+    [IPC.CREATE_FILE]: wrap(async (_event, parentPath, name) => {
       const parent = normalizeLocalPath(parentPath);
       const safeName = requireEntryName(name, "file name");
       const target = path.join(parent, safeName);
@@ -527,28 +693,22 @@ function registerLocalFileHandlers({ ipcMain, shell }) {
       await fsp.writeFile(target, "", { flag: "wx" });
       return { path: target };
     }),
-  );
 
-  ipcMain.handle(
-    IPC.RENAME,
-    wrap(async (_event, oldPath, newName) => {
+    [IPC.RENAME]: wrap(async (_event, oldPath, newName) => {
       const source = normalizeLocalPath(oldPath);
       const safeName = requireEntryName(newName, "name");
       const target = path.join(path.dirname(source), safeName);
       if (target === source) return { path: source };
       if (await pathExists(target)) {
-        throw new Error(`"${safeName}" already exists`);
+        throw new LocalFileError("EEXIST", `"${safeName}" already exists`);
       }
       await fsp.rename(source, target);
       return { path: target };
     }),
-  );
 
-  // Moves entries to the OS trash (Finder Trash / Recycle Bin) rather than
-  // deleting outright, so a mis-click in the file manager is recoverable.
-  ipcMain.handle(
-    IPC.TRASH,
-    wrap(async (_event, targetPaths) => {
+    // Moves entries to the OS trash (Finder Trash / Recycle Bin) rather than
+    // deleting outright, so a mis-click in the file manager is recoverable.
+    [IPC.TRASH]: wrap(async (_event, targetPaths) => {
       if (!Array.isArray(targetPaths) || targetPaths.length === 0) {
         throw new Error("No local paths provided");
       }
@@ -566,67 +726,82 @@ function registerLocalFileHandlers({ ipcMain, shell }) {
       }
       return { trashed: targetPaths.length - failed.length, failed };
     }),
-  );
 
-  ipcMain.handle(
-    IPC.ENSURE_DIR,
-    wrap(async (_event, dirPath) => {
+    [IPC.ENSURE_DIR]: wrap(async (_event, dirPath) => {
       const target = normalizeLocalPath(dirPath);
       await fsp.mkdir(target, { recursive: true });
       return { path: target };
     }),
-  );
 
-  ipcMain.handle(
-    IPC.WALK,
-    wrap(async (_event, rootPaths) => {
+    // Which of the given paths already exist; lets the renderer ask about
+    // collisions before a batch download starts.
+    [IPC.EXISTS]: wrap(async (_event, targetPaths) => {
+      if (!Array.isArray(targetPaths)) {
+        throw new Error("Expected a list of paths");
+      }
+      const existing = [];
+      for (const candidate of targetPaths) {
+        const target = normalizeLocalPath(candidate);
+        if (await pathExists(target)) existing.push(target);
+      }
+      return { existing };
+    }),
+
+    [IPC.WALK]: wrap(async (_event, rootPaths) => {
       if (!Array.isArray(rootPaths) || rootPaths.length === 0) {
         throw new Error("No local paths provided");
       }
       return walkPaths(rootPaths);
     }),
-  );
 
-  ipcMain.handle(
-    IPC.REVEAL,
-    wrap(async (_event, targetPath) => {
+    [IPC.REVEAL]: wrap(async (_event, targetPath) => {
       shell.showItemInFolder(normalizeLocalPath(targetPath));
     }),
-  );
 
-  ipcMain.handle(
-    IPC.OPEN,
-    wrap(async (_event, targetPath) => {
+    [IPC.OPEN]: wrap(async (_event, targetPath) => {
       const error = await shell.openPath(normalizeLocalPath(targetPath));
       if (error) throw new Error(error);
     }),
-  );
 
-  ipcMain.handle(
-    IPC.UPLOAD,
-    wrap((event, options) => uploadLocalFile(event, options)),
-  );
+    [IPC.UPLOAD]: wrap((event, options) =>
+      uploadLocalFile(deps, event, options),
+    ),
 
-  ipcMain.handle(
-    IPC.DOWNLOAD,
-    wrap((event, options) => downloadToLocal(event, options)),
-  );
+    [IPC.DOWNLOAD]: wrap((event, options) =>
+      downloadToLocal(deps, event, options),
+    ),
 
-  ipcMain.handle(
-    IPC.CANCEL,
-    wrap(async (_event, transferId) => {
+    [IPC.CANCEL]: wrap(async (_event, transferId) => {
       const state = activeTransfers.get(transferId);
       if (!state) return { cancelled: false };
       state.abort();
       return { cancelled: true };
     }),
-  );
+  };
+}
+
+function registerLocalFileHandlers({ ipcMain, shell }) {
+  // Real Electron wiring; tests build the handlers directly instead.
+  const { net } = require("electron");
+  const remoteSync = require("./remote-sync.cjs");
+  const handlers = createLocalFileHandlers({
+    net,
+    shell,
+    getRemoteSyncConfig: remoteSync.getRemoteSyncConfig,
+    getRemoteSyncJwt: remoteSync.getRemoteSyncJwt,
+  });
+  for (const [channel, handler] of Object.entries(handlers)) {
+    ipcMain.handle(channel, handler);
+  }
 }
 
 module.exports = {
   IPC,
+  TRANSFER_ROUTES,
   registerLocalFileHandlers,
   // exported for tests / reuse
+  createLocalFileHandlers,
+  createTargetResolver,
   walkPaths,
   listDirectory,
 };

--- a/electron/local-files.cjs
+++ b/electron/local-files.cjs
@@ -470,38 +470,134 @@ function partialPathFor(absDest, transferId) {
   return `${absDest}.${token || "transfer"}.termix-part`;
 }
 
-// Moves a finished partial file onto its final name. Without `overwrite` the
-// publish is exclusive: an existing file is never replaced, even if it
-// appeared while the download was running.
-async function publishDownload(partialPath, absDest, overwrite) {
-  if (overwrite) {
-    await fsp.rename(partialPath, absDest);
-    return;
-  }
+// File operations used to publish a download, injectable so the replace
+// strategy can be tested against Windows-like semantics (where rename() onto
+// an existing name fails) without running on Windows.
+const defaultPublishFs = Object.freeze({
+  rename: (from, to) => fsp.rename(from, to),
+  link: (from, to) => fsp.link(from, to),
+  copyFileExcl: (from, to) =>
+    fsp.copyFile(from, to, fs.constants.COPYFILE_EXCL),
+  rm: (target) => fsp.rm(target, { force: true }),
+  lstat: (target) => fsp.lstat(target),
+});
+
+function replacedPathFor(absDest, transferId) {
+  const token = String(transferId)
+    .replace(/[^A-Za-z0-9_-]/g, "")
+    .slice(0, 48);
+  return `${absDest}.${token || "transfer"}.termix-replaced`;
+}
+
+// Puts `sourcePath` under `absDest` without ever replacing an existing file:
+// link() is atomic and fails with EEXIST if the name is taken; filesystems
+// without hard links fall back to an exclusive copy. The source is removed
+// once the destination exists.
+async function publishExclusive(io, sourcePath, absDest) {
+  const exists = () =>
+    new LocalFileError("EEXIST", `"${path.basename(absDest)}" already exists`);
   try {
-    // link() is atomic and fails with EEXIST if the name is taken.
-    await fsp.link(partialPath, absDest);
+    await io.link(sourcePath, absDest);
   } catch (error) {
-    if (error && error.code === "EEXIST") {
+    if (error && error.code === "EEXIST") throw exists();
+    try {
+      await io.copyFileExcl(sourcePath, absDest);
+    } catch (copyError) {
+      if (copyError && copyError.code === "EEXIST") throw exists();
+      throw copyError;
+    }
+  }
+  await io.rm(sourcePath);
+}
+
+// Replaces `absDest` with the finished partial. rename() over an existing
+// file is not portable: POSIX replaces it, but on Windows the call commonly
+// fails (EEXIST / EPERM, always when the file is open), so the swap never
+// renames onto an occupied name. Instead:
+//   1. move the current file aside to a transfer-unique sibling
+//      (renaming to a fresh name is safe everywhere);
+//   2. publish the partial exclusively under the now-free name;
+//   3. delete the aside copy.
+// If step 1 fails nothing has changed and the caller gets EBUSY. If step 2
+// fails the aside copy is moved back, so the original survives.
+async function replaceExisting(io, partialPath, absDest, transferId) {
+  let current;
+  try {
+    current = await io.lstat(absDest);
+  } catch (error) {
+    if (error && error.code === "ENOENT") {
+      // Nothing to replace after all (the file went away meanwhile).
+      await publishExclusive(io, partialPath, absDest);
+      return;
+    }
+    throw error;
+  }
+  if (current.isDirectory()) {
+    throw new LocalFileError(
+      "EISDIR",
+      `"${path.basename(absDest)}" is a folder and cannot be replaced by a file`,
+    );
+  }
+
+  const asidePath = replacedPathFor(absDest, transferId);
+  try {
+    await io.rename(absDest, asidePath);
+  } catch (error) {
+    if (
+      error &&
+      (error.code === "EPERM" ||
+        error.code === "EBUSY" ||
+        error.code === "EACCES")
+    ) {
       throw new LocalFileError(
-        "EEXIST",
-        `"${path.basename(absDest)}" already exists`,
+        "EBUSY",
+        `"${path.basename(absDest)}" is in use and could not be replaced`,
       );
     }
-    // Filesystems without hard links: fall back to an exclusive copy.
-    await fsp
-      .copyFile(partialPath, absDest, fs.constants.COPYFILE_EXCL)
-      .catch((copyError) => {
-        if (copyError && copyError.code === "EEXIST") {
-          throw new LocalFileError(
-            "EEXIST",
-            `"${path.basename(absDest)}" already exists`,
-          );
-        }
-        throw copyError;
-      });
+    throw error;
   }
-  await fsp.rm(partialPath, { force: true });
+
+  try {
+    await publishExclusive(io, partialPath, absDest);
+  } catch (error) {
+    // Put the original back under its name; the partial is cleaned up by
+    // the caller.
+    await io.rm(absDest).catch(() => {});
+    await io.rename(asidePath, absDest).catch(() => {});
+    throw error;
+  }
+
+  // The old contents are no longer reachable under the real name; removing
+  // the aside copy can still fail on Windows if another process holds it
+  // open, so retry once before giving up and leaving it for the user.
+  try {
+    await io.rm(asidePath);
+  } catch {
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    await io.rm(asidePath).catch((error) => {
+      console.warn(
+        `[local-files] replaced "${absDest}" but could not remove the previous copy at "${asidePath}": ${error && error.message}`,
+      );
+    });
+  }
+}
+
+// Moves a finished partial file onto its final name. Without `overwrite` the
+// publish is exclusive: an existing file is never replaced, even if it
+// appeared while the download was running. With `overwrite` the existing file
+// is swapped out in a way that also works on Windows.
+async function publishDownload(
+  partialPath,
+  absDest,
+  overwrite,
+  transferId,
+  io = defaultPublishFs,
+) {
+  if (overwrite) {
+    await replaceExisting(io, partialPath, absDest, transferId);
+    return;
+  }
+  await publishExclusive(io, partialPath, absDest);
 }
 
 // Streams one remote file (via the backend's `downloadFileStream` route) into
@@ -509,7 +605,11 @@ async function publishDownload(partialPath, absDest, overwrite) {
 // are published under the real name only on success, so a failed transfer
 // never leaves a truncated file behind. Existing files are refused unless
 // the caller explicitly asked to overwrite.
-async function downloadToLocal({ net, resolveTransferTarget }, event, options) {
+async function downloadToLocal(
+  { net, resolveTransferTarget, publishFs },
+  event,
+  options,
+) {
   const { transferId, origin, deviceId, body, destPath, expectedSize } =
     options || {};
   const overwrite = options?.overwrite === true;
@@ -623,7 +723,13 @@ async function downloadToLocal({ net, resolveTransferTarget }, event, options) {
       request.end();
     });
 
-    await publishDownload(partialPath, absDest, overwrite);
+    await publishDownload(
+      partialPath,
+      absDest,
+      overwrite,
+      transferId,
+      publishFs || defaultPublishFs,
+    );
     return { success: true, path: absDest };
   } catch (error) {
     await fsp.rm(partialPath, { force: true }).catch(() => {});
@@ -657,6 +763,7 @@ function createLocalFileHandlers({
   getRemoteSyncConfig,
   getRemoteSyncJwt,
   localBaseUrl,
+  publishFs,
 }) {
   if (!net || typeof net.request !== "function") {
     throw new Error("createLocalFileHandlers requires a net implementation");
@@ -666,7 +773,11 @@ function createLocalFileHandlers({
     getRemoteSyncConfig,
     getRemoteSyncJwt,
   });
-  const deps = { net, resolveTransferTarget };
+  const deps = {
+    net,
+    resolveTransferTarget,
+    publishFs: publishFs || defaultPublishFs,
+  };
 
   return {
     [IPC.HOME]: wrap(async () => ({
@@ -802,6 +913,8 @@ module.exports = {
   // exported for tests / reuse
   createLocalFileHandlers,
   createTargetResolver,
+  publishDownload,
+  defaultPublishFs,
   walkPaths,
   listDirectory,
 };

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -32,6 +32,7 @@ const { isCloseActiveTabInput } = require("./keyboard-shortcuts.cjs");
 const { quitApp } = require("./app-quit.cjs");
 const { selectLinuxPasswordStore } = require("./linux-password-store.cjs");
 const { resolveLocalShell } = require("./local-shell.cjs");
+const { registerLocalFileHandlers } = require("./local-files.cjs");
 
 const localTerminalSessions = new Map();
 
@@ -3272,6 +3273,10 @@ async function testServerConnection(
 }
 
 ipcMain.handle("test-server-connection", testServerConnection);
+
+// Local disk browsing + streamed local<->remote transfers for the file
+// manager's dual-pane mode (see electron/local-files.cjs).
+registerLocalFileHandlers({ ipcMain, shell });
 
 function createMenu() {
   if (process.platform === "darwin") {

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -129,6 +129,36 @@ contextBridge.exposeInMainWorld("electronAPI", {
     return () => ipcRenderer.removeListener(channel, listener);
   },
 
+  // Dual-pane file manager: local disk browsing and streamed transfers.
+  localFs: {
+    home: () => ipcRenderer.invoke("local-fs:home"),
+    list: (dirPath) => ipcRenderer.invoke("local-fs:list", dirPath),
+    mkdir: (parentPath, name) =>
+      ipcRenderer.invoke("local-fs:mkdir", parentPath, name),
+    createFile: (parentPath, name) =>
+      ipcRenderer.invoke("local-fs:create-file", parentPath, name),
+    rename: (oldPath, newName) =>
+      ipcRenderer.invoke("local-fs:rename", oldPath, newName),
+    trash: (paths) => ipcRenderer.invoke("local-fs:trash", paths),
+    ensureDir: (dirPath) => ipcRenderer.invoke("local-fs:ensure-dir", dirPath),
+    walk: (paths) => ipcRenderer.invoke("local-fs:walk", paths),
+    reveal: (targetPath) => ipcRenderer.invoke("local-fs:reveal", targetPath),
+    open: (targetPath) => ipcRenderer.invoke("local-fs:open", targetPath),
+  },
+  localTransfer: {
+    upload: (options) => ipcRenderer.invoke("local-transfer:upload", options),
+    download: (options) =>
+      ipcRenderer.invoke("local-transfer:download", options),
+    cancel: (transferId) =>
+      ipcRenderer.invoke("local-transfer:cancel", transferId),
+    onProgress: (callback) => {
+      const listener = (_event, payload) => callback(payload);
+      ipcRenderer.on("local-transfer:progress", listener);
+      return () =>
+        ipcRenderer.removeListener("local-transfer:progress", listener);
+    },
+  },
+
   invoke: invokeAllowed,
 });
 

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -141,6 +141,7 @@ contextBridge.exposeInMainWorld("electronAPI", {
       ipcRenderer.invoke("local-fs:rename", oldPath, newName),
     trash: (paths) => ipcRenderer.invoke("local-fs:trash", paths),
     ensureDir: (dirPath) => ipcRenderer.invoke("local-fs:ensure-dir", dirPath),
+    exists: (paths) => ipcRenderer.invoke("local-fs:exists", paths),
     walk: (paths) => ipcRenderer.invoke("local-fs:walk", paths),
     reveal: (targetPath) => ipcRenderer.invoke("local-fs:reveal", targetPath),
     open: (targetPath) => ipcRenderer.invoke("local-fs:open", targetPath),

--- a/src/backend/tests/electron/local-files.test.ts
+++ b/src/backend/tests/electron/local-files.test.ts
@@ -1,0 +1,491 @@
+import { createRequire } from "node:module";
+import http from "node:http";
+import fs from "node:fs";
+import fsp from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import crypto from "node:crypto";
+import { EventEmitter } from "node:events";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from "vitest";
+
+const require = createRequire(import.meta.url);
+const localFiles = require("../../../../electron/local-files.cjs") as {
+  IPC: Record<string, string>;
+  TRANSFER_ROUTES: Record<string, string>;
+  createTargetResolver: (deps: {
+    localBaseUrl?: string;
+    getRemoteSyncConfig?: () => { serverUrl?: string } | null;
+    getRemoteSyncJwt?: () => string | null;
+  }) => (req: { origin?: unknown; route?: unknown; deviceId?: unknown }) => {
+    url: string;
+    headers: Record<string, string>;
+  };
+  createLocalFileHandlers: (deps: {
+    net: unknown;
+    shell: unknown;
+    getRemoteSyncConfig?: () => { serverUrl?: string } | null;
+    getRemoteSyncJwt?: () => string | null;
+    localBaseUrl?: string;
+  }) => Record<
+    string,
+    (
+      event: unknown,
+      ...args: unknown[]
+    ) => Promise<
+      { success: boolean; error?: string; code?: string } & Record<
+        string,
+        unknown
+      >
+    >
+  >;
+};
+
+// Minimal stand-in for Electron's net.request built on Node http, exposing
+// the subset of the ClientRequest API local-files.cjs uses.
+class FakeClientRequest extends EventEmitter {
+  private req: http.ClientRequest;
+  chunkedEncoding = false;
+  constructor(opts: { method: string; url: string }) {
+    super();
+    const u = new URL(opts.url);
+    this.req = http.request({
+      method: opts.method,
+      hostname: u.hostname,
+      port: u.port,
+      path: u.pathname,
+    });
+    this.req.on("response", (res) => this.emit("response", res));
+    this.req.on("error", (e) => this.emit("error", e));
+  }
+  setHeader(k: string, v: string) {
+    this.req.setHeader(k, v);
+  }
+  write(chunk: Buffer | string, cb?: () => void) {
+    return this.req.write(chunk, cb);
+  }
+  end() {
+    this.req.end();
+  }
+  abort() {
+    this.req.destroy();
+    this.emit("abort");
+  }
+}
+
+const fakeNet = {
+  request: (opts: { method: string; url: string }) =>
+    new FakeClientRequest(opts),
+};
+
+const fakeEvent = {
+  sender: { session: null, isDestroyed: () => false, send: () => {} },
+};
+
+// A backend stand-in: records what it receives and serves a fixed payload on
+// the download route (optionally slowly, to exercise concurrency).
+function startBackend(
+  payload: Buffer,
+  opts: { delayMs?: number; failAll?: boolean } = {},
+) {
+  const seen: Array<{ url: string; headers: http.IncomingHttpHeaders }> = [];
+  const server = http.createServer((req, res) => {
+    seen.push({ url: req.url || "", headers: req.headers });
+    let body = "";
+    req.on("data", (d) => (body += d));
+    req.on("end", () => {
+      if (!opts.failAll && req.url?.endsWith("/ssh/downloadFileStream")) {
+        // Headers go out immediately so the client opens its temp file;
+        // the body may be delayed to keep the transfer in flight.
+        res.writeHead(200, { "Content-Length": payload.length });
+        res.flushHeaders();
+        const send = () => res.end(payload);
+        if (opts.delayMs) setTimeout(send, opts.delayMs);
+        else send();
+        return;
+      }
+      res.statusCode = 404;
+      res.end(JSON.stringify({ error: `no route ${req.url}` }));
+    });
+  });
+  return new Promise<{
+    url: string;
+    seen: typeof seen;
+    close: () => Promise<void>;
+  }>((resolve) => {
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address() as { port: number };
+      resolve({
+        url: `http://127.0.0.1:${address.port}/ssh/file_manager`,
+        seen,
+        close: () => new Promise((r) => server.close(() => r())),
+      });
+    });
+  });
+}
+
+describe("local-files transfer target resolution", () => {
+  const resolve = localFiles.createTargetResolver({
+    localBaseUrl: "http://127.0.0.1:30004/ssh/file_manager",
+    getRemoteSyncConfig: () => ({ serverUrl: "https://termix.example.com/" }),
+    getRemoteSyncJwt: () => "remote-jwt",
+  });
+
+  it("only reaches the two file-manager streaming routes on the local backend", () => {
+    expect(resolve({ origin: "local", route: "uploadFileStream" })).toEqual({
+      url: "http://127.0.0.1:30004/ssh/file_manager/ssh/uploadFileStream",
+      headers: { "X-Electron-App": "true" },
+    });
+    expect(resolve({ origin: "local", route: "downloadFileStream" }).url).toBe(
+      "http://127.0.0.1:30004/ssh/file_manager/ssh/downloadFileStream",
+    );
+  });
+
+  it("derives the remote target from the configured sync server and attaches its JWT itself", () => {
+    const target = resolve({ origin: "remote", route: "downloadFileStream" });
+    expect(target.url).toBe(
+      "https://termix.example.com/ssh/file_manager/ssh/downloadFileStream",
+    );
+    expect(target.headers.Authorization).toBe("Bearer remote-jwt");
+  });
+
+  it("refuses unknown origins, routes, and off-origin URLs smuggled as either", () => {
+    expect(() =>
+      resolve({ origin: "https://evil.example", route: "uploadFileStream" }),
+    ).toThrow(/Unknown transfer origin/);
+    expect(() => resolve({ origin: "local", route: "/../admin" })).toThrow(
+      /Unknown transfer route/,
+    );
+    expect(() =>
+      resolve({ origin: "local", route: "http://evil.example/x" }),
+    ).toThrow(/Unknown transfer route/);
+    expect(() => resolve({})).toThrow(/Unknown transfer route/);
+  });
+
+  it("refuses a remote origin when no sync server is configured or it is not http(s)", () => {
+    const unconfigured = localFiles.createTargetResolver({
+      getRemoteSyncConfig: () => null,
+    });
+    expect(() =>
+      unconfigured({ origin: "remote", route: "uploadFileStream" }),
+    ).toThrow(/not configured/);
+    const bogus = localFiles.createTargetResolver({
+      getRemoteSyncConfig: () => ({ serverUrl: "file:///etc/passwd" }),
+    });
+    expect(() =>
+      bogus({ origin: "remote", route: "uploadFileStream" }),
+    ).toThrow(/must use http or https/);
+  });
+
+  it("accepts only a well-formed device id and never arbitrary headers", () => {
+    expect(
+      resolve({
+        origin: "local",
+        route: "uploadFileStream",
+        deviceId: "dev_1.2:3-x",
+      }).headers["X-Termix-Device-ID"],
+    ).toBe("dev_1.2:3-x");
+    expect(() =>
+      resolve({
+        origin: "local",
+        route: "uploadFileStream",
+        deviceId: "x\r\nHost: evil",
+      }),
+    ).toThrow(/Invalid device id/);
+    const headers = resolve({
+      origin: "local",
+      route: "uploadFileStream",
+    }).headers;
+    expect(Object.keys(headers)).toEqual(["X-Electron-App"]);
+  });
+});
+
+describe("local-files download boundary", () => {
+  let root: string;
+  const payload = crypto.randomBytes(64 * 1024 + 7);
+  let backend: Awaited<ReturnType<typeof startBackend>>;
+  let handlers: ReturnType<typeof localFiles.createLocalFileHandlers>;
+
+  beforeAll(async () => {
+    backend = await startBackend(payload);
+    handlers = localFiles.createLocalFileHandlers({
+      net: fakeNet,
+      shell: {},
+      localBaseUrl: backend.url,
+      getRemoteSyncConfig: () => null,
+      getRemoteSyncJwt: () => null,
+    });
+  });
+  afterAll(() => backend.close());
+  beforeEach(async () => {
+    root = await fsp.mkdtemp(path.join(os.tmpdir(), "termix-local-files-"));
+  });
+  afterEach(() => fsp.rm(root, { recursive: true, force: true }));
+
+  const download = (
+    dest: string,
+    extra: Record<string, unknown> = {},
+    transferId = `t-${Math.random().toString(36).slice(2)}`,
+  ) =>
+    handlers[localFiles.IPC.DOWNLOAD](fakeEvent, {
+      transferId,
+      origin: "local",
+      body: { sessionId: "1", path: "/remote/file.bin" },
+      destPath: dest,
+      ...extra,
+    });
+
+  it("ignores renderer-supplied url/headers and talks to the resolved backend only", async () => {
+    const dest = path.join(root, "a.bin");
+    const result = await download(dest, {
+      url: "http://evil.example/steal",
+      headers: { Authorization: "Bearer leaked", Cookie: "jwt=leaked" },
+    });
+    expect(result.success).toBe(true);
+    const last = backend.seen[backend.seen.length - 1];
+    expect(last.url).toBe("/ssh/file_manager/ssh/downloadFileStream");
+    expect(last.headers.authorization).toBeUndefined();
+    expect(last.headers.cookie).toBeUndefined();
+    expect(last.headers["x-electron-app"]).toBe("true");
+    expect((await fsp.readFile(dest)).equals(payload)).toBe(true);
+  });
+
+  it("refuses to replace an existing file by default and leaves it untouched", async () => {
+    const dest = path.join(root, "keep.bin");
+    await fsp.writeFile(dest, "original");
+    const requestsBefore = backend.seen.length;
+
+    const result = await download(dest);
+    expect(result.success).toBe(false);
+    expect(result.code).toBe("EEXIST");
+    expect(await fsp.readFile(dest, "utf8")).toBe("original");
+    // Refused before any network traffic.
+    expect(backend.seen.length).toBe(requestsBefore);
+    expect(await fsp.readdir(root)).toEqual(["keep.bin"]);
+  });
+
+  it("replaces an existing file only when overwrite is explicitly requested", async () => {
+    const dest = path.join(root, "replace.bin");
+    await fsp.writeFile(dest, "original");
+    const result = await download(dest, { overwrite: true });
+    expect(result.success).toBe(true);
+    expect((await fsp.readFile(dest)).equals(payload)).toBe(true);
+    expect(await fsp.readdir(root)).toEqual(["replace.bin"]);
+  });
+
+  it("refuses to publish over a file that appeared while the download was running", async () => {
+    const slow = await startBackend(payload, { delayMs: 300 });
+    const slowHandlers = localFiles.createLocalFileHandlers({
+      net: fakeNet,
+      shell: {},
+      localBaseUrl: slow.url,
+    });
+    try {
+      const dest = path.join(root, "race.bin");
+      const pending = slowHandlers[localFiles.IPC.DOWNLOAD](fakeEvent, {
+        transferId: "race-1",
+        origin: "local",
+        body: {},
+        destPath: dest,
+      });
+      await new Promise((r) => setTimeout(r, 100));
+      await fsp.writeFile(dest, "someone else wrote this");
+      const result = await pending;
+      expect(result.success).toBe(false);
+      expect(result.code).toBe("EEXIST");
+      expect(await fsp.readFile(dest, "utf8")).toBe("someone else wrote this");
+      expect(await fsp.readdir(root)).toEqual(["race.bin"]);
+    } finally {
+      await slow.close();
+    }
+  });
+
+  it("uses a transfer-unique temp file and rejects a concurrent download to the same destination", async () => {
+    const slow = await startBackend(payload, { delayMs: 300 });
+    const slowHandlers = localFiles.createLocalFileHandlers({
+      net: fakeNet,
+      shell: {},
+      localBaseUrl: slow.url,
+    });
+    try {
+      const dest = path.join(root, "same.bin");
+      const first = slowHandlers[localFiles.IPC.DOWNLOAD](fakeEvent, {
+        transferId: "first",
+        origin: "local",
+        body: {},
+        destPath: dest,
+      });
+      await new Promise((r) => setTimeout(r, 50));
+      const second = await slowHandlers[localFiles.IPC.DOWNLOAD](fakeEvent, {
+        transferId: "second",
+        origin: "local",
+        body: {},
+        destPath: dest,
+      });
+      expect(second.success).toBe(false);
+      expect(second.code).toBe("EBUSY");
+
+      // While the first is in flight its partial carries the transfer id.
+      const partials = (await fsp.readdir(root)).filter((n) =>
+        n.endsWith(".termix-part"),
+      );
+      expect(partials).toEqual(["same.bin.first.termix-part"]);
+
+      const result = await first;
+      expect(result.success).toBe(true);
+      expect((await fsp.readFile(dest)).equals(payload)).toBe(true);
+      expect(await fsp.readdir(root)).toEqual(["same.bin"]);
+    } finally {
+      await slow.close();
+    }
+  });
+
+  it("allows two downloads of different files to run side by side", async () => {
+    const [a, b] = await Promise.all([
+      download(path.join(root, "one.bin")),
+      download(path.join(root, "two.bin")),
+    ]);
+    expect(a.success && b.success).toBe(true);
+    expect((await fsp.readdir(root)).sort()).toEqual(["one.bin", "two.bin"]);
+  });
+
+  it("cleans up its partial file and never creates the destination on a backend error", async () => {
+    const failingBackend = await startBackend(payload, { failAll: true });
+    const failing = localFiles.createLocalFileHandlers({
+      net: fakeNet,
+      shell: {},
+      localBaseUrl: failingBackend.url,
+    });
+    try {
+      const bad = await failing[localFiles.IPC.DOWNLOAD](fakeEvent, {
+        transferId: "err",
+        origin: "local",
+        body: {},
+        destPath: path.join(root, "never.bin"),
+      });
+      expect(bad.success).toBe(false);
+      expect(bad.error).toMatch(/no route/);
+      expect(fs.existsSync(path.join(root, "never.bin"))).toBe(false);
+      expect(await fsp.readdir(root)).toEqual([]);
+    } finally {
+      await failingBackend.close();
+    }
+  });
+
+  it("reports which destinations already exist for the collision prompt", async () => {
+    const present = path.join(root, "present.txt");
+    await fsp.writeFile(present, "x");
+    const result = await handlers[localFiles.IPC.EXISTS](fakeEvent, [
+      present,
+      path.join(root, "absent.txt"),
+    ]);
+    expect(result.success).toBe(true);
+    expect(result.existing).toEqual([present]);
+  });
+});
+
+describe("local-files upload boundary", () => {
+  it("streams the file as multipart to the resolved backend and ignores renderer url/headers", async () => {
+    const Busboy = require("busboy") as (opts: {
+      headers: http.IncomingHttpHeaders;
+    }) => NodeJS.EventEmitter & NodeJS.WritableStream;
+    const received: {
+      fields: Record<string, string>;
+      fileName?: string;
+      hash?: string;
+      url?: string;
+      headers?: http.IncomingHttpHeaders;
+    } = { fields: {} };
+
+    const server = http.createServer((req, res) => {
+      received.url = req.url;
+      received.headers = req.headers;
+      const bb = Busboy({ headers: req.headers });
+      bb.on("field", (name: string, value: string) => {
+        received.fields[name] = value;
+      });
+      bb.on(
+        "file",
+        (
+          _name: string,
+          stream: NodeJS.ReadableStream,
+          info: { filename: string },
+        ) => {
+          received.fileName = info.filename;
+          const hash = crypto.createHash("sha256");
+          stream.on("data", (d: Buffer) => hash.update(d));
+          stream.on("end", () => {
+            received.hash = hash.digest("hex");
+          });
+        },
+      );
+      bb.on("close", () => {
+        res.setHeader("Content-Type", "application/json");
+        res.end(JSON.stringify({ message: "ok" }));
+      });
+      req.pipe(bb);
+    });
+    await new Promise<void>((r) => server.listen(0, "127.0.0.1", () => r()));
+    const port = (server.address() as { port: number }).port;
+
+    const root = await fsp.mkdtemp(path.join(os.tmpdir(), "termix-upload-"));
+    const payload = crypto.randomBytes(3 * 1024 * 1024 + 11);
+    const localPath = path.join(root, "big.bin");
+    await fsp.writeFile(localPath, payload);
+
+    try {
+      const handlers = localFiles.createLocalFileHandlers({
+        net: fakeNet,
+        shell: {},
+        localBaseUrl: `http://127.0.0.1:${port}/ssh/file_manager`,
+      });
+      const result = await handlers[localFiles.IPC.UPLOAD](fakeEvent, {
+        transferId: "up-1",
+        origin: "local",
+        fields: { sessionId: "42", path: "/home/ubuntu" },
+        localPath,
+        fileName: "big renamed.bin",
+        url: "http://evil.example/exfil",
+        headers: { Authorization: "Bearer leaked" },
+      });
+      expect(result.success).toBe(true);
+      expect(received.url).toBe("/ssh/file_manager/ssh/uploadFileStream");
+      expect(received.headers?.authorization).toBeUndefined();
+      expect(received.fields).toEqual({
+        sessionId: "42",
+        path: "/home/ubuntu",
+      });
+      expect(received.fileName).toBe("big renamed.bin");
+      expect(received.hash).toBe(
+        crypto.createHash("sha256").update(payload).digest("hex"),
+      );
+    } finally {
+      await new Promise<void>((r) => server.close(() => r()));
+      await fsp.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("refuses an upload whose origin is not one of the two Termix backends", async () => {
+    const handlers = localFiles.createLocalFileHandlers({
+      net: fakeNet,
+      shell: {},
+      localBaseUrl: "http://127.0.0.1:1/ssh/file_manager",
+    });
+    const result = await handlers[localFiles.IPC.UPLOAD](fakeEvent, {
+      transferId: "up-2",
+      origin: "http://evil.example",
+      fields: {},
+      localPath: __filename,
+      fileName: "x",
+    });
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/Unknown transfer origin/);
+  });
+});

--- a/src/backend/tests/electron/local-files.test.ts
+++ b/src/backend/tests/electron/local-files.test.ts
@@ -17,7 +17,24 @@ import {
 } from "vitest";
 
 const require = createRequire(import.meta.url);
+
+type PublishFs = {
+  rename: (from: string, to: string) => Promise<void>;
+  link: (from: string, to: string) => Promise<void>;
+  copyFileExcl: (from: string, to: string) => Promise<void>;
+  rm: (target: string) => Promise<void>;
+  lstat: (target: string) => Promise<fs.Stats>;
+};
+
 const localFiles = require("../../../../electron/local-files.cjs") as {
+  publishDownload: (
+    partialPath: string,
+    absDest: string,
+    overwrite: boolean,
+    transferId: string,
+    io?: PublishFs,
+  ) => Promise<void>;
+  defaultPublishFs: PublishFs;
   IPC: Record<string, string>;
   TRANSFER_ROUTES: Record<string, string>;
   createTargetResolver: (deps: {
@@ -34,6 +51,7 @@ const localFiles = require("../../../../electron/local-files.cjs") as {
     getRemoteSyncConfig?: () => { serverUrl?: string } | null;
     getRemoteSyncJwt?: () => string | null;
     localBaseUrl?: string;
+    publishFs?: PublishFs;
   }) => Record<
     string,
     (
@@ -388,6 +406,169 @@ describe("local-files download boundary", () => {
     ]);
     expect(result.success).toBe(true);
     expect(result.existing).toEqual([present]);
+  });
+});
+
+// Simulates the Windows rename contract on top of the real filesystem:
+// rename() onto a name that already exists fails instead of replacing it.
+// Every rename is recorded so a test can prove the swap never relied on
+// rename-over-existing.
+function windowsLikeFs(
+  overrides: Partial<PublishFs> = {},
+): PublishFs & { renames: Array<[string, string]> } {
+  const base = localFiles.defaultPublishFs;
+  const renames: Array<[string, string]> = [];
+  return {
+    ...base,
+    renames,
+    rename: async (from, to) => {
+      renames.push([from, to]);
+      if (fs.existsSync(to)) {
+        throw Object.assign(new Error(`EEXIST: file already exists, rename`), {
+          code: "EEXIST",
+        });
+      }
+      await base.rename(from, to);
+    },
+    ...overrides,
+  };
+}
+
+describe("local-files replace primitive (Windows-safe overwrite)", () => {
+  let root: string;
+  beforeEach(async () => {
+    root = await fsp.mkdtemp(path.join(os.tmpdir(), "termix-replace-"));
+  });
+  afterEach(() => fsp.rm(root, { recursive: true, force: true }));
+
+  const seed = async (name: string, existing: string, fresh: Buffer) => {
+    const dest = path.join(root, name);
+    const partial = `${dest}.t1.termix-part`;
+    await fsp.writeFile(dest, existing);
+    await fsp.writeFile(partial, fresh);
+    return { dest, partial };
+  };
+
+  it("replaces an existing file without renaming onto an occupied name", async () => {
+    const fresh = crypto.randomBytes(4096);
+    const { dest, partial } = await seed("swap.bin", "original", fresh);
+    const io = windowsLikeFs();
+
+    await localFiles.publishDownload(partial, dest, true, "t1", io);
+
+    expect((await fsp.readFile(dest)).equals(fresh)).toBe(true);
+    expect(await fsp.readdir(root)).toEqual(["swap.bin"]);
+    // Every rename targeted a name that was free at the time.
+    expect(io.renames.length).toBeGreaterThan(0);
+    for (const [, to] of io.renames) {
+      expect(to === dest || to.endsWith(".termix-replaced")).toBe(true);
+    }
+  });
+
+  it("restores the original byte-for-byte when publishing the new contents fails", async () => {
+    const fresh = crypto.randomBytes(1024);
+    const { dest, partial } = await seed("restore.bin", "original", fresh);
+    const denied = () =>
+      Promise.reject(
+        Object.assign(new Error("EACCES: permission denied"), {
+          code: "EACCES",
+        }),
+      );
+    const io = windowsLikeFs({ link: denied, copyFileExcl: denied });
+
+    await expect(
+      localFiles.publishDownload(partial, dest, true, "t1", io),
+    ).rejects.toMatchObject({ code: "EACCES" });
+
+    expect(await fsp.readFile(dest, "utf8")).toBe("original");
+    // Only the original and the caller-owned partial remain: no aside copy.
+    expect((await fsp.readdir(root)).sort()).toEqual(
+      ["restore.bin", "restore.bin.t1.termix-part"].sort(),
+    );
+  });
+
+  it("reports EBUSY and touches nothing when the existing file cannot be moved aside (open on Windows)", async () => {
+    const fresh = crypto.randomBytes(1024);
+    const { dest, partial } = await seed("locked.bin", "original", fresh);
+    const io = windowsLikeFs({
+      rename: () =>
+        Promise.reject(
+          Object.assign(new Error("EPERM: operation not permitted"), {
+            code: "EPERM",
+          }),
+        ),
+    });
+
+    await expect(
+      localFiles.publishDownload(partial, dest, true, "t1", io),
+    ).rejects.toMatchObject({ code: "EBUSY" });
+
+    expect(await fsp.readFile(dest, "utf8")).toBe("original");
+    expect((await fsp.readFile(partial)).equals(fresh)).toBe(true);
+  });
+
+  it("refuses to replace a folder with a file", async () => {
+    const dest = path.join(root, "folder");
+    await fsp.mkdir(dest);
+    await fsp.writeFile(path.join(dest, "inner.txt"), "keep");
+    const partial = `${dest}.t1.termix-part`;
+    await fsp.writeFile(partial, "new");
+
+    await expect(
+      localFiles.publishDownload(partial, dest, true, "t1", windowsLikeFs()),
+    ).rejects.toMatchObject({ code: "EISDIR" });
+    expect(await fsp.readFile(path.join(dest, "inner.txt"), "utf8")).toBe(
+      "keep",
+    );
+  });
+
+  it("falls back to an exclusive publish when the file to replace has disappeared", async () => {
+    const dest = path.join(root, "gone.bin");
+    const partial = `${dest}.t1.termix-part`;
+    await fsp.writeFile(partial, "new");
+
+    await localFiles.publishDownload(
+      partial,
+      dest,
+      true,
+      "t1",
+      windowsLikeFs(),
+    );
+    expect(await fsp.readFile(dest, "utf8")).toBe("new");
+    expect(await fsp.readdir(root)).toEqual(["gone.bin"]);
+  });
+
+  it("works end to end through the download handler on a Windows-like filesystem", async () => {
+    const payload = crypto.randomBytes(16 * 1024 + 3);
+    const backend = await startBackend(payload);
+    try {
+      const io = windowsLikeFs();
+      const handlers = localFiles.createLocalFileHandlers({
+        net: fakeNet,
+        shell: {},
+        localBaseUrl: backend.url,
+        publishFs: io,
+      });
+      const dest = path.join(root, "e2e.bin");
+      await fsp.writeFile(dest, "original");
+
+      const result = await handlers[localFiles.IPC.DOWNLOAD](fakeEvent, {
+        transferId: "e2e-1",
+        origin: "local",
+        body: { sessionId: "1", path: "/remote/file.bin" },
+        destPath: dest,
+        overwrite: true,
+      });
+
+      expect(result.success).toBe(true);
+      expect((await fsp.readFile(dest)).equals(payload)).toBe(true);
+      expect(await fsp.readdir(root)).toEqual(["e2e.bin"]);
+      for (const [, to] of io.renames) {
+        expect(to === dest || to.endsWith(".termix-replaced")).toBe(true);
+      }
+    } finally {
+      backend.close();
+    }
   });
 });
 

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -192,6 +192,112 @@ export interface ElectronAPI {
     sessionId: string,
     callback: (exitCode: number) => void,
   ): () => void;
+
+  /** Local disk browsing for the dual-pane file manager (desktop only). */
+  localFs?: {
+    home: () => Promise<LocalFsResult<LocalFsHomeInfo>>;
+    list: (dirPath: string) => Promise<LocalFsResult<LocalDirectoryListing>>;
+    mkdir: (
+      parentPath: string,
+      name: string,
+    ) => Promise<LocalFsResult<{ path: string }>>;
+    createFile: (
+      parentPath: string,
+      name: string,
+    ) => Promise<LocalFsResult<{ path: string }>>;
+    rename: (
+      oldPath: string,
+      newName: string,
+    ) => Promise<LocalFsResult<{ path: string }>>;
+    trash: (paths: string[]) => Promise<LocalFsResult<LocalTrashResult>>;
+    ensureDir: (dirPath: string) => Promise<LocalFsResult<{ path: string }>>;
+    walk: (paths: string[]) => Promise<LocalFsResult<LocalWalkResult>>;
+    reveal: (targetPath: string) => Promise<LocalFsResult<unknown>>;
+    open: (targetPath: string) => Promise<LocalFsResult<unknown>>;
+  };
+
+  /** Streamed local<->remote transfers driven by the main process. */
+  localTransfer?: {
+    upload: (
+      options: LocalUploadRequest,
+    ) => Promise<LocalFsResult<{ bytes: number }>>;
+    download: (
+      options: LocalDownloadRequest,
+    ) => Promise<LocalFsResult<{ path: string }>>;
+    cancel: (
+      transferId: string,
+    ) => Promise<LocalFsResult<{ cancelled: boolean }>>;
+    onProgress: (
+      callback: (payload: LocalTransferProgress) => void,
+    ) => () => void;
+  };
+}
+
+export type LocalFsResult<T> =
+  ({ success: true } & T) | { success: false; error: string; code?: string };
+
+export interface LocalFsHomeInfo {
+  home: string;
+  separator: string;
+  platform: string;
+}
+
+export interface LocalFileEntry {
+  name: string;
+  path: string;
+  type: "file" | "directory" | "link";
+  size: number;
+  modifiedTimestamp?: number;
+  linkTarget?: string;
+  hidden: boolean;
+}
+
+export interface LocalDirectoryListing {
+  path: string;
+  parent: string | null;
+  entries: LocalFileEntry[];
+}
+
+export interface LocalTrashResult {
+  trashed: number;
+  failed: Array<{ path: string; error: string }>;
+}
+
+export interface LocalWalkFile {
+  localPath: string;
+  /** Path relative to the drop root; "/"-separated and includes the root's own name. */
+  relativePath: string;
+  size: number;
+}
+
+export interface LocalWalkResult {
+  files: LocalWalkFile[];
+  emptyDirs: string[];
+  totalBytes: number;
+}
+
+export interface LocalUploadRequest {
+  transferId: string;
+  url: string;
+  headers: Record<string, string>;
+  fields: Record<string, string>;
+  localPath: string;
+  fileName: string;
+}
+
+export interface LocalDownloadRequest {
+  transferId: string;
+  url: string;
+  headers: Record<string, string>;
+  body: Record<string, unknown>;
+  destPath: string;
+  expectedSize?: number;
+}
+
+export interface LocalTransferProgress {
+  transferId: string;
+  transferred: number;
+  total?: number;
 }
 
 declare global {

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -211,6 +211,7 @@ export interface ElectronAPI {
     ) => Promise<LocalFsResult<{ path: string }>>;
     trash: (paths: string[]) => Promise<LocalFsResult<LocalTrashResult>>;
     ensureDir: (dirPath: string) => Promise<LocalFsResult<{ path: string }>>;
+    exists: (paths: string[]) => Promise<LocalFsResult<{ existing: string[] }>>;
     walk: (paths: string[]) => Promise<LocalFsResult<LocalWalkResult>>;
     reveal: (targetPath: string) => Promise<LocalFsResult<unknown>>;
     open: (targetPath: string) => Promise<LocalFsResult<unknown>>;
@@ -276,22 +277,30 @@ export interface LocalWalkResult {
   totalBytes: number;
 }
 
+/**
+ * Which Termix backend a transfer talks to. The main process resolves the
+ * actual URL and credentials for the origin; the renderer never supplies them.
+ */
+export type LocalTransferOrigin = "local" | "remote";
+
 export interface LocalUploadRequest {
   transferId: string;
-  url: string;
-  headers: Record<string, string>;
+  origin: LocalTransferOrigin;
   fields: Record<string, string>;
   localPath: string;
   fileName: string;
+  deviceId?: string;
 }
 
 export interface LocalDownloadRequest {
   transferId: string;
-  url: string;
-  headers: Record<string, string>;
+  origin: LocalTransferOrigin;
   body: Record<string, unknown>;
   destPath: string;
   expectedSize?: number;
+  /** Replace an existing file at destPath; otherwise the transfer is refused with code EEXIST. */
+  overwrite?: boolean;
+  deviceId?: string;
 }
 
 export interface LocalTransferProgress {


### PR DESCRIPTION
> **Review round 2 — restructured.** This PR is now *only* the Electron main-process bridge, so the trust boundary can be reviewed on its own (~850 lines incl. tests). The UI moved to follow-up PRs: #1413 (dual pane + drag-and-drop) → #1414 (local context menu) → #1393 → #1394 → #1395 → #1415 → #1396. Each of those is "previous branch + one commit".
>
> Review fixes are kept as separate commits so each delta is visible: `fix(desktop): harden the local transfer bridge` (c010285) for the two original blockers, and `fix(desktop): Windows-safe replace for overwrite downloads` (4a6bc67) for the rename-over-existing issue in the explicit overwrite path.

# Overview

Main-process side of a Termius-style Local | Remote file manager for the desktop app. No UI in this PR.

- [x] Added: `electron/local-files.cjs` — IPC handlers for browsing the local disk (home, list, mkdir, createFile, rename, trash, ensureDir, exists, walk, reveal, open) and for streaming files between the local disk and the file-manager backend (`uploadLocalFile`, `downloadToLocal`, progress events, cancel).
- [x] Added: `src/backend/tests/electron/local-files.test.ts` — 21 main-process tests.
- [x] Updated: `electron/preload.js` exposes `window.electronAPI.localFs` / `localTransfer`; the existing `invoke` allowlist is untouched.
- [x] Updated: `src/types/electron.d.ts`, `electron/main.cjs` (registration).

# Changes Made

**Trust boundary.** The renderer never supplies a URL or headers. It sends `{ origin: "local" | "remote", route, deviceId }` and the main process resolves the target itself:

- `route` must be one of a fixed allowlist (`uploadFileStream`, `downloadFileStream`).
- `origin: "local"` → the embedded backend base (`http://localhost:30004/ssh/file_manager`).
- `origin: "remote"` → the remote-sync config's URL (http/https only) with the stored JWT; refused if remote sync is not configured.
- `deviceId` is validated (`^[A-Za-z0-9._:-]{1,128}$`).
- Anything else throws before a request is made.

**Collision policy for downloads.** Nothing is renamed or replaced silently:

- Destination is checked first; `EEXIST` is returned unless the caller passes `overwrite: true`.
- Each transfer writes to its own `<dest>.<transferId>.termix-part`, opened with `wx`, and is published with `fs.link` / `COPYFILE_EXCL`. Two concurrent transfers to the same destination cannot share or clobber a partial — the second gets `EBUSY`.
- Partials are removed on failure and on cancel.

**Windows-safe overwrite.** `rename()` onto an existing name is POSIX-only (Windows fails with EEXIST/EPERM), so the explicit overwrite path never does it. The existing file is moved aside to a transfer-unique `<dest>.<transferId>.termix-replaced`, the partial is published exclusively under the freed name, then the aside copy is removed. If the aside step fails (file open on Windows) nothing is touched and the caller gets `EBUSY`; if publishing fails the original is moved back. Replacing a folder is refused with `EISDIR`. The publish primitives take an injectable `publishFs`, which is how the tests exercise this against a Windows-like `rename()` that refuses to overwrite.

**Streaming.** Uses Electron's `net` with `useSessionCookies` and `chunkedEncoding`, so the session cookie / remembered JWT is attached the same way as the renderer's own requests and large files are not buffered in memory.

**Testability.** `createLocalFileHandlers` / `createTargetResolver` take `net`, `shell` and the remote-sync getters as parameters, so the boundary is tested without Electron.

# Related Issues

- Followed by #1413 (UI), #1414, #1393, #1394, #1395, #1415, #1396 (stacked, each one commit).

# Screenshots / Demos

No UI. Test run:

```
npx vitest run src/backend/tests/electron/local-files.test.ts
 ✓ target resolution: local/remote/unknown origin, route allowlist, deviceId validation, unconfigured remote
 ✓ download: EEXIST without overwrite, overwrite replaces, EBUSY while in flight, unique partial per transfer, partial cleanup on failure/cancel, exists()
 ✓ upload: multipart body integrity (parsed with Busboy), off-origin refusal
 ✓ replace primitive (Windows-like fs): swap with no rename onto an occupied name, original restored on publish failure, EBUSY when the file cannot be moved aside, EISDIR for folders, vanished destination, end-to-end overwrite through the handler
 Tests  21 passed (21)
```

# Checklist

- [x] Code follows project style guidelines (prettier, eslint, type-check, build all green)
- [x] Supports mobile and desktop UI/app (desktop-only feature; no change for web/mobile)
- [x] I have read [Contributing.md](https://github.com/Termix-SSH/Termix/blob/main/CONTRIBUTING.md)
- [x] This is not a translation request. See [docs](https://docs.termix.site/translations)
