### PR TITLE
Fix macOS Alt+digit characters in SSH terminals

### DIFF
--- a/src/ui/AppShell.tsx
+++ b/src/ui/AppShell.tsx
@@ -40,7 +40,11 @@ import { useUiPreferencesContext } from "@/contexts/UiPreferencesContext";
 import { defaultSizes, SplitView, type RowColSizes } from "@/shell/SplitView";
 import { renderTabContent } from "@/shell/tabUtils";
 import { TabBar } from "@/shell/TabBar";
-import { dispatchCtrlW, isShiftKey } from "@/lib/app-keyboard-shortcuts";
+import {
+  dispatchCtrlW,
+  getAltDigitShortcut,
+  isShiftKey,
+} from "@/lib/app-keyboard-shortcuts";
 import { parseCustomKeybindings } from "@/api/open-tabs-api";
 import { findMatchingKeybinding } from "@/lib/keybinding-match";
 import type {
@@ -822,10 +826,10 @@ export function AppShell({
         }
 
         // Alt+1..9 — jump directly to the tab at that position
-        const digitMatch = /^Digit([1-9])$/.exec(e.code);
-        if (digitMatch) {
+        const digit = getAltDigitShortcut(e);
+        if (digit !== null) {
           const currentTabs = tabsRef.current;
-          const index = Number(digitMatch[1]) - 1;
+          const index = digit - 1;
           if (index < currentTabs.length) {
             e.preventDefault();
             setActiveTabId(currentTabs[index].id);

--- a/src/ui/features/terminal/Terminal.tsx
+++ b/src/ui/features/terminal/Terminal.tsx
@@ -52,6 +52,7 @@ import {
 import { ensureTerminalFontsLoaded } from "./terminal-global-styles.ts";
 import { useTheme } from "@/components/theme-provider.tsx";
 import { globalShortcutHandler } from "@/lib/global-shortcut-handler";
+import { getAltDigitShortcut } from "@/lib/app-keyboard-shortcuts";
 import { useCommandTracker } from "@/features/terminal/command-history/useCommandTracker.ts";
 import {
   highlightTerminalOutput,
@@ -2987,7 +2988,7 @@ const TerminalInner = forwardRef<TerminalHandle, SSHTerminalProps>(
             "ArrowUp",
             "ArrowDown",
           ];
-          if (arrowCodes.includes(e.code) || /^Digit[1-9]$/.test(e.code)) {
+          if (arrowCodes.includes(e.code) || getAltDigitShortcut(e) !== null) {
             e.stopPropagation();
             globalShortcutHandler.current?.(e);
             return false;

--- a/src/ui/lib/app-keyboard-shortcuts.ts
+++ b/src/ui/lib/app-keyboard-shortcuts.ts
@@ -6,6 +6,13 @@ export function isShiftKey(event: Pick<KeyboardEvent, "key" | "code">) {
   );
 }
 
+export function getAltDigitShortcut(
+  event: Pick<KeyboardEvent, "key" | "code">,
+) {
+  const match = /^Digit([1-9])$/.exec(event.code);
+  return match && event.key === match[1] ? Number(match[1]) : null;
+}
+
 export function dispatchCtrlW(target: EventTarget | null) {
   if (!target) return false;
 

--- a/src/ui/tests/lib/app-keyboard-shortcuts.test.ts
+++ b/src/ui/tests/lib/app-keyboard-shortcuts.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
-import { dispatchCtrlW, isShiftKey } from "../../lib/app-keyboard-shortcuts";
+import {
+  dispatchCtrlW,
+  getAltDigitShortcut,
+  isShiftKey,
+} from "../../lib/app-keyboard-shortcuts";
 
 describe("app keyboard shortcuts", () => {
   it.each(["ShiftLeft", "ShiftRight"])(
@@ -11,6 +15,14 @@ describe("app keyboard shortcuts", () => {
 
   it("does not classify other keys as Shift", () => {
     expect(isShiftKey({ key: "w", code: "KeyW" })).toBe(false);
+  });
+
+  it("recognizes Alt+digit shortcuts by their logical key", () => {
+    expect(getAltDigitShortcut({ key: "7", code: "Digit7" })).toBe(7);
+  });
+
+  it("does not swallow layout characters produced by Alt+digit", () => {
+    expect(getAltDigitShortcut({ key: "|", code: "Digit7" })).toBeNull();
   });
 
   it("lets the focused control consume Electron Ctrl+W", () => {


### PR DESCRIPTION
## Summary
- only route Alt+1..9 to tab shortcuts when the logical key is the matching digit
- preserve keyboard-layout characters such as macOS Option+7 (`|`) in SSH terminals
- add regression coverage for both the shortcut and layout-character paths

## Verification
- `pnpm vitest run src/ui/tests/lib/app-keyboard-shortcuts.test.ts`
- `pnpm eslint src/ui/lib/app-keyboard-shortcuts.ts src/ui/AppShell.tsx src/ui/features/terminal/Terminal.tsx src/ui/tests/lib/app-keyboard-shortcuts.test.ts`
- `pnpm tsc -b --force`

Fixes Termix-SSH/Support#1262