### PR TITLE
fix(file-manager): keep name column visible on narrow viewports in list view

### DIFF
--- a/src/ui/features/file-manager/FileManagerGrid.tsx
+++ b/src/ui/features/file-manager/FileManagerGrid.tsx
@@ -1120,7 +1120,7 @@ export function FileManagerGrid({
             <div className="flex flex-col">
               <div
                 className={cn(
-                  "grid grid-cols-[1fr_120px_150px_80px_90px] gap-2 text-[10px] font-bold uppercase tracking-widest text-muted-foreground border-b border-border bg-card",
+                  "grid grid-cols-[minmax(140px,1fr)_120px_150px_80px_90px] gap-2 text-[10px] font-bold uppercase tracking-widest text-muted-foreground border-b border-border bg-card",
                   compact ? "px-2 py-1" : "px-4 py-2",
                 )}
               >
@@ -1194,7 +1194,7 @@ export function FileManagerGrid({
                         data-file-path={file.path}
                         draggable={true}
                         className={cn(
-                          "grid grid-cols-[1fr_120px_150px_80px_90px] gap-2 items-center cursor-pointer border-b border-border hover:bg-muted/50 rounded-none select-none transition-colors",
+                          "grid grid-cols-[minmax(140px,1fr)_120px_150px_80px_90px] gap-2 items-center cursor-pointer border-b border-border hover:bg-muted/50 rounded-none select-none transition-colors",
                           compact
                             ? "px-2 py-1 text-[11px]"
                             : "px-4 py-2 text-xs",
@@ -1503,7 +1503,7 @@ function CreateIntentListItem({
 
   return (
     <div
-      className="grid grid-cols-[1fr_120px_150px_80px_90px] gap-2 px-4 py-2 items-center border-b border-accent-brand/30 bg-accent-brand/5 rounded-none"
+      className="grid grid-cols-[minmax(140px,1fr)_120px_150px_80px_90px] gap-2 px-4 py-2 items-center border-b border-accent-brand/30 bg-accent-brand/5 rounded-none"
       onClick={(e) => e.stopPropagation()}
       onMouseDown={(e) => e.stopPropagation()}
     >


### PR DESCRIPTION
# Overview

On narrow viewports (phones), the file manager **list view** shows every row with a completely blank NAME column — no file names and no icons (both live in the same cell), while Modified/Size/Permissions render fine. Detailed reproduction and cause analysis in #1401.

- [x] Fixed: name column collapsing to 0px in list view on narrow viewports

# Changes Made

The list view grid used a fixed `1fr` track for the name column alongside four fixed-width tracks (~500px total):

```
grid-cols-[1fr_120px_150px_80px_90px]
```

On a ~390px phone viewport, the fixed tracks consume the entire row and the `1fr` name track collapses to 0px; the name cell's `overflow-hidden` then clips the name and icon away entirely.

This PR changes the name track to `minmax(140px, 1fr)` in all 3 list-view grids (header, rows, CreateIntentListItem) so it always keeps a minimum width — the table now scrolls horizontally instead of hiding the most important column.

```diff
- grid-cols-[1fr_120px_150px_80px_90px]
+ grid-cols-[minmax(140px,1fr)_120px_150px_80px_90px]
```

No behavior change on desktop viewports (the name track stays `1fr` as soon as there is room).

# Related Issues

- Closes #1401

# Screenshots / Demos

Repro: iPhone (Safari), Termix 2.7.1, list view, any directory → NAME column blank for all rows.

Verified locally on 2.7.1 (patched, rebuilt, deployed): names and icons render correctly on iPhone after the fix; desktop list/grid views unchanged.

# Checklist

- [x] Code follows project style guidelines
- [x] Supports mobile and desktop UI/app (if applicable)
- [x] I have read [Contributing.md](https://github.com/Termix-SSH/Termix/blob/main/CONTRIBUTING.md)
- [x] This is not a translation request. See [docs](https://docs.termix.site/translations)