### PR TITLE
fix(workspaces): fall back when randomUUID is unavailable

### DIFF
--- a/src/ui/shell/workspaceUtils.ts
+++ b/src/ui/shell/workspaceUtils.ts
@@ -54,6 +54,13 @@ export const HOSTLESS_WORKSPACE_TAB_TYPES: TabType[] = [
   "ai",
 ];
 
+function createWorkspaceSlotId(): string {
+  if (typeof globalThis.crypto?.randomUUID === "function") {
+    return globalThis.crypto.randomUUID();
+  }
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}-${Math.random().toString(36).slice(2)}`;
+}
+
 /**
  * Maps live tabs to WorkspaceTabSnapshots, generating a fresh slotId per tab.
  * slotId is a stable key within the saved payload, distinct from Tab.id
@@ -61,7 +68,7 @@ export const HOSTLESS_WORKSPACE_TAB_TYPES: TabType[] = [
  */
 export function buildWorkspaceTabSnapshots(
   tabs: Tab[],
-  genSlotId: () => string = () => crypto.randomUUID(),
+  genSlotId: () => string = createWorkspaceSlotId,
 ): { snapshots: WorkspaceTabSnapshot[]; slotIdByTabId: Map<string, string> } {
   const capturable = tabs.filter((t) =>
     WORKSPACE_CAPTURABLE_TYPES.includes(t.type),

--- a/src/ui/tests/shell/workspaceUtils.test.ts
+++ b/src/ui/tests/shell/workspaceUtils.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   buildWorkspacePayload,
   buildWorkspaceTabSnapshots,
@@ -6,6 +6,8 @@ import {
   resolveWorkspaceTabTarget,
 } from "../../shell/workspaceUtils";
 import type { Host, Tab, WorkspaceTabSnapshot } from "@/types/ui-types";
+
+afterEach(() => vi.unstubAllGlobals());
 
 function makeHost(overrides: Partial<Host> = {}): Host {
   return {
@@ -39,6 +41,17 @@ function makeTab(overrides: Partial<Tab> = {}): Tab {
 }
 
 describe("buildWorkspaceTabSnapshots", () => {
+  it("falls back when randomUUID is unavailable", () => {
+    vi.stubGlobal("crypto", {});
+    const tabs = [makeTab({ id: "t1" }), makeTab({ id: "t2" })];
+
+    const { snapshots } = buildWorkspaceTabSnapshots(tabs);
+
+    expect(snapshots).toHaveLength(2);
+    expect(snapshots[0].slotId).toBeTruthy();
+    expect(snapshots[1].slotId).not.toBe(snapshots[0].slotId);
+  });
+
   it("captures host-bound and singleton tabs with generated slot ids", () => {
     let counter = 0;
     const genSlotId = () => `slot-${counter++}`;


### PR DESCRIPTION
## Summary
- generate workspace slot IDs without assuming `crypto.randomUUID` exists
- retain native UUIDs when available
- cover browsers/non-secure contexts without the API

## Verification
- `npx vitest run src/ui/tests/shell/workspaceUtils.test.ts` (17 passed)
- focused ESLint
- `npx tsc -b --force --pretty false`

Fixes Termix-SSH/Support#1263