### PR TITLE
Fix host key verification after sync identity resolution

### DIFF
--- a/src/backend/hosts/file-manager/index.ts
+++ b/src/backend/hosts/file-manager/index.ts
@@ -29,7 +29,7 @@ import type {
   ConnectionStage,
 } from "../../../types/connection-log.js";
 import { SSHHostKeyVerifier } from "../host-key-verifier.js";
-import { resolveHostById } from "../host-resolver.js";
+import { resolveHostById, resolveHostBySyncId } from "../host-resolver.js";
 import {
   startHostTransfer,
   getTransferStatus,
@@ -63,6 +63,7 @@ import {
   hostAddressMismatch,
   HostAddressMismatchError,
   HostNotOnThisServerError,
+  resolveServerHostId,
 } from "../terminal/host-identity.js";
 import { registerFileDownloadRoutes } from "./download-routes.js";
 import { registerFileActionRoutes } from "./action-routes.js";
@@ -977,7 +978,15 @@ app.post("/ssh/file_manager/ssh/connect", async (req, res) => {
     }
   }
 
-  const preloadedHostData = await SSHHostKeyVerifier.preloadHostData(hostId);
+  let serverHostId = hostId;
+  if (hostSyncId && userId) {
+    const resolvedHost = await resolveHostBySyncId(hostSyncId, userId);
+    assertResolvedHost(ip, hostSyncId, resolvedHost, hostId, userId);
+    serverHostId = resolveServerHostId(hostId, resolvedHost) ?? hostId;
+  }
+
+  const preloadedHostData =
+    await SSHHostKeyVerifier.preloadHostData(serverHostId);
   const keepalive = resolveSshKeepalive(
     hostKeepaliveInterval,
     hostKeepaliveCountMax,
@@ -994,7 +1003,7 @@ app.post("/ssh/file_manager/ssh/connect", async (req, res) => {
     tcpKeepAlive: true,
     tcpKeepAliveInitialDelay: 30000,
     hostVerifier: await SSHHostKeyVerifier.createHostVerifier(
-      hostId,
+      serverHostId,
       resolvedIp,
       resolvedPort,
       null,
@@ -1132,7 +1141,7 @@ app.post("/ssh/file_manager/ssh/connect", async (req, res) => {
   } else if (usesIssuedCertificate(resolvedCredentials.authType)) {
     try {
       const { getOPKSSHToken } = await import("../opkssh-auth.js");
-      const token = await getOPKSSHToken(userId, hostId);
+      const token = await getOPKSSHToken(userId, serverHostId);
 
       if (!token) {
         connectionLogs.push(
@@ -1188,7 +1197,7 @@ app.post("/ssh/file_manager/ssh/connect", async (req, res) => {
       const { setupVaultSshSignerAuth } =
         await import("../vault-ssh-connect.js");
       await setupVaultSshSignerAuth(config as ConnectConfig, client, {
-        id: hostId,
+        id: serverHostId,
         username: resolvedUsername,
         userId,
         vaultProfile: { id: resolvedVaultProfileId },
@@ -1296,7 +1305,7 @@ app.post("/ssh/file_manager/ssh/connect", async (req, res) => {
       operation: "file_ssh_connected",
       sessionId,
       userId,
-      hostId,
+      hostId: serverHostId,
       ip,
       port,
       username,
@@ -1324,7 +1333,7 @@ app.post("/ssh/file_manager/ssh/connect", async (req, res) => {
       userId,
       ip,
       port,
-      hostId,
+      hostId: serverHostId,
       username,
       sudoPassword: resolvedCredentials.sudoPassword,
       scpLegacy: resolvedScpLegacy,
@@ -1339,7 +1348,7 @@ app.post("/ssh/file_manager/ssh/connect", async (req, res) => {
           username: await getAuditUsername(userId),
           action: "file_manager_connect",
           resourceType: "host",
-          resourceId: hostId ? String(hostId) : undefined,
+          resourceId: serverHostId ? String(serverHostId) : undefined,
           resourceName: `${username}@${ip}:${port}`,
           ipAddress,
           userAgent,

--- a/src/backend/hosts/terminal/host-identity.ts
+++ b/src/backend/hosts/terminal/host-identity.ts
@@ -64,6 +64,13 @@ export function resolveServerJumpHosts(
   return clientJumpHosts?.length ? clientJumpHosts : serverJumpHosts;
 }
 
+export function resolveServerHostId(
+  clientHostId: number | null,
+  resolvedHost: { id?: unknown } | null,
+): number | null {
+  return typeof resolvedHost?.id === "number" ? resolvedHost.id : clientHostId;
+}
+
 /**
  * Thrown where a mismatch is reported by rejecting rather than by messaging
  * the socket. Callers whose host-resolution is wrapped in a "failed to resolve

--- a/src/backend/hosts/terminal/index.ts
+++ b/src/backend/hosts/terminal/index.ts
@@ -65,6 +65,7 @@ import {
   hostAddressMismatch,
   HOST_ADDRESS_MISMATCH_MESSAGE,
   HOST_NOT_ON_THIS_SERVER_MESSAGE,
+  resolveServerHostId,
   resolveServerJumpHosts,
 } from "./host-identity.js";
 import { extractWebSocketToken } from "../../utils/ws-auth.js";
@@ -1755,7 +1756,7 @@ wss.on("connection", async (ws: WebSocket, req) => {
       }
     }
 
-    const statusHostId = resolvedHostData?.id ?? id;
+    const serverHostId = resolveServerHostId(id, resolvedHostData);
 
     // Resolve credentials server-side when frontend doesn't provide them
     let resolvedCredentials = {
@@ -1926,7 +1927,7 @@ wss.on("connection", async (ws: WebSocket, req) => {
     });
 
     sshConn.on("ready", () => {
-      clearOnlineStatus ??= hostSessionStatus.register(statusHostId);
+      clearOnlineStatus ??= hostSessionStatus.register(serverHostId);
       clearTimeout(connectionTimeout);
       isTailscaleRetrying = false;
       if (tailscaleCheckPending) {
@@ -2947,7 +2948,8 @@ wss.on("connection", async (ws: WebSocket, req) => {
     // Pre-fetch the stored host key before connect so the verifier callback
     // runs synchronously during SSH key exchange, avoiding LoginGraceTime
     // expiry on slow connections (especially through jump host tunnels).
-    const preloadedHostData = await SSHHostKeyVerifier.preloadHostData(id);
+    const preloadedHostData =
+      await SSHHostKeyVerifier.preloadHostData(serverHostId);
 
     const connectConfig: Record<string, unknown> = {
       host: connectHost,
@@ -2967,7 +2969,7 @@ wss.on("connection", async (ws: WebSocket, req) => {
           ? TAILSCALE_CHECK_TIMEOUT_MS
           : 120000,
       hostVerifier: await SSHHostKeyVerifier.createHostVerifier(
-        id,
+        serverHostId,
         ip,
         port,
         ws,

--- a/src/backend/tests/hosts/terminal/host-identity.test.ts
+++ b/src/backend/tests/hosts/terminal/host-identity.test.ts
@@ -6,6 +6,7 @@ import {
   HostAddressMismatchError,
   HostNotOnThisServerError,
   normalizeHostAddress,
+  resolveServerHostId,
   resolveServerJumpHosts,
 } from "../../../hosts/terminal/host-identity.js";
 
@@ -71,6 +72,16 @@ describe("resolveServerJumpHosts", () => {
     expect(resolveServerJumpHosts([{ hostId: 7 }], [{ hostId: 42 }])).toEqual([
       { hostId: 7 },
     ]);
+  });
+});
+
+describe("resolveServerHostId", () => {
+  it("uses the server-side row id after resolving a sync identity", () => {
+    expect(resolveServerHostId(4, { id: 5 })).toBe(5);
+  });
+
+  it("keeps the client id when no server-side row was resolved", () => {
+    expect(resolveServerHostId(4, null)).toBe(4);
   });
 });
 


### PR DESCRIPTION
## Summary
- use the server-resolved host row ID for terminal host-key preload, verification, and online status
- apply the same identity correction to File Manager host-key verification and its downstream OPKSSH, Vault, session, and audit references
- retain the client numeric ID only when no server-side row was resolved

## Why
A desktop numeric host ID belongs to the embedded database. After a remote server resolves the stable host `syncId`, continuing to use the client ID can compare and overwrite another host’s pinned key.

## Validation
- `vitest run src/backend/tests/hosts/terminal/host-identity.test.ts` (15 passed)
- `npm run type-check`
- Prettier check on changed files

Fixes Termix-SSH/Support#1277