### PR TITLE
fix(auth): skip TOTP only after verified WebAuthn user verification

### DIFF
--- a/src/backend/database/routes/user-webauthn-routes.ts
+++ b/src/backend/database/routes/user-webauthn-routes.ts
@@ -17,11 +17,7 @@ import { nanoid } from "nanoid";
 import type { AuthenticatedRequest } from "../../../types/index.js";
 import { AuthManager } from "../../utils/auth-manager.js";
 import { authLogger } from "../../utils/logger.js";
-import {
-  generateDeviceFingerprint,
-  getDeviceId,
-  parseUserAgent,
-} from "../../utils/user-agent-parser.js";
+import { parseUserAgent } from "../../utils/user-agent-parser.js";
 import {
   createCurrentUserRepository,
   createCurrentWebauthnCredentialRepository,
@@ -400,12 +396,12 @@ export function registerUserWebAuthnRoutes(
    * /users/webauthn/authenticate/verify:
    *   post:
    *     summary: Finish passkey login
-   *     description: Verifies the WebAuthn assertion and issues a session token (or a TOTP challenge).
+   *     description: Verifies the WebAuthn assertion and issues a session token. A verified security key already satisfies 2FA, so TOTP is not required.
    *     tags:
    *       - WebAuthn
    *     responses:
    *       200:
-   *         description: Login succeeded or TOTP verification required.
+   *         description: Login succeeded.
    *       400:
    *         description: Challenge expired or invalid response.
    *       401:
@@ -487,29 +483,6 @@ export function registerUserWebAuthnRoutes(
           lastUsedAt: new Date().toISOString(),
         },
       );
-
-      if (userRecord.totpEnabled) {
-        const deviceFingerprint = generateDeviceFingerprint(
-          deviceInfo,
-          getDeviceId(req),
-        );
-        const isTrusted = deviceFingerprint
-          ? await authManager.isTrustedDevice(userRecord.id, deviceFingerprint)
-          : false;
-
-        if (!isTrusted) {
-          const tempToken = await authManager.generateJWTToken(userRecord.id, {
-            pendingTOTP: true,
-            expiresIn: "10m",
-          });
-          return res.json({
-            success: true,
-            requires_totp: true,
-            temp_token: tempToken,
-            rememberMe: !!req.body?.rememberMe,
-          });
-        }
-      }
 
       const token = await authManager.generateJWTToken(userRecord.id, {
         rememberMe: !!req.body?.rememberMe,


### PR DESCRIPTION
## Summary
- Treat a verified WebAuthn/security-key assertion as sufficient 2FA.
- Issue a full session on passkey login instead of prompting for TOTP when it is also enabled.
- Password login is unchanged: TOTP is still required when it is enabled.

## Test plan
- [x] Log in with a passkey on an account that also has TOTP enabled and confirm no TOTP prompt appears.
- [x] Log in with username/password on the same account and confirm TOTP is still required.
- [x] Confirm passkey login still works on an account without TOTP.


Made with [Cursor](https://cursor.com)